### PR TITLE
Rename method name

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -261,7 +261,7 @@ public interface EntriesClient {
      *                    The value should be a standard language tag.
      * @return CompletableFuture<Entry> The return value
      */
-    CompletableFuture<Entry> moveOrRenameDocument(String repoId, Integer entryId, PatchEntryRequest requestBody,
+    CompletableFuture<Entry> moveOrRenameEntry(String repoId, Integer entryId, PatchEntryRequest requestBody,
             Boolean autoRename, String culture);
 
     /**

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -503,7 +503,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     @Override
-    public CompletableFuture<Entry> moveOrRenameDocument(String repoId, Integer entryId, PatchEntryRequest requestBody,
+    public CompletableFuture<Entry> moveOrRenameEntry(String repoId, Integer entryId, PatchEntryRequest requestBody,
             Boolean autoRename, String culture) {
         Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
                 new Object[]{autoRename, culture});

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -220,7 +220,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName("RepositoryApiClientIntegrationTest Java MovedFolder");
 
         Entry movedEntry = client
-                .moveOrRenameDocument(repoId, childFolder.getId(), request, true, null)
+                .moveOrRenameEntry(repoId, childFolder.getId(), request, true, null)
                 .join();
 
         assertNotNull(movedEntry);


### PR DESCRIPTION
The `MoveOrRenameDocument` API can also be applied to other types of entries, not just `Document`. So in this PR, we changed its name to `MoveOrRenameEntry` to better reflect its capability.