### PR TITLE
Use a more robust subtype resolution

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -12,8 +12,8 @@ import java.util.List;
 import java.util.Objects;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2022-08-19T17:07:43.799-04:00[America/New_York]")
-@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
-@JsonSubTypes({@JsonSubTypes.Type(Document.class), @JsonSubTypes.Type(Folder.class), @JsonSubTypes.Type(Shortcut.class)})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NONE, property = "entryType")
+@JsonSubTypes({@JsonSubTypes.Type(value = Document.class, name = "Document"), @JsonSubTypes.Type(value = Folder.class, name = "Folder"), @JsonSubTypes.Type(value = Shortcut.class, name = "Shortcut")})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Entry {
 


### PR DESCRIPTION
Entry currently has four different subtypes: Entry (itself), Folder, Document, Shortcut. This error doesn't happen if the API is return one of the subtypes. It only happens when returning a list of Entry objects where each of them could be different subtypes, for example, when the getEntryListing returns a list consists of Folder and Document, it will fail.

The solution is to use a less "smart" way of figuring out the subtype: directly telling Jackson what the subtype should be.