### PR TITLE
Fix bug for exportApi always returning null.

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -26,7 +26,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
     private final TemplateDefinitionsClient templateDefinitionsClient;
 
     protected RepositoryApiClientImpl(String servicePrincipalKey, AccessKey accessKey, String baseUrlDebug) {
-        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.domain + "/repository";
+        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.getDomain() + "/repository";
         httpClient = Unirest.spawnInstance();
 
         httpClient

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -26,7 +26,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
     private final TemplateDefinitionsClient templateDefinitionsClient;
 
     protected RepositoryApiClientImpl(String servicePrincipalKey, AccessKey accessKey, String baseUrlDebug) {
-        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.getDomain() + "/repository";
+        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.domain + "/repository";
         httpClient = Unirest.spawnInstance();
 
         httpClient

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -9,7 +9,7 @@ import java.util.function.Function;
 public interface AttributesClient {
 
     /**
-     * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within "Everyone" group.
+     * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
      * @param repoId       The requested repository ID.
@@ -20,9 +20,9 @@ public interface AttributesClient {
     CompletableFuture<Attribute> getTrusteeAttributeValueByKey(String repoId, String attributeKey, Boolean everyone);
 
     /**
-     * - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the "Everyone" group.
+     * - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
-     * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the "Everyone" group. Note when this is true, the response does not include both the "Everyone" groups attribute and the currently authenticated user, but only the "Everyone" groups.
+     * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *
      * @param repoId   The requested repository ID.
      * @param everyone Boolean value that indicates whether to return attributes key value pairs associated with everyone or the currently authenticated user.
@@ -48,7 +48,7 @@ public interface AttributesClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTrusteeAttributeKeyValuePairs</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTrusteeAttributeKeyValuePairs&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -2,11 +2,11 @@ package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 public interface EntriesClient {
@@ -279,29 +279,30 @@ public interface EntriesClient {
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     * @param repoId       The requested repository ID.
-     * @param entryId      The requested document ID.
-     * @param range        An optional header used to retrieve partial content of the edoc. Only supports single
-     *                     range with byte unit.
-     * @param exportedFile A File object used to store the exported file into. If the file already exists, it will be overwritten.
-     * @return CompletableFuture&lt;File&gt; The return value
+     * @param repoId              The requested repository ID.
+     * @param entryId             The requested document ID.
+     * @param range               An optional header used to retrieve partial content of the edoc. Only supports single
+     *                            range with byte unit.
+     * @param inputStreamConsumer A Consumer&lt;InputStream&gt; object that the is provided with the response's inputStream to consume it, if the request has been successful.
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
-    CompletableFuture<File> exportDocumentWithAuditReason(String repoId, Integer entryId,
-            GetEdocWithAuditReasonRequest requestBody, String range, File exportedFile);
+    CompletableFuture<Void> exportDocumentWithAuditReason(String repoId, Integer entryId,
+            GetEdocWithAuditReasonRequest requestBody, String range, Consumer<InputStream> inputStreamConsumer);
 
     /**
      * - Returns an entry's edoc resource in a stream format.
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
-     * @param repoId       The requested repository ID.
-     * @param entryId      The requested document ID.
-     * @param range        An optional header used to retrieve partial content of the edoc. Only supports single
-     *                     range with byte unit.
-     * @param exportedFile A File object used to store the exported file into. If the file already exists, it will be overwritten.
-     * @return CompletableFuture&lt;File&gt; The return value
+     * @param repoId              The requested repository ID.
+     * @param entryId             The requested document ID.
+     * @param range               An optional header used to retrieve partial content of the edoc. Only supports single
+     *                            range with byte unit.
+     * @param inputStreamConsumer A Consumer&lt;InputStream&gt; object that the is provided with the response's inputStream to consume it, if the request has been successful.
+     * @return CompletableFuture&lt;Void&gt; The return value
      */
-    CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range, File exportedFile);
+    CompletableFuture<Void> exportDocument(String repoId, Integer entryId, String range,
+            Consumer<InputStream> inputStreamConsumer);
 
     /**
      * - Delete the edoc associated with the provided entry ID.

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -46,7 +46,7 @@ public interface EntriesClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getFieldValues</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldValues&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
@@ -97,6 +97,7 @@ public interface EntriesClient {
      *                      renamed if an entry already exists with the given name in the folder. The default value is false.
      * @param culture       An optional query parameter used to indicate the locale that should be used.
      *                      The value should be a standard language tag. This may be used when setting field values with tokens.
+     * @param inputStream   An InputStream object to read the raw bytes for the file to be uploaded.
      * @return CompletableFuture&lt;CreateEntryResult&gt; The return value
      */
     CompletableFuture<CreateEntryResult> importDocument(String repoId, Integer parentEntryId, String fileName,
@@ -131,7 +132,7 @@ public interface EntriesClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getLinkValuesFromEntry</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkValuesFromEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
@@ -278,27 +279,29 @@ public interface EntriesClient {
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested document ID.
-     * @param range   An optional header used to retrieve partial content of the edoc. Only supports single
-     *                range with byte unit.
+     * @param repoId       The requested repository ID.
+     * @param entryId      The requested document ID.
+     * @param range        An optional header used to retrieve partial content of the edoc. Only supports single
+     *                     range with byte unit.
+     * @param exportedFile A File object used to store the exported file into. If the file already exists, it will be overwritten.
      * @return CompletableFuture&lt;File&gt; The return value
      */
     CompletableFuture<File> exportDocumentWithAuditReason(String repoId, Integer entryId,
-            GetEdocWithAuditReasonRequest requestBody, String range);
+            GetEdocWithAuditReasonRequest requestBody, String range, File exportedFile);
 
     /**
      * - Returns an entry's edoc resource in a stream format.
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested document ID.
-     * @param range   An optional header used to retrieve partial content of the edoc. Only supports single
-     *                range with byte unit.
+     * @param repoId       The requested repository ID.
+     * @param entryId      The requested document ID.
+     * @param range        An optional header used to retrieve partial content of the edoc. Only supports single
+     *                     range with byte unit.
+     * @param exportedFile A File object used to store the exported file into. If the file already exists, it will be overwritten.
      * @return CompletableFuture&lt;File&gt; The return value
      */
-    CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range);
+    CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range, File exportedFile);
 
     /**
      * - Delete the edoc associated with the provided entry ID.
@@ -322,7 +325,7 @@ public interface EntriesClient {
 
     /**
      * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
-     * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: "1,2,3", "1-3,5", "2-7,10-12."
+     * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
      * @param repoId    The requested repository ID.
      * @param entryId   The requested document ID.
@@ -334,7 +337,7 @@ public interface EntriesClient {
     /**
      * - Returns the children entries of a folder in the repository.
      * - Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.
-     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: "PropertyName direction,PropertyName2 direction". Sort order can be either value "asc" or "desc". Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. Sort order can be either value &quot;asc&quot; or &quot;desc&quot;. Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
      * - Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
@@ -369,7 +372,7 @@ public interface EntriesClient {
     CompletableFuture<ODataValueContextOfIListOfEntry> getEntryListingNextLink(String nextLink, Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getEntryListing</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getEntryListing&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback         A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize      Optionally specify the maximum number of items to retrieve.
@@ -441,7 +444,7 @@ public interface EntriesClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTagsAssignedToEntry</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagsAssignedToEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -53,7 +53,7 @@ public interface FieldDefinitionsClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getFieldDefinitions</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -48,7 +48,7 @@ public interface LinkDefinitionsClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getLinkDefinitions</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -58,7 +58,7 @@ public interface SearchesClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getSearchContextHits</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchContextHits&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
@@ -92,7 +92,7 @@ public interface SearchesClient {
      * - Returns a search result listing if the search is completed.
      * - Optional query parameter: groupByOrderType (default false). This query parameter decides whether or not results are returned in groups based on their entry type.
      * - Optional query parameter: refresh (default false). If the search listing should be refreshed to show updated values.
-     * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: "PropertyName direction,PropertyName2 direction". sort order can be either "asc" or "desc". Search results expire after 5 minutes, but can be refreshed by retrieving the results again.
+     * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. sort order can be either &quot;asc&quot; or &quot;desc&quot;. Search results expire after 5 minutes, but can be refreshed by retrieving the results again.
      * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
@@ -128,7 +128,7 @@ public interface SearchesClient {
     CompletableFuture<ODataValueContextOfIListOfEntry> getSearchResultsNextLink(String nextLink, Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getSearchResults</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchResults&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback         A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize      Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -10,7 +10,7 @@ public interface ServerSessionClient {
     /**
      * - Deprecated.
      * - Invalidates the server session.
-     * - Acts as a "logout" operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
+     * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
      *
      * @param repoId The requested repository ID.

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -8,7 +8,7 @@ import java.util.concurrent.CompletableFuture;
 public interface SimpleSearchesClient {
 
     /**
-     * - Runs a "simple" search operation on the repository.
+     * - Runs a &quot;simple&quot; search operation on the repository.
      * - Returns a truncated search result listing.
      * - Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.
      * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -38,7 +38,7 @@ public interface TagDefinitionsClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTagDefinitions</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -41,7 +41,7 @@ public interface TemplateDefinitionsClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTemplateDefinitions</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback     A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize  Optionally specify the maximum number of items to retrieve.
@@ -94,7 +94,7 @@ public interface TemplateDefinitionsClient {
             String nextLink, Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTemplateFieldDefinitionsByTemplateName</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitionsByTemplateName&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback     A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize  Optionally specify the maximum number of items to retrieve.
@@ -147,7 +147,7 @@ public interface TemplateDefinitionsClient {
             Integer maxPageSize);
 
     /**
-     * Provides the functionality to iteratively (i.e. through paging) call <b>getTemplateFieldDefinitions</b>, and apply a function on the response of each iteration.
+     * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
      * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -8,10 +8,11 @@ import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.laserfiche.repository.api.clients.impl.deserialization.OffsetDateTimeDeserializer;
 import kong.unirest.Header;
-import kong.unirest.HttpResponse;
+import kong.unirest.Headers;
 import kong.unirest.UnirestInstance;
 import org.threeten.bp.OffsetDateTime;
 
+import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -73,11 +74,26 @@ public class ApiClient {
         return json;
     }
 
-    protected Map<String, String> getHeadersMap(HttpResponse httpResponse) {
-        return httpResponse
-                .getHeaders()
+    protected Map<String, String> getHeadersMap(Headers headers) {
+        return headers
                 .all()
                 .stream()
                 .collect(Collectors.toMap(Header::getName, Header::getValue));
+    }
+
+    protected void saveFile(InputStream inputStream, File outputFile) {
+        try (BufferedOutputStream fileOutputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
+            byte[] buffer = new byte[1024];
+            while (true) {
+                int readCount = inputStream.read(buffer);
+                if (readCount <= 0) {
+                    break;
+                }
+                fileOutputStream.write(buffer, 0, readCount);
+            }
+            fileOutputStream.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -12,7 +12,6 @@ import kong.unirest.Headers;
 import kong.unirest.UnirestInstance;
 import org.threeten.bp.OffsetDateTime;
 
-import java.io.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -79,21 +78,5 @@ public class ApiClient {
                 .all()
                 .stream()
                 .collect(Collectors.toMap(Header::getName, Header::getValue));
-    }
-
-    protected void saveFile(InputStream inputStream, File outputFile) {
-        try (BufferedOutputStream fileOutputStream = new BufferedOutputStream(new FileOutputStream(outputFile))) {
-            byte[] buffer = new byte[1024];
-            while (true) {
-                int readCount = inputStream.read(buffer);
-                if (readCount <= 0) {
-                    break;
-                }
-                fileOutputStream.write(buffer, 0, readCount);
-            }
-            fileOutputStream.flush();
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -36,21 +36,23 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Attribute.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -103,21 +105,23 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.Attribute;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -48,10 +49,12 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -117,10 +120,12 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -29,21 +29,23 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AuditReasons.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -5,6 +5,7 @@ import com.laserfiche.repository.api.clients.AuditReasonsClient;
 import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -41,10 +42,12 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -7,12 +7,12 @@ import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONObject;
 
-import java.io.File;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -855,8 +855,8 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     @Override
-    public CompletableFuture<File> exportDocumentWithAuditReason(String repoId, Integer entryId,
-            GetEdocWithAuditReasonRequest requestBody, String range, File exportedFile) {
+    public CompletableFuture<Void> exportDocumentWithAuditReason(String repoId, Integer entryId,
+            GetEdocWithAuditReasonRequest requestBody, String range, Consumer<InputStream> inputStreamConsumer) {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
                 new Object[]{repoId, entryId});
         Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
@@ -874,7 +874,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                     .body(requestBody)
                     .thenConsume(rawResponse -> {
                         if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                            saveFile(rawResponse.getContent(), exportedFile);
+                            inputStreamConsumer.accept(rawResponse.getContent());
                         } else {
                             ProblemDetails problemDetails = null;
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
@@ -912,13 +912,14 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
             if (exception[0] != null) {
                 throw exception[0];
             } else {
-                return CompletableFuture.completedFuture(exportedFile);
+                return CompletableFuture.completedFuture(null);
             }
         }
     }
 
     @Override
-    public CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range, File exportedFile) {
+    public CompletableFuture<Void> exportDocument(String repoId, Integer entryId, String range,
+            Consumer<InputStream> inputStreamConsumer) {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
                 new Object[]{repoId, entryId});
         Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
@@ -934,7 +935,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                     .headers(headerParametersWithStringTypeValue)
                     .thenConsume(rawResponse -> {
                         if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                            saveFile(rawResponse.getContent(), exportedFile);
+                            inputStreamConsumer.accept(rawResponse.getContent());
                         } else {
                             ProblemDetails problemDetails = null;
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
@@ -972,7 +973,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
             if (exception[0] != null) {
                 throw exception[0];
             } else {
-                return CompletableFuture.completedFuture(exportedFile);
+                return CompletableFuture.completedFuture(null);
             }
         }
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -5,6 +5,7 @@ import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.io.InputStream;
@@ -67,10 +68,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -150,10 +153,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -211,10 +216,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -287,10 +294,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -368,10 +377,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -428,10 +439,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -483,10 +496,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -541,10 +556,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -597,10 +614,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -655,10 +674,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -709,10 +730,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -767,10 +790,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -828,10 +853,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1004,10 +1031,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1056,10 +1085,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1113,10 +1144,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1188,10 +1221,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1273,10 +1308,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1345,10 +1382,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -1426,10 +1465,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -55,21 +55,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -136,21 +138,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -195,21 +199,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, CreateEntryResult.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -269,21 +275,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -348,21 +356,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -406,21 +416,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -459,21 +471,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -515,21 +529,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -569,21 +585,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, FindEntryResult.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -625,21 +643,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -677,21 +697,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -733,21 +755,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -792,21 +816,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -830,7 +856,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public CompletableFuture<File> exportDocumentWithAuditReason(String repoId, Integer entryId,
-            GetEdocWithAuditReasonRequest requestBody, String range) {
+            GetEdocWithAuditReasonRequest requestBody, String range, File exportedFile) {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
                 new Object[]{repoId, entryId});
         Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
@@ -838,60 +864,61 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .entrySet()
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        return httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason")
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObjectAsync(Object.class)
-                .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 206) {
-                        try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
-                            return objectMapper.readValue(jsonString, File.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+        {
+            final RuntimeException[] exception = {null};
+            httpClient
+                    .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason")
+                    .routeParam(pathParameters)
+                    .headers(headerParametersWithStringTypeValue)
+                    .contentType("application/json")
+                    .body(requestBody)
+                    .thenConsume(rawResponse -> {
+                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                            saveFile(rawResponse.getContent(), exportedFile);
+                        } else {
+                            ProblemDetails problemDetails = null;
+                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                            try {
+                                String jsonString = rawResponse.getContentAsString();
+                                problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            } catch (JsonProcessingException | IllegalStateException e) {
+                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
+                                        rawResponse.getContentAsString(), headersMap, null);
+                            }
+                            if (rawResponse.getStatus() == 400)
+                                exception[0] = new ApiException("Invalid or bad request.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 401)
+                                exception[0] = new ApiException("Access token is invalid or expired.",
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 403)
+                                exception[0] = new ApiException("Access denied for the operation.",
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 404)
+                                exception[0] = new ApiException("Request entry id not found.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 423)
+                                exception[0] = new ApiException("Entry is locked.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 429)
+                                exception[0] = new ApiException("Rate limit is reached.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
-                    } else {
-                        Object body = httpResponse.getBody();
-                        ProblemDetails problemDetails;
-                        try {
-                            String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
-                        }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
-                        if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else
-                            throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                });
+                    });
+            if (exception[0] != null) {
+                throw exception[0];
+            } else {
+                return CompletableFuture.completedFuture(exportedFile);
+            }
+        }
     }
 
     @Override
-    public CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range) {
+    public CompletableFuture<File> exportDocument(String repoId, Integer entryId, String range, File exportedFile) {
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
                 new Object[]{repoId, entryId});
         Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
@@ -899,54 +926,55 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .entrySet()
                 .stream()
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        return httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObjectAsync(Object.class)
-                .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 206) {
-                        try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
-                            return objectMapper.readValue(jsonString, File.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+        {
+            final RuntimeException[] exception = {null};
+            httpClient
+                    .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
+                    .routeParam(pathParameters)
+                    .headers(headerParametersWithStringTypeValue)
+                    .thenConsume(rawResponse -> {
+                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                            saveFile(rawResponse.getContent(), exportedFile);
+                        } else {
+                            ProblemDetails problemDetails = null;
+                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                            try {
+                                String jsonString = rawResponse.getContentAsString();
+                                problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            } catch (JsonProcessingException | IllegalStateException e) {
+                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
+                                        rawResponse.getContentAsString(), headersMap, null);
+                            }
+                            if (rawResponse.getStatus() == 400)
+                                exception[0] = new ApiException("Invalid or bad request.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 401)
+                                exception[0] = new ApiException("Access token is invalid or expired.",
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 403)
+                                exception[0] = new ApiException("Access denied for the operation.",
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 404)
+                                exception[0] = new ApiException("Request entry id not found.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 423)
+                                exception[0] = new ApiException("Entry is locked.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else if (rawResponse.getStatus() == 429)
+                                exception[0] = new ApiException("Rate limit is reached.", rawResponse.getStatus(),
+                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                            else
+                                exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
-                    } else {
-                        Object body = httpResponse.getBody();
-                        ProblemDetails problemDetails;
-                        try {
-                            String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
-                        }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
-                        if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
-                        else
-                            throw new RuntimeException(httpResponse.getStatusText());
-                    }
-                });
+                    });
+            if (exception[0] != null) {
+                throw exception[0];
+            } else {
+                return CompletableFuture.completedFuture(exportedFile);
+            }
+        }
     }
 
     @Override
@@ -963,21 +991,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1020,14 +1050,16 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1068,21 +1100,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1141,21 +1175,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1224,21 +1260,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1294,21 +1332,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -1373,21 +1413,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIList
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -49,10 +50,12 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -117,10 +120,12 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -37,21 +37,23 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WFieldInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -103,21 +105,23 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -48,10 +49,12 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -117,10 +120,12 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -36,21 +36,23 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -103,21 +105,23 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfEntryLinkTypeInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -29,21 +29,23 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
                             return objectMapper.readValue(jsonString, RepositoryInfo[].class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -5,6 +5,7 @@ import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 
@@ -41,10 +42,12 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -31,21 +31,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -81,21 +83,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -151,21 +155,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -229,21 +235,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -299,21 +307,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.SearchesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -43,10 +44,12 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -95,10 +98,12 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -167,10 +172,12 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -247,10 +254,12 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -319,10 +328,12 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -42,10 +43,12 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -93,10 +96,12 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 401)
                             throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
@@ -135,10 +140,12 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -30,21 +30,23 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -79,21 +81,23 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 401)
                             throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -119,21 +123,23 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -38,21 +38,23 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -50,10 +51,12 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -6,6 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIList
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -61,10 +62,12 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -143,10 +146,12 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -49,21 +49,23 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -129,21 +131,23 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTagInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -30,21 +30,23 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -80,14 +82,16 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -5,6 +5,7 @@ import com.laserfiche.repository.api.clients.TasksClient;
 import com.laserfiche.repository.api.clients.impl.model.OperationProgress;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -42,10 +43,12 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -87,10 +90,12 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -52,21 +52,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -148,21 +150,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -245,21 +249,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);
@@ -325,21 +331,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             Object body = httpResponse.getBody();
                             String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTemplateInfo.class);
-                        } catch (JsonProcessingException e) {
+                        } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
                         Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
+                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-                        } catch (JsonProcessingException e) {
-                            e.printStackTrace();
-                            return null;
+                        } catch (JsonProcessingException | IllegalStateException e) {
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                                    .getParsingError()
+                                    .get()
+                                    .getOriginalBody(), headersMap, null);
                         }
-                        Map<String, String> headersMap = getHeadersMap(httpResponse);
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
                                     httpResponse.getStatusText(), headersMap, problemDetails);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -7,6 +7,7 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIList
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
 import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
@@ -64,10 +65,12 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -162,10 +165,12 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -261,10 +266,12 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
@@ -343,10 +350,12 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             String jsonString = new JSONObject(body).toString();
                             problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), httpResponse
+                            UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
-                                    .get()
-                                    .getOriginalBody(), headersMap, null);
+                                    .orElseGet(null);
+                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                                    (parsingException == null) ? null : parsingException.getOriginalBody(), headersMap,
+                                    null);
                         }
                         if (httpResponse.getStatus() == 400)
                             throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -394,7 +394,7 @@ class EntriesApiTest extends BaseTest {
         Optional<Entry> optionalEntry = entryList
                 .getValue()
                 .stream()
-                .filter(entry -> entry.getEntryType() == EntryType.DOCUMENT)
+                .filter(entry -> entry.getEntryType() == EntryType.DOCUMENT && entry.getId() < 5000)
                 .findFirst();
         Entry entry = optionalEntry.get();
         assertNotNull(entry);
@@ -405,5 +405,6 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(headers.get("Content-Type"));
         assertNotNull(headers.get("Content-Length"));
     }
+
 
 }

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -1,0 +1,88 @@
+package integration;
+
+import com.laserfiche.repository.api.clients.EntriesClient;
+import com.laserfiche.repository.api.clients.impl.ApiException;
+import com.laserfiche.repository.api.clients.impl.model.CreateEntryOperations;
+import com.laserfiche.repository.api.clients.impl.model.CreateEntryResult;
+import com.laserfiche.repository.api.clients.impl.model.DeleteEntryWithAuditReason;
+import com.laserfiche.repository.api.clients.impl.model.PostEntryWithEdocMetadataRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ExportDocumentApiTest extends BaseTest {
+    private EntriesClient client;
+    private int createdEntryId;
+
+    @BeforeEach
+    public void perTestSetup() {
+        client = repositoryApiClient.getEntriesClient();
+        createEmptyDocument();
+    }
+
+    @AfterEach
+    public void deleteEntries() {
+        if (createdEntryId != 0) {
+            DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
+            client
+                    .deleteEntryInfo(repoId, createdEntryId, body)
+                    .join();
+        }
+    }
+
+
+    @Test
+    void exportDocument_Returns_Exported_File() {
+        File exportedFile = new File("exportDocument_temp_file.txt");
+        File file = client
+                .exportDocument(repoId, createdEntryId, null, exportedFile)
+                .join();
+        assertNotNull(file);
+        assertNotNull(exportedFile);
+        assertTrue(file.exists());
+        assertTrue(exportedFile.exists());
+        assertEquals(file.getAbsolutePath(), exportedFile.getAbsolutePath());
+        assertEquals(file.length(), exportedFile.length());
+        boolean exportedFileIsDeletedSuccessfully = file.delete();
+        assertTrue(exportedFileIsDeletedSuccessfully);
+    }
+
+    @Test
+    void exportDocument_Returns_Error_For_Invalid_EntryId() {
+        File exportedFile = new File("exportDocument_temp_file.txt");
+        Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
+            client
+                    .exportDocument(repoId, -createdEntryId, null, exportedFile);
+        });
+        Assertions.assertEquals("Invalid or bad request.", thrown.getMessage());
+
+        assertNotNull(exportedFile);
+        assertFalse(exportedFile.exists());
+    }
+
+    private void createEmptyDocument() {
+        try {
+            String fileName = "JavaClientLibrary_ExportDocumentApiTest";
+            File toUpload = File.createTempFile(fileName, "txt");
+            CreateEntryResult result = client
+                    .importDocument(repoId, 1, fileName, true, null,
+                            new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest())
+                    .join();
+
+            CreateEntryOperations operations = result.getOperations();
+            createdEntryId = operations
+                    .getEntryCreate()
+                    .getEntryId();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+}


### PR DESCRIPTION
The pr includes changes for fixing the exportDocument apis always returning null.
The main changes are:

- a new parameter is added to the interface of exportDocument api, to specify the File object where the export result should be stored. 
- If asObjectAsync(Objec.class) is used in the response handler, like other apis, the problem is that the response.body is always null, whether the request is successful or failed. The other option was to use asFileAsync, but the problem with this option was that in the failure path, the error details sent from server, were stored in the File that is supposed to store the export result. In other words, if export fails, the error would have been stored in the target file. Finally, the option that works is thenConsume. This method is a void method, so the part of UnirestGenerator that generates code for response handling, needs a lot of modification for exportDocument api. To keep the code clean, separate methods are created in UnirestGenerator for generating code for exportDocument api.
