### PR TITLE
Fallback type

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Objects;
 
 @javax.annotation.Generated(value = "io.swagger.codegen.v3.generators.java.JavaClientCodegen", date = "2022-10-17T11:38:41.655-04:00[America/New_York]")
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "entryType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = "entryType", visible = true, defaultImpl = Entry.class)
 @JsonSubTypes({@JsonSubTypes.Type(value = Document.class, name = "Document"), @JsonSubTypes.Type(value = Folder.class, name = "Folder"), @JsonSubTypes.Type(value = Shortcut.class, name = "Shortcut"), @JsonSubTypes.Type(value = RecordSeries.class, name = "RecordSeries")})
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Entry {

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -35,6 +35,19 @@ class EntriesApiTest extends BaseTest {
         Entry entry = future.join();
 
         assertNotNull(entry);
+        assertTrue(entry instanceof Folder); // We know the root folder is of type Folder.
+    }
+
+    @Test
+    void getEntry_ReturnEntryWhenTypeInfoMissing() {
+        CompletableFuture<Entry> future = client.getEntry(repoId, 1, "name");
+        Entry entry = future.join();
+
+        assertNotNull(entry);
+        assertFalse(entry instanceof Folder
+                || entry instanceof Shortcut
+                || entry instanceof Document
+                || entry instanceof RecordSeries); // When no type information, the data is deserialized to Entry.
     }
 
     @Test


### PR DESCRIPTION
APIServer has a parameter called "field" where you could put an array of string where each element matches a name in the data classes that an API retrieves. The current behavior is that once you define this parameter, with a few exceptions, only the ones you selected will be returned.

This behavior makes it possible for the user to not to select the entryType field that our client libraries (Java, C#, TS) uses to decide which object the incoming JSON obejct should be deseralized to. It's a widespread practice to have the JSON include type information so the client can deserialize it properly. Now with the this select parameter, deserialization is broken.

The Toronto Integration team suggests that in this situation, one could just fall back to the parent type. For example, we have Entry as the parent type and Folder, Shortcut, Document as the subtypes. If the user only selects a few fields (excluding entryType), just deserialize it to Entry.

In this PR we implemented this idea.