### PR TITLE
Add Subtype Hint Annotations

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -2,6 +2,8 @@ package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.v3.oas.annotations.media.Schema;
 import org.threeten.bp.OffsetDateTime;
 
@@ -10,6 +12,8 @@ import java.util.List;
 import java.util.Objects;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2022-08-19T17:07:43.799-04:00[America/New_York]")
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({@JsonSubTypes.Type(Folder.class), @JsonSubTypes.Type(Shortcut.class)})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Entry {
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -13,7 +13,7 @@ import java.util.Objects;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2022-08-19T17:07:43.799-04:00[America/New_York]")
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({@JsonSubTypes.Type(Folder.class), @JsonSubTypes.Type(Shortcut.class)})
+@JsonSubTypes({@JsonSubTypes.Type(Document.class), @JsonSubTypes.Type(Folder.class), @JsonSubTypes.Type(Shortcut.class)})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Entry {
 

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -42,7 +42,6 @@ public class CreateCopyEntryApiTest extends BaseTest {
     }
 
     @Test
-    @Disabled("Ignore for now because of the APIServer's entry related serialization bug.")
     void createCopyEntry_CreateFolder() {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
         Integer parentEntryId = 1;
@@ -66,7 +65,6 @@ public class CreateCopyEntryApiTest extends BaseTest {
     }
 
     @Test
-    @Disabled("Ignore for now because of the APIServer's entry related serialization bug.")
     void createCopyEntry_CreateShortcut() {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
         Integer parentEntryId = 1;


### PR DESCRIPTION
When an API that returns an Entry object, it could mean any of its subtypes: Shortcut and Folder. But the client deserializer has no way of knowing this so we add the type hint here.