### PR TITLE
Return problem details in error response.

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiException.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiException.java
@@ -1,0 +1,53 @@
+package com.laserfiche.repository.api.clients.impl;
+
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+
+import java.util.Map;
+
+public class ApiException extends RuntimeException {
+    private int statusCode;
+    private String response;
+    private Map<String, String> headers;
+    private ProblemDetails problemDetails;
+
+    public ApiException(String message, int statusCode, String response, Map<String, String> headers,
+            ProblemDetails problemDetails) {
+        super(message);
+        this.statusCode = statusCode;
+        this.response = response;
+        this.headers = headers;
+        this.problemDetails = problemDetails;
+    }
+
+    public ProblemDetails getProblemDetails() {
+        return problemDetails;
+    }
+
+    public void setProblemDetails(ProblemDetails problemDetails) {
+        this.problemDetails = problemDetails;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public void setStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+    }
+
+    public String getResponse() {
+        return response;
+    }
+
+    public void setResponse(String response) {
+        this.response = response;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
+    public void setHeaders(Map<String, String> headers) {
+        this.headers = headers;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -38,35 +38,37 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             return objectMapper.readValue(jsonString, Attribute.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested attribute key not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested attribute key not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -103,35 +105,37 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.AttributesClient;
 import com.laserfiche.repository.api.clients.impl.model.Attribute;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -26,27 +29,44 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .get(baseUrl + "/v1/Repositories/{repoId}/Attributes/{attributeKey}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(Attribute.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Attribute.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested attribute key not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested attribute key not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -74,27 +94,44 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfListOfAttribute.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,8 +1,11 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.AuditReasonsClient;
 import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -19,27 +22,44 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
         return httpClient
                 .get(baseUrl + "/v1/Repositories/{repoId}/AuditReasons")
                 .routeParam(pathParameters)
-                .asObjectAsync(AuditReasons.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, AuditReasons.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -31,35 +31,37 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                             return objectMapper.readValue(jsonString, AuditReasons.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -57,35 +57,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -136,38 +138,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -193,43 +197,43 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, CreateEntryResult.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Parent entry is not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 409)
-                                throw new ApiException("Document creation is partial success.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 500)
-                                throw new ApiException("Document creation is complete failure.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Parent entry is not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 409)
+                            throw new ApiException("Document creation is partial success.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 500)
+                            throw new ApiException("Document creation is complete failure.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -267,35 +271,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -344,38 +350,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -400,38 +408,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -451,38 +461,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -505,35 +517,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -557,35 +571,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, FindEntryResult.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested entry path not found", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested entry path not found", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -611,36 +627,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Operation limit or request limit reached.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Operation limit or request limit reached.",
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -662,35 +679,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -716,41 +735,43 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 409)
-                                throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 409)
+                            throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -773,36 +794,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Operation limit or request limit reached.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Operation limit or request limit reached.",
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -831,38 +853,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, File.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -888,38 +912,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, File.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -939,38 +965,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -990,36 +1018,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                 .stream()
                                 .collect(Collectors.toMap(Header::getName, Header::getValue));
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -1041,38 +1070,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -1112,35 +1143,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -1193,38 +1226,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 409)
-                                throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 409)
+                            throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -1261,35 +1296,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -1338,38 +1375,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 423)
-                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 423)
+                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,9 +1,11 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.io.File;
 import java.io.InputStream;
@@ -46,27 +48,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfFieldValue.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -108,30 +127,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(ODataValueOfIListOfFieldValue.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -148,33 +184,52 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .field("request", toJson(requestBody))
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(CreateEntryResult.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 201) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, CreateEntryResult.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Parent entry is not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 409)
+                                throw new ApiException("Document creation is partial success.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 500)
+                                throw new ApiException("Document creation is complete failure.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Parent entry is not found.");
-                    }
-                    if (httpResponse.getStatus() == 409) {
-                        throw new RuntimeException("Document creation is partial success.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() == 500) {
-                        throw new RuntimeException("Document creation is complete failure.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -203,27 +258,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfWEntryLinkInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -263,30 +335,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(ODataValueOfIListOfWEntryLinkInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -302,30 +391,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(Entry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Entry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -336,30 +442,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
         return httpClient
                 .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template")
                 .routeParam(pathParameters)
-                .asObjectAsync(Entry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Entry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -375,25 +498,42 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync((new HashMap<String, String[]>()).getClass())
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -408,27 +548,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .get(baseUrl + "/v1/Repositories/{repoId}/Entries/ByPath")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(FindEntryResult.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, FindEntryResult.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested entry path not found", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested entry path not found");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -445,27 +602,45 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(AcceptedOperation.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 201) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, AcceptedOperation.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Operation limit or request limit reached.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Operation limit or request limit reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -478,27 +653,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(Entry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Entry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -515,33 +707,50 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(Entry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Entry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 409)
+                                throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 409) {
-                        throw new RuntimeException("Entry name conflicts.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -555,27 +764,45 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(AcceptedOperation.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 201) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, AcceptedOperation.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Operation limit or request limit reached.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Operation limit or request limit reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -595,30 +822,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(File.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 206) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, File.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -635,30 +879,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(File.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 206) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, File.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -669,30 +930,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
         return httpClient
                 .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfBoolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -705,32 +983,43 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(new HashMap<String, String>().getClass())
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        return httpResponse
+                                .getHeaders()
+                                .all()
+                                .stream()
+                                .collect(Collectors.toMap(Header::getName, Header::getValue));
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse
-                            .getHeaders()
-                            .all()
-                            .stream()
-                            .collect(Collectors.toMap(Header::getName, Header::getValue));
+                    return null;
                 });
     }
 
@@ -743,30 +1032,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfBoolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -797,27 +1103,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfEntry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -861,30 +1184,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(Entry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 201) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, Entry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 409)
+                                throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 409) {
-                        throw new RuntimeException("Entry name conflicts.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -912,27 +1252,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfWTagInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request entry id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -972,30 +1329,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(ODataValueOfIListOfWTagInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 423)
+                                throw new ApiException("Entry is locked.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request id not found.");
-                    }
-                    if (httpResponse.getStatus() == 423) {
-                        throw new RuntimeException("Entry is locked.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -27,27 +30,45 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .get(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions/{fieldDefinitionId}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(WFieldInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, WFieldInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested field definition id not found.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested field definition id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -74,27 +95,44 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfWFieldInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -39,36 +39,37 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             return objectMapper.readValue(jsonString, WFieldInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested field definition id not found.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested field definition id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -104,35 +105,37 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -38,36 +38,37 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Requested link type definition ID not found",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Requested link type definition ID not found",
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -104,35 +105,37 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                                     ODataValueContextOfIListOfEntryLinkTypeInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.LinkDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -26,27 +29,45 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .get(baseUrl + "/v1/Repositories/{repoId}/LinkDefinitions/{linkTypeId}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(EntryLinkTypeInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Requested link type definition ID not found",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Requested link type definition ID not found");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -73,27 +94,45 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfEntryLinkTypeInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString,
+                                    ODataValueContextOfIListOfEntryLinkTypeInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,9 +1,15 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public class RepositoriesClientImpl extends ApiClient implements RepositoriesClient {
@@ -16,24 +22,41 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
     public CompletableFuture<RepositoryInfo[]> getRepositoryList() {
         return httpClient
                 .get(baseUrl + "/v1/Repositories")
-                .asObjectAsync(RepositoryInfo[].class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
+                            return objectMapper.readValue(jsonString, RepositoryInfo[].class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -31,32 +31,34 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                             return objectMapper.readValue(jsonString, RepositoryInfo[].class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -33,35 +33,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -81,35 +83,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -149,35 +153,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -225,36 +231,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Operation limit or request limit reached.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Operation limit or request limit reached.",
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -294,35 +301,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,8 +1,10 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.SearchesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -22,27 +24,44 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
         return httpClient
                 .get(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
                 .routeParam(pathParameters)
-                .asObjectAsync(OperationProgress.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, OperationProgress.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request search token not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -53,27 +72,44 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
         return httpClient
                 .delete(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfBoolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request search token not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -104,27 +140,44 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfContextHit.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request search token not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -163,27 +216,45 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(AcceptedOperation.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 201) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, AcceptedOperation.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Operation limit or request limit reached.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Operation limit or request limit reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -214,27 +285,44 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfEntry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request search token not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request search token not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -32,35 +32,37 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -79,26 +81,28 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -117,35 +121,37 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.ServerSessionClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -20,27 +23,44 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
         return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Invalidate")
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfBoolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -50,18 +70,35 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
         return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Create")
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfBoolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -71,27 +108,44 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
         return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Refresh")
                 .routeParam(pathParameters)
-                .asObjectAsync(ODataValueOfDateTime.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -40,36 +40,37 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Operation limit or request limit reached.",
-                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Operation limit or request limit reached.",
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.SimpleSearchesClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -28,27 +31,45 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 .routeParam(pathParameters)
                 .contentType("application/json")
                 .body(requestBody)
-                .asObjectAsync(ODataValueOfIListOfEntry.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Operation limit or request limit reached.",
+                                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Operation limit or request limit reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -51,35 +51,37 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
+                                    headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -129,35 +131,37 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             return objectMapper.readValue(jsonString, WTagInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request tag definition id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request tag definition id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,9 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.TagDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,27 +42,44 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfWTagInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -100,27 +120,44 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .get(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions/{tagId}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(WTagInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, WTagInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request tag definition id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request tag definition id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -1,8 +1,11 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.TasksClient;
 import com.laserfiche.repository.api.clients.impl.model.OperationProgress;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -20,27 +23,44 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
         return httpClient
                 .get(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}")
                 .routeParam(pathParameters)
-                .asObjectAsync(OperationProgress.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, OperationProgress.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request operationToken not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -51,27 +71,38 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
         return httpClient
                 .delete(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}")
                 .routeParam(pathParameters)
-                .asObjectAsync(Boolean.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 204) {
+                        return true;
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request operationToken not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return true;
+                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -32,35 +32,37 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -76,33 +78,34 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                     if (httpResponse.getStatus() == 204) {
                         return true;
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -54,35 +54,37 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request template name not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request template name not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -148,35 +150,37 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request template name not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request template name not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -243,35 +247,37 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request template id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request template id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 
@@ -321,35 +327,37 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             return objectMapper.readValue(jsonString, WTemplateInfo.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
                     } else {
+                        Object body = httpResponse.getBody();
+                        ProblemDetails problemDetails;
                         try {
-                            Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
-                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                            Map<String, String> headersMap = getHeadersMap(httpResponse);
-                            if (httpResponse.getStatus() == 400)
-                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 401)
-                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 403)
-                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 404)
-                                throw new ApiException("Request template id not found.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else if (httpResponse.getStatus() == 429)
-                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                        httpResponse.getStatusText(), headersMap, problemDetails);
-                            else
-                                throw new RuntimeException(httpResponse.getStatusText());
+                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException e) {
                             e.printStackTrace();
+                            return null;
                         }
+                        Map<String, String> headersMap = getHeadersMap(httpResponse);
+                        if (httpResponse.getStatus() == 400)
+                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 401)
+                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 403)
+                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 404)
+                            throw new ApiException("Request template id not found.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else if (httpResponse.getStatus() == 429)
+                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                        else
+                            throw new RuntimeException(httpResponse.getStatusText());
                     }
-                    return null;
                 });
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -1,10 +1,13 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.TemplateDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfTemplateFieldInfo;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTemplateInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.json.JSONObject;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -42,27 +45,44 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfWTemplateInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request template name not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request template name not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -118,27 +138,45 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfTemplateFieldInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString,
+                                    ODataValueContextOfIListOfTemplateFieldInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request template name not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request template name not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -195,27 +233,45 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(ODataValueContextOfIListOfTemplateFieldInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString,
+                                    ODataValueContextOfIListOfTemplateFieldInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request template id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request template id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 
@@ -256,27 +312,44 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .get(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}")
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
-                .asObjectAsync(WTemplateInfo.class)
+                .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 400) {
-                        throw new RuntimeException("Invalid or bad request.");
+                    if (httpResponse.getStatus() == 200) {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, WTemplateInfo.class);
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        try {
+                            Object body = httpResponse.getBody();
+                            String jsonString = new JSONObject(body).toString();
+                            ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            Map<String, String> headersMap = getHeadersMap(httpResponse);
+                            if (httpResponse.getStatus() == 400)
+                                throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 401)
+                                throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 403)
+                                throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 404)
+                                throw new ApiException("Request template id not found.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else if (httpResponse.getStatus() == 429)
+                                throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
+                                        httpResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                throw new RuntimeException(httpResponse.getStatusText());
+                        } catch (JsonProcessingException e) {
+                            e.printStackTrace();
+                        }
                     }
-                    if (httpResponse.getStatus() == 401) {
-                        throw new RuntimeException("Access token is invalid or expired.");
-                    }
-                    if (httpResponse.getStatus() == 403) {
-                        throw new RuntimeException("Access denied for the operation.");
-                    }
-                    if (httpResponse.getStatus() == 404) {
-                        throw new RuntimeException("Request template id not found.");
-                    }
-                    if (httpResponse.getStatus() == 429) {
-                        throw new RuntimeException("Rate limit is reached.");
-                    }
-                    if (httpResponse.getStatus() >= 299) {
-                        throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                    return httpResponse.getBody();
+                    return null;
                 });
     }
 }

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -5,7 +5,6 @@ import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -103,7 +102,6 @@ public class CreateCopyEntryApiTest extends BaseTest {
     }
 
     @Test
-    @Disabled("Test is failing: We need to update it to match the new implementation.")
     void createCopyEntry_CopyEntry() throws InterruptedException {
         String testFolderName = "RepositoryApiClientIntegrationTest Java CreateCopyEntry_CopyEntry_test_folder";
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -47,8 +47,10 @@ public class ImportDocumentApiTest extends BaseTest {
 
         assertNotNull(toUpload);
 
-        CreateEntryResult result = client.importDocument(repoId, 1, fileName, true, null,
-                new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest()).join();
+        CreateEntryResult result = client
+                .importDocument(repoId, 1, fileName, true, null,
+                        new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest())
+                .join();
 
         CreateEntryOperations operations = result.getOperations();
 
@@ -75,13 +77,19 @@ public class ImportDocumentApiTest extends BaseTest {
     @Test
     void importDocument_DocumentCreated_FromFile_WithTemplate() throws ExecutionException, InterruptedException, FileNotFoundException {
         WTemplateInfo template = null;
-        ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient.getTemplateDefinitionClient().getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null).join();
+        ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient
+                .getTemplateDefinitionClient()
+                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null)
+                .join();
         List<WTemplateInfo> templateDefinitions = templateDefinitionResult.getValue();
         assertNotNull(templateDefinitions);
         Assertions.assertTrue(templateDefinitions.size() > 0);
         for (WTemplateInfo templateDefinition : templateDefinitions) {
-            ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionFieldsResult = repositoryApiClient.getTemplateDefinitionClient().getTemplateFieldDefinitions(repoId,
-                    templateDefinition.getId(), null, null, null, null, null, null, null).join();
+            ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionFieldsResult = repositoryApiClient
+                    .getTemplateDefinitionClient()
+                    .getTemplateFieldDefinitions(repoId,
+                            templateDefinition.getId(), null, null, null, null, null, null, null)
+                    .join();
             if (templateDefinitionFieldsResult.getValue() != null && allFalse(
                     templateDefinitionFieldsResult.getValue()).get()) {
                 template = templateDefinition;
@@ -102,8 +110,10 @@ public class ImportDocumentApiTest extends BaseTest {
         PostEntryWithEdocMetadataRequest request = new PostEntryWithEdocMetadataRequest();
         request.setTemplate(template.getName());
 
-        CreateEntryResult result = client.importDocument(repoId, parentEntryId, fileName,
-                true, null, new FileInputStream(toUpload), request).join();
+        CreateEntryResult result = client
+                .importDocument(repoId, parentEntryId, fileName,
+                        true, null, new FileInputStream(toUpload), request)
+                .join();
 
         CreateEntryOperations operations = result.getOperations();
         assertNotNull(operations);
@@ -136,12 +146,15 @@ public class ImportDocumentApiTest extends BaseTest {
     void importDocument_DocumentCreated_FromURL() throws IOException {
         String fileName = "myFile";
         CreateEntryResult result = null;
-        URL googleLogoUrl = new URL("https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png");
+        URL googleLogoUrl = new URL(
+                "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png");
         InputStream inputStream = googleLogoUrl.openStream();
         assertNotNull(inputStream);
 
-        result = client.importDocument(repoId, 1, fileName, true, null,
-                inputStream, new PostEntryWithEdocMetadataRequest()).join();
+        result = client
+                .importDocument(repoId, 1, fileName, true, null,
+                        inputStream, new PostEntryWithEdocMetadataRequest())
+                .join();
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -171,11 +184,13 @@ public class ImportDocumentApiTest extends BaseTest {
         String fileName = "myFile";
         CreateEntryResult result = null;
         String fileContent = "This is the file content";
-        InputStream inputStream =  new ByteArrayInputStream(fileContent.getBytes());
+        InputStream inputStream = new ByteArrayInputStream(fileContent.getBytes());
         assertNotNull(inputStream);
 
-        result = client.importDocument(repoId, 1, fileName, true, null,
-                inputStream, new PostEntryWithEdocMetadataRequest()).join();
+        result = client
+                .importDocument(repoId, 1, fileName, true, null,
+                        inputStream, new PostEntryWithEdocMetadataRequest())
+                .join();
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.TasksClient;
+import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,8 @@ public class TasksApiTest extends BaseTest {
                     .join();
         });
 
-        Assertions.assertEquals("java.lang.RuntimeException: Invalid or bad request.", thrown.getMessage());
+        Assertions.assertEquals(String.format("%s: Invalid or bad request.", ApiException.class.getCanonicalName()),
+                thrown.getMessage());
     }
 
     @Test


### PR DESCRIPTION
- The client library code for handling APIServer's response is updated to include ProblemDetails object if the request has failed.
   - for this, it is needed to use asObjectAsync with Object.class, as the parameter must be something that can accept both the successful and failed response bodies. 
   - updated the code so that client implementations have access to objectMapper created in their superclass (i.e. ApiClass)
   - A new exception type, ApiException is created to be used in the failure path
- Some minor updates, like 
  - replacing *-imports in the generated code, to make the client code more self-documented and readable.  
  - rearranging the imports to make the generated code look better
  