### PR TITLE
Fix passphrase not used and hanging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>1.0.0</version>
+  <version>1.0.0-SNAPSHOT</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>
@@ -186,7 +186,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
+        <version>1.6</version>
         <executions>
           <execution>
             <id>sign-artifacts</id>
@@ -197,6 +197,7 @@
           </execution>
         </executions>
         <configuration>
+          <!-- Prevent gpg from using pinentry programs -->
           <gpgArguments>
             <arg>--pinentry-mode</arg>
             <arg>loopback</arg>
@@ -263,7 +264,7 @@
     <dependency>
       <groupId>com.laserfiche</groupId>
       <artifactId>lf-api-client-core</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
 
     


### PR DESCRIPTION
When one release a jar, one needs to sign it. maven-gpg-plugin is used to do that. But the 1.5 version of it has a bug which makes it not reading the passphrase of the private key in the settings.xml (`%username%/m2/settings.xml`) so it will ask for it every time. But in order to also run the pipeline in GitHub, we set it to not promot the user for passphrase. Therefore, the end result is that when releasing from one's computer, the pipeline hangs forever.

1.6 of the plugin fixes that issue so we upgrade to 1.6 in this PR.

Also in this PR we use the snapshot version of the client core library because we have sorted out the firewall issue on Maven snapshot repository.