### PR TITLE
Enforce line endings from now on

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Any file not git-ignored that is a text file (non-binary) will have LF as line ending.
+# Note:
+# Working tree: not affected. But if you check it out again, it will be in LF line ending.
+# Index & repository: line endings will be in LF even if working tree is in CRLF.
+* text=auto
+
+# Windows scripts will be stored with line ending LF, they will always be checked out with CRLF.
+# Note: existing working tree remains untouched.
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf


### PR DESCRIPTION
Fix #5 

Note: if you are unfamiliar with the git configuration in this PR, please take a look at this [article](https://www.aleksandrhovhannisyan.com/blog/crlf-vs-lf-normalizing-line-endings-in-git).

We did:

1. Add git attributes to store all text files with line ending LF. Note this doesn't not affect your working tree. But when you check out a file in the future, it will be with LF line ending. This is okay as all IDEs and editors we use know how to work with it properly.
    - except for legacy Windows specific files that requires CRLF ending: cmd and bat files: they will be stored with LF line ending and checked out with CRLF always so nothing breaks.
2. No matter what line ending you choose in your editor, it will be LF in the repository after this PR. So there's no work on your side.