### PR TITLE
Story/397206 file upload parameter

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -97,7 +97,7 @@ public interface EntriesClient {
      *                      renamed if an entry already exists with the given name in the folder. The default value is false.
      * @param culture       An optional query parameter used to indicate the locale that should be used.
      *                      The value should be a standard language tag.
-     * @param file          The file that will be uploaded.
+     * @param inputStream   An InputStream object to read the raw bytes for the file to be uploaded.
      * @param requestBody   null
      * @return CompletableFuture<CreateEntryResult> The return value
      */

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -3,6 +3,7 @@ package com.laserfiche.repository.api.clients;
 import com.laserfiche.repository.api.clients.impl.model.*;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -101,7 +102,7 @@ public interface EntriesClient {
      * @return CompletableFuture<CreateEntryResult> The return value
      */
     CompletableFuture<CreateEntryResult> importDocument(String repoId, Integer parentEntryId, String fileName,
-            Boolean autoRename, String culture, File file, PostEntryWithEdocMetadataRequest requestBody);
+            Boolean autoRename, String culture, InputStream inputStream, PostEntryWithEdocMetadataRequest requestBody);
 
     /**
      * - Returns the links assigned to an entry.

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -6,6 +6,7 @@ import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -136,14 +137,14 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public CompletableFuture<CreateEntryResult> importDocument(String repoId, Integer parentEntryId, String fileName,
-            Boolean autoRename, String culture, File file, PostEntryWithEdocMetadataRequest requestBody) {
+            Boolean autoRename, String culture, InputStream inputStream, PostEntryWithEdocMetadataRequest requestBody) {
         Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
                 new Object[]{autoRename, culture});
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "parentEntryId", "fileName"},
                 new Object[]{repoId, parentEntryId, fileName});
         return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{parentEntryId}/{fileName}")
-                .field("electronicDocument", file)
+                .field("electronicDocument", inputStream, fileName)
                 .field("request", toJson(requestBody))
                 .queryString(queryParameters)
                 .routeParam(pathParameters)

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -1,9 +1,20 @@
 package integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;
-import com.laserfiche.repository.api.clients.impl.model.DeleteEntryWithAuditReason;
+import com.laserfiche.repository.api.clients.impl.model.*;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ImportDocumentApiTest extends BaseTest {
     EntriesClient client;
@@ -26,8 +37,8 @@ public class ImportDocumentApiTest extends BaseTest {
         }
     }
 
-  /*  @Test
-    void importDocument_DocumentCreated() {
+    @Test
+    void importDocument_DocumentCreated_FromFile() throws FileNotFoundException {
         String fileName = "myFile";
         File toUpload = null;
         try {
@@ -39,7 +50,7 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(toUpload);
 
         CreateEntryResult result = client.importDocument(repoId, 1, fileName, true, null,
-                toUpload, new PostEntryWithEdocMetadataRequest()).join();
+                new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest()).join();
 
         CreateEntryOperations operations = result.getOperations();
 
@@ -60,10 +71,11 @@ public class ImportDocumentApiTest extends BaseTest {
         createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
-    }*/
+        assertTrue(createdEntryId > 0);
+    }
 
- /*   @Test
-    void importDocument_DocumentCreatedWithTemplate() throws ExecutionException, InterruptedException {
+    @Test
+    void importDocument_DocumentCreated_FromFile_WithTemplate() throws ExecutionException, InterruptedException, FileNotFoundException {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient.getTemplateDefinitionClient().getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null).join();
         List<WTemplateInfo> templateDefinitions = templateDefinitionResult.getValue();
@@ -93,7 +105,7 @@ public class ImportDocumentApiTest extends BaseTest {
         request.setTemplate(template.getName());
 
         CreateEntryResult result = client.importDocument(repoId, parentEntryId, fileName,
-                true, null, toUpload, request).join();
+                true, null, new FileInputStream(toUpload), request).join();
 
         CreateEntryOperations operations = result.getOperations();
         assertNotNull(operations);
@@ -119,5 +131,74 @@ public class ImportDocumentApiTest extends BaseTest {
         createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
-    }*/
+        assertTrue(createdEntryId > 0);
+    }
+
+    @Test
+    void importDocument_DocumentCreated_FromURL() throws IOException {
+        String fileName = "myFile";
+        CreateEntryResult result = null;
+        URL googleLogoUrl = new URL("https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png");
+        InputStream inputStream = googleLogoUrl.openStream();
+        assertNotNull(inputStream);
+
+        result = client.importDocument(repoId, 1, fileName, true, null,
+                inputStream, new PostEntryWithEdocMetadataRequest()).join();
+
+        assertNotNull(result);
+        CreateEntryOperations operations = result.getOperations();
+
+        assertNotNull(result);
+        assertNotNull(operations);
+        assertNotNull(result.getDocumentLink());
+        assertNotEquals(0, operations
+                .getEntryCreate()
+                .getEntryId());
+        assertEquals(0, operations
+                .getEntryCreate()
+                .getExceptions()
+                .size());
+        assertEquals(0, operations
+                .getSetEdoc()
+                .getExceptions()
+                .size());
+        createdEntryId = operations
+                .getEntryCreate()
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
+    }
+
+    @Test
+    void importDocument_DocumentCreated_FromString() throws IOException {
+        String fileName = "myFile";
+        CreateEntryResult result = null;
+        String fileContent = "This is the file content";
+        InputStream inputStream =  new ByteArrayInputStream(fileContent.getBytes());
+        assertNotNull(inputStream);
+
+        result = client.importDocument(repoId, 1, fileName, true, null,
+                inputStream, new PostEntryWithEdocMetadataRequest()).join();
+
+        assertNotNull(result);
+        CreateEntryOperations operations = result.getOperations();
+
+        assertNotNull(result);
+        assertNotNull(operations);
+        assertNotNull(result.getDocumentLink());
+        assertNotEquals(0, operations
+                .getEntryCreate()
+                .getEntryId());
+        assertEquals(0, operations
+                .getEntryCreate()
+                .getExceptions()
+                .size());
+        assertEquals(0, operations
+                .getSetEdoc()
+                .getExceptions()
+                .size());
+        createdEntryId = operations
+                .getEntryCreate()
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
+    }
 }

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.net.ServerSocket;
-import java.net.Socket;
 import java.net.URL;
 import java.util.List;
 import java.util.concurrent.ExecutionException;


### PR DESCRIPTION
Import api is updated to use InputStream instead of File, as the parameter
integration tests for the import api are updated
new integration tests are added for importing from url and a string object.