### PR TITLE
Escape JavaDoc for Public APIs

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -15,7 +15,7 @@ public interface AttributesClient {
      * @param repoId       The requested repository ID.
      * @param attributeKey The requested attribute key.
      * @param everyone     Boolean value that indicates whether to return attributes associated with everyone or the currently authenticated user.
-     * @return CompletableFuture<Attribute> The return value
+     * @return CompletableFuture&lt;Attribute&gt; The return value
      */
     CompletableFuture<Attribute> getTrusteeAttributeValueByKey(String repoId, String attributeKey, Boolean everyone);
 
@@ -32,7 +32,7 @@ public interface AttributesClient {
      * @param top      Limits the number of items returned from a collection.
      * @param skip     Excludes the specified number of items of the queried collection from the result.
      * @param count    Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfListOfAttribute> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfListOfAttribute&gt; The return value
      */
     CompletableFuture<ODataValueContextOfListOfAttribute> getTrusteeAttributeKeyValuePairs(String repoId,
             Boolean everyone, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -42,7 +42,7 @@ public interface AttributesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfListOfAttribute> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfListOfAttribute&gt; The return value
      */
     CompletableFuture<ODataValueContextOfListOfAttribute> getTrusteeAttributeKeyValuePairsNextLink(String nextLink,
             Integer maxPageSize);
@@ -60,7 +60,7 @@ public interface AttributesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTrusteeAttributeKeyValuePairsForEach(
             Function<CompletableFuture<ODataValueContextOfListOfAttribute>, CompletableFuture<Boolean>> callback,

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -12,7 +12,7 @@ public interface AuditReasonsClient {
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *
      * @param repoId The requested repository ID.
-     * @return CompletableFuture<AuditReasons> The return value
+     * @return CompletableFuture&lt;AuditReasons&gt; The return value
      */
     CompletableFuture<AuditReasons> getAuditReasons(String repoId);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -29,7 +29,7 @@ public interface EntriesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfFieldValue> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfFieldValue&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfFieldValue> getFieldValues(String repoId, Integer entryId,
             String prefer, Boolean formatValue, String culture, String select, String orderby, Integer top,
@@ -40,7 +40,7 @@ public interface EntriesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfFieldValue> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfFieldValue&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfFieldValue> getFieldValuesNextLink(String nextLink,
             Integer maxPageSize);
@@ -63,7 +63,7 @@ public interface EntriesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getFieldValuesForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfFieldValue>, CompletableFuture<Boolean>> callback,
@@ -80,7 +80,7 @@ public interface EntriesClient {
      * @param requestBody
      * @param culture     An optional query parameter used to indicate the locale that should be used.
      *                    The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @return CompletableFuture<ODataValueOfIListOfFieldValue> The return value
+     * @return CompletableFuture&lt;ODataValueOfIListOfFieldValue&gt; The return value
      */
     CompletableFuture<ODataValueOfIListOfFieldValue> assignFieldValues(String repoId, Integer entryId,
             Map<String, FieldToUpdate> requestBody, String culture);
@@ -97,9 +97,7 @@ public interface EntriesClient {
      *                      renamed if an entry already exists with the given name in the folder. The default value is false.
      * @param culture       An optional query parameter used to indicate the locale that should be used.
      *                      The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @param inputStream   An InputStream object to read the raw bytes for the file to be uploaded.
-     * @param requestBody   null
-     * @return CompletableFuture<CreateEntryResult> The return value
+     * @return CompletableFuture&lt;CreateEntryResult&gt; The return value
      */
     CompletableFuture<CreateEntryResult> importDocument(String repoId, Integer parentEntryId, String fileName,
             Boolean autoRename, String culture, InputStream inputStream, PostEntryWithEdocMetadataRequest requestBody);
@@ -117,7 +115,7 @@ public interface EntriesClient {
      * @param top     Limits the number of items returned from a collection.
      * @param skip    Excludes the specified number of items of the queried collection from the result.
      * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWEntryLinkInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo> getLinkValuesFromEntry(String repoId, Integer entryId,
             String prefer, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -127,7 +125,7 @@ public interface EntriesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWEntryLinkInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo> getLinkValuesFromEntryNextLink(String nextLink,
             Integer maxPageSize);
@@ -145,7 +143,7 @@ public interface EntriesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getLinkValuesFromEntryForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo>, CompletableFuture<Boolean>> callback,
@@ -157,10 +155,9 @@ public interface EntriesClient {
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
-     * @param repoId      The request repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody null
-     * @return CompletableFuture<ODataValueOfIListOfWEntryLinkInfo> The return value
+     * @param repoId  The request repository ID.
+     * @param entryId The requested entry ID.
+     * @return CompletableFuture&lt;ODataValueOfIListOfWEntryLinkInfo&gt; The return value
      */
     CompletableFuture<ODataValueOfIListOfWEntryLinkInfo> assignEntryLinks(String repoId, Integer entryId,
             List<PutLinksRequest> requestBody);
@@ -175,7 +172,7 @@ public interface EntriesClient {
      * @param requestBody The template and template fields that will be assigned to the entry.
      * @param culture     An optional query parameter used to indicate the locale that should be used.
      *                    The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @return CompletableFuture<Entry> The return value
+     * @return CompletableFuture&lt;Entry&gt; The return value
      */
     CompletableFuture<Entry> writeTemplateValueToEntry(String repoId, Integer entryId, PutTemplateRequest requestBody,
             String culture);
@@ -187,7 +184,7 @@ public interface EntriesClient {
      *
      * @param repoId  The requested repository ID.
      * @param entryId The ID of the entry that will have its template removed.
-     * @return CompletableFuture<Entry> The return value
+     * @return CompletableFuture&lt;Entry&gt; The return value
      */
     CompletableFuture<Entry> deleteAssignedTemplate(String repoId, Integer entryId);
 
@@ -196,10 +193,9 @@ public interface EntriesClient {
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
      * Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody null
-     * @return CompletableFuture<Map < String, String [ ]>> The return value
+     * @param repoId  The requested repository ID.
+     * @param entryId The requested entry ID.
+     * @return CompletableFuture&lt;Map&lt;String,String[]&gt;&gt; The return value
      */
     CompletableFuture<Map<String, String[]>> getDynamicFieldValues(String repoId, Integer entryId,
             GetDynamicFieldLogicValueRequest requestBody);
@@ -211,7 +207,7 @@ public interface EntriesClient {
      * @param repoId                    The requested repository ID.
      * @param fullPath                  The requested entry path.
      * @param fallbackToClosestAncestor An optional query parameter used to indicate whether or not the closest ancestor in the path should be returned if the initial entry path is not found. The default value is false.
-     * @return CompletableFuture<FindEntryResult> The return value
+     * @return CompletableFuture&lt;FindEntryResult&gt; The return value
      */
     CompletableFuture<FindEntryResult> getEntryByPath(String repoId, String fullPath,
             Boolean fallbackToClosestAncestor);
@@ -229,7 +225,7 @@ public interface EntriesClient {
      *                    renamed if an entry already exists with the given name in the folder. The default value is false.
      * @param culture     An optional query parameter used to indicate the locale that should be used.
      *                    The value should be a standard language tag.
-     * @return CompletableFuture<AcceptedOperation> The return value
+     * @return CompletableFuture&lt;AcceptedOperation&gt; The return value
      */
     CompletableFuture<AcceptedOperation> copyEntryAsync(String repoId, Integer entryId, CopyAsyncRequest requestBody,
             Boolean autoRename, String culture);
@@ -242,7 +238,7 @@ public interface EntriesClient {
      * @param repoId  The requested repository ID.
      * @param entryId The requested entry ID.
      * @param select  Limits the properties returned in the result.
-     * @return CompletableFuture<Entry> The return value
+     * @return CompletableFuture&lt;Entry&gt; The return value
      */
     CompletableFuture<Entry> getEntry(String repoId, Integer entryId, String select);
 
@@ -259,7 +255,7 @@ public interface EntriesClient {
      *                    renamed if another entry already exists with the same name in the folder. The default value is false.
      * @param culture     An optional query parameter used to indicate the locale that should be used.
      *                    The value should be a standard language tag.
-     * @return CompletableFuture<Entry> The return value
+     * @return CompletableFuture&lt;Entry&gt; The return value
      */
     CompletableFuture<Entry> moveOrRenameEntry(String repoId, Integer entryId, PatchEntryRequest requestBody,
             Boolean autoRename, String culture);
@@ -272,7 +268,7 @@ public interface EntriesClient {
      * @param repoId      The requested repository ID.
      * @param entryId     The requested entry ID.
      * @param requestBody The submitted audit reason.
-     * @return CompletableFuture<AcceptedOperation> The return value
+     * @return CompletableFuture&lt;AcceptedOperation&gt; The return value
      */
     CompletableFuture<AcceptedOperation> deleteEntryInfo(String repoId, Integer entryId,
             DeleteEntryWithAuditReason requestBody);
@@ -282,12 +278,11 @@ public interface EntriesClient {
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested document ID.
-     * @param requestBody null
-     * @param range       An optional header used to retrieve partial content of the edoc. Only supports single
-     *                    range with byte unit.
-     * @return CompletableFuture<File> The return value
+     * @param repoId  The requested repository ID.
+     * @param entryId The requested document ID.
+     * @param range   An optional header used to retrieve partial content of the edoc. Only supports single
+     *                range with byte unit.
+     * @return CompletableFuture&lt;File&gt; The return value
      */
     CompletableFuture<File> exportDocumentWithAuditReason(String repoId, Integer entryId,
             GetEdocWithAuditReasonRequest requestBody, String range);
@@ -301,7 +296,7 @@ public interface EntriesClient {
      * @param entryId The requested document ID.
      * @param range   An optional header used to retrieve partial content of the edoc. Only supports single
      *                range with byte unit.
-     * @return CompletableFuture<File> The return value
+     * @return CompletableFuture&lt;File&gt; The return value
      */
     CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range);
 
@@ -310,7 +305,7 @@ public interface EntriesClient {
      *
      * @param repoId  The requested repository ID.
      * @param entryId The requested document ID.
-     * @return CompletableFuture<ODataValueOfBoolean> The return value
+     * @return CompletableFuture&lt;ODataValueOfBoolean&gt; The return value
      */
     CompletableFuture<ODataValueOfBoolean> deleteDocument(String repoId, Integer entryId);
 
@@ -321,7 +316,7 @@ public interface EntriesClient {
      *
      * @param repoId  The requested repository ID.
      * @param entryId The requested document ID.
-     * @return CompletableFuture<Map < String, String>> The return value
+     * @return CompletableFuture&lt;Map&lt;String,String&gt;&gt; The return value
      */
     CompletableFuture<Map<String, String>> getDocumentContentType(String repoId, Integer entryId);
 
@@ -332,7 +327,7 @@ public interface EntriesClient {
      * @param repoId    The requested repository ID.
      * @param entryId   The requested document ID.
      * @param pageRange The pages to be deleted.
-     * @return CompletableFuture<ODataValueOfBoolean> The return value
+     * @return CompletableFuture&lt;ODataValueOfBoolean&gt; The return value
      */
     CompletableFuture<ODataValueOfBoolean> deletePages(String repoId, Integer entryId, String pageRange);
 
@@ -358,7 +353,7 @@ public interface EntriesClient {
      * @param top              Limits the number of items returned from a collection.
      * @param skip             Excludes the specified number of items of the queried collection from the result.
      * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntry> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntry> getEntryListing(String repoId, Integer entryId,
             Boolean groupByEntryType, String[] fields, Boolean formatFields, String prefer, String culture,
@@ -369,7 +364,7 @@ public interface EntriesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntry> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntry> getEntryListingNextLink(String nextLink, Integer maxPageSize);
 
@@ -392,7 +387,7 @@ public interface EntriesClient {
      * @param top              Limits the number of items returned from a collection.
      * @param skip             Excludes the specified number of items of the queried collection from the result.
      * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getEntryListingForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfEntry>, CompletableFuture<Boolean>> callback,
@@ -412,7 +407,7 @@ public interface EntriesClient {
      *                    renamed if an entry already exists with the given name in the folder. The default value is false.
      * @param culture     An optional query parameter used to indicate the locale that should be used.
      *                    The value should be a standard language tag.
-     * @return CompletableFuture<Entry> The return value
+     * @return CompletableFuture&lt;Entry&gt; The return value
      */
     CompletableFuture<Entry> createOrCopyEntry(String repoId, Integer entryId, PostEntryChildrenRequest requestBody,
             Boolean autoRename, String culture);
@@ -430,7 +425,7 @@ public interface EntriesClient {
      * @param top     Limits the number of items returned from a collection.
      * @param skip    Excludes the specified number of items of the queried collection from the result.
      * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTagInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTagInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTagInfo> getTagsAssignedToEntry(String repoId, Integer entryId,
             String prefer, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -440,7 +435,7 @@ public interface EntriesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTagInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTagInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTagInfo> getTagsAssignedToEntryNextLink(String nextLink,
             Integer maxPageSize);
@@ -458,7 +453,7 @@ public interface EntriesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTagsAssignedToEntryForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfWTagInfo>, CompletableFuture<Boolean>> callback,
@@ -473,7 +468,7 @@ public interface EntriesClient {
      * @param repoId      The requested repository ID.
      * @param entryId     The requested entry ID.
      * @param requestBody The tags to add.
-     * @return CompletableFuture<ODataValueOfIListOfWTagInfo> The return value
+     * @return CompletableFuture&lt;ODataValueOfIListOfWTagInfo&gt; The return value
      */
     CompletableFuture<ODataValueOfIListOfWTagInfo> assignTags(String repoId, Integer entryId,
             PutTagRequest requestBody);

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -18,7 +18,7 @@ public interface FieldDefinitionsClient {
      * @param culture           An optional query parameter used to indicate the locale that should be used for formatting.
      *                          The value should be a standard language tag.
      * @param select            Limits the properties returned in the result.
-     * @return CompletableFuture<WFieldInfo> The return value
+     * @return CompletableFuture&lt;WFieldInfo&gt; The return value
      */
     CompletableFuture<WFieldInfo> getFieldDefinitionById(String repoId, Integer fieldDefinitionId, String culture,
             String select);
@@ -37,7 +37,7 @@ public interface FieldDefinitionsClient {
      * @param top     Limits the number of items returned from a collection.
      * @param skip    Excludes the specified number of items of the queried collection from the result.
      * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfWFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWFieldInfo> getFieldDefinitions(String repoId, String prefer,
             String culture, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -47,7 +47,7 @@ public interface FieldDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfWFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWFieldInfo> getFieldDefinitionsNextLink(String nextLink,
             Integer maxPageSize);
@@ -66,7 +66,7 @@ public interface FieldDefinitionsClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getFieldDefinitionsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfWFieldInfo>, CompletableFuture<Boolean>> callback,

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -16,7 +16,7 @@ public interface LinkDefinitionsClient {
      * @param repoId     The requested repository ID.
      * @param linkTypeId The requested link type ID.
      * @param select     Limits the properties returned in the result.
-     * @return CompletableFuture<EntryLinkTypeInfo> The return value
+     * @return CompletableFuture&lt;EntryLinkTypeInfo&gt; The return value
      */
     CompletableFuture<EntryLinkTypeInfo> getLinkDefinitionById(String repoId, Integer linkTypeId, String select);
 
@@ -32,7 +32,7 @@ public interface LinkDefinitionsClient {
      * @param top     Limits the number of items returned from a collection.
      * @param skip    Excludes the specified number of items of the queried collection from the result.
      * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntryLinkTypeInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntryLinkTypeInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntryLinkTypeInfo> getLinkDefinitions(String repoId, String prefer,
             String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -42,7 +42,7 @@ public interface LinkDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntryLinkTypeInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntryLinkTypeInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntryLinkTypeInfo> getLinkDefinitionsNextLink(String nextLink,
             Integer maxPageSize);
@@ -59,7 +59,7 @@ public interface LinkDefinitionsClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getLinkDefinitionsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfEntryLinkTypeInfo>, CompletableFuture<Boolean>> callback,

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
@@ -9,7 +9,7 @@ public interface RepositoriesClient {
     /**
      * - Returns the repository resource list that current user has access to.
      *
-     * @return CompletableFuture<RepositoryInfo [ ]> The return value
+     * @return CompletableFuture&lt;RepositoryInfo[]&gt; The return value
      */
     CompletableFuture<RepositoryInfo[]> getRepositoryList();
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -14,7 +14,7 @@ public interface SearchesClient {
      *
      * @param repoId      The requested repository ID.
      * @param searchToken The requested searchToken.
-     * @return CompletableFuture<OperationProgress> The return value
+     * @return CompletableFuture&lt;OperationProgress&gt; The return value
      */
     CompletableFuture<OperationProgress> getSearchStatus(String repoId, String searchToken);
 
@@ -24,7 +24,7 @@ public interface SearchesClient {
      *
      * @param repoId      The requested repository ID.
      * @param searchToken The requested searchToken.
-     * @return CompletableFuture<ODataValueOfBoolean> The return value
+     * @return CompletableFuture&lt;ODataValueOfBoolean&gt; The return value
      */
     CompletableFuture<ODataValueOfBoolean> cancelOrCloseSearch(String repoId, String searchToken);
 
@@ -42,7 +42,7 @@ public interface SearchesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfContextHit> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfContextHit&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfContextHit> getSearchContextHits(String repoId, String searchToken,
             Integer rowNumber, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -52,7 +52,7 @@ public interface SearchesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfContextHit> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfContextHit&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfContextHit> getSearchContextHitsNextLink(String nextLink,
             Integer maxPageSize);
@@ -71,7 +71,7 @@ public interface SearchesClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getSearchContextHitsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfContextHit>, CompletableFuture<Boolean>> callback,
@@ -84,7 +84,7 @@ public interface SearchesClient {
      *
      * @param repoId      The requested repository ID.
      * @param requestBody The Laserfiche search command to run, optionally include fuzzy search settings.
-     * @return CompletableFuture<AcceptedOperation> The return value
+     * @return CompletableFuture&lt;AcceptedOperation&gt; The return value
      */
     CompletableFuture<AcceptedOperation> createSearchOperation(String repoId, AdvancedSearchRequest requestBody);
 
@@ -112,7 +112,7 @@ public interface SearchesClient {
      * @param top              Limits the number of items returned from a collection.
      * @param skip             Excludes the specified number of items of the queried collection from the result.
      * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntry> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntry> getSearchResults(String repoId, String searchToken,
             Boolean groupByEntryType, Boolean refresh, String[] fields, Boolean formatFields, String prefer,
@@ -123,7 +123,7 @@ public interface SearchesClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfEntry> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfEntry> getSearchResultsNextLink(String nextLink, Integer maxPageSize);
 
@@ -147,7 +147,7 @@ public interface SearchesClient {
      * @param top              Limits the number of items returned from a collection.
      * @param skip             Excludes the specified number of items of the queried collection from the result.
      * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getSearchResultsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfEntry>, CompletableFuture<Boolean>> callback,

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -14,7 +14,7 @@ public interface ServerSessionClient {
      * - Only available in Laserfiche Cloud.
      *
      * @param repoId The requested repository ID.
-     * @return CompletableFuture<ODataValueOfBoolean> The return value
+     * @return CompletableFuture&lt;ODataValueOfBoolean&gt; The return value
      */
     CompletableFuture<ODataValueOfBoolean> invalidateServerSession(String repoId);
 
@@ -23,7 +23,7 @@ public interface ServerSessionClient {
      * - Only available in Laserfiche Cloud.
      *
      * @param repoId The requested repository ID.
-     * @return CompletableFuture<ODataValueOfBoolean> The return value
+     * @return CompletableFuture&lt;ODataValueOfBoolean&gt; The return value
      */
     CompletableFuture<ODataValueOfBoolean> createServerSession(String repoId);
 
@@ -34,7 +34,7 @@ public interface ServerSessionClient {
      * - Only available in Laserfiche Cloud.
      *
      * @param repoId The requested repository ID.
-     * @return CompletableFuture<ODataValueOfDateTime> The return value
+     * @return CompletableFuture&lt;ODataValueOfDateTime&gt; The return value
      */
     CompletableFuture<ODataValueOfDateTime> refreshServerSession(String repoId);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -25,7 +25,7 @@ public interface SimpleSearchesClient {
      * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
      *                     The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
      *                     culture will not be used for formatting.
-     * @return CompletableFuture<ODataValueOfIListOfEntry> The return value
+     * @return CompletableFuture&lt;ODataValueOfIListOfEntry&gt; The return value
      */
     CompletableFuture<ODataValueOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
             Boolean count, String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody,

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -22,7 +22,7 @@ public interface TagDefinitionsClient {
      * @param top     Limits the number of items returned from a collection.
      * @param skip    Excludes the specified number of items of the queried collection from the result.
      * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTagInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTagInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTagInfo> getTagDefinitions(String repoId, String prefer,
             String culture, String select, String orderby, Integer top, Integer skip, Boolean count);
@@ -32,7 +32,7 @@ public interface TagDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTagInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTagInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTagInfo> getTagDefinitionsNextLink(String nextLink,
             Integer maxPageSize);
@@ -51,7 +51,7 @@ public interface TagDefinitionsClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTagDefinitionsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfWTagInfo>, CompletableFuture<Boolean>> callback,
@@ -68,7 +68,7 @@ public interface TagDefinitionsClient {
      * @param culture An optional query parameter used to indicate the locale that should be used for formatting.
      *                The value should be a standard language tag.
      * @param select  Limits the properties returned in the result.
-     * @return CompletableFuture<WTagInfo> The return value
+     * @return CompletableFuture&lt;WTagInfo&gt; The return value
      */
     CompletableFuture<WTagInfo> getTagDefinitionById(String repoId, Integer tagId, String culture, String select);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -13,7 +13,7 @@ public interface TasksClient {
      *
      * @param repoId         The requested repository ID
      * @param operationToken The operation token
-     * @return CompletableFuture<OperationProgress> The return value
+     * @return CompletableFuture&lt;OperationProgress&gt; The return value
      */
     CompletableFuture<OperationProgress> getOperationStatusAndProgress(String repoId, String operationToken);
 
@@ -24,7 +24,7 @@ public interface TasksClient {
      *
      * @param repoId         The requested repository ID
      * @param operationToken The operation token
-     * @return CompletableFuture<Boolean> The return value
+     * @return CompletableFuture&lt;Boolean&gt; The return value
      */
     CompletableFuture<Boolean> cancelOperation(String repoId, String operationToken);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -24,7 +24,7 @@ public interface TemplateDefinitionsClient {
      * @param top          Limits the number of items returned from a collection.
      * @param skip         Excludes the specified number of items of the queried collection from the result.
      * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTemplateInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTemplateInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTemplateInfo> getTemplateDefinitions(String repoId,
             String templateName, String prefer, String culture, String select, String orderby, Integer top,
@@ -35,7 +35,7 @@ public interface TemplateDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfWTemplateInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfWTemplateInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfWTemplateInfo> getTemplateDefinitionsNextLink(String nextLink,
             Integer maxPageSize);
@@ -55,7 +55,7 @@ public interface TemplateDefinitionsClient {
      * @param top          Limits the number of items returned from a collection.
      * @param skip         Excludes the specified number of items of the queried collection from the result.
      * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTemplateDefinitionsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfWTemplateInfo>, CompletableFuture<Boolean>> callback,
@@ -77,7 +77,7 @@ public interface TemplateDefinitionsClient {
      * @param top          Limits the number of items returned from a collection.
      * @param skip         Excludes the specified number of items of the queried collection from the result.
      * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfTemplateFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> getTemplateFieldDefinitionsByTemplateName(
             String repoId, String templateName, String prefer, String culture, String select, String orderby,
@@ -88,7 +88,7 @@ public interface TemplateDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfTemplateFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> getTemplateFieldDefinitionsByTemplateNameNextLink(
             String nextLink, Integer maxPageSize);
@@ -108,7 +108,7 @@ public interface TemplateDefinitionsClient {
      * @param top          Limits the number of items returned from a collection.
      * @param skip         Excludes the specified number of items of the queried collection from the result.
      * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTemplateFieldDefinitionsByTemplateNameForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo>, CompletableFuture<Boolean>> callback,
@@ -130,7 +130,7 @@ public interface TemplateDefinitionsClient {
      * @param top        Limits the number of items returned from a collection.
      * @param skip       Excludes the specified number of items of the queried collection from the result.
      * @param count      Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfTemplateFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> getTemplateFieldDefinitions(String repoId,
             Integer templateId, String prefer, String culture, String select, String orderby, Integer top, Integer skip,
@@ -141,7 +141,7 @@ public interface TemplateDefinitionsClient {
      *
      * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @return CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfTemplateFieldInfo&gt; The return value
      */
     CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo> getTemplateFieldDefinitionsNextLink(String nextLink,
             Integer maxPageSize);
@@ -161,7 +161,7 @@ public interface TemplateDefinitionsClient {
      * @param top         Limits the number of items returned from a collection.
      * @param skip        Excludes the specified number of items of the queried collection from the result.
      * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return CompletableFuture<Void> The return value
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
     CompletableFuture<Void> getTemplateFieldDefinitionsForEach(
             Function<CompletableFuture<ODataValueContextOfIListOfTemplateFieldInfo>, CompletableFuture<Boolean>> callback,
@@ -178,7 +178,7 @@ public interface TemplateDefinitionsClient {
      * @param culture    An optional query parameter used to indicate the locale that should be used for formatting.
      *                   The value should be a standard language tag.
      * @param select     Limits the properties returned in the result.
-     * @return CompletableFuture<WTemplateInfo> The return value
+     * @return CompletableFuture&lt;WTemplateInfo&gt; The return value
      */
     CompletableFuture<WTemplateInfo> getTemplateDefinitionById(String repoId, Integer templateId, String culture,
             String select);


### PR DESCRIPTION
When we generate JavaDoc, it's required to escape the HTML characters (such as < and > in Java Generic expression). This PR does that.