### PR TITLE
Use new method for deserializing json to ProblemDetails. Add new inte…

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.laserfiche.repository.api.clients.impl.deserialization.OffsetDateTimeDeserializer;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.Header;
 import kong.unirest.Headers;
 import kong.unirest.UnirestInstance;
@@ -78,5 +79,30 @@ public class ApiClient {
                 .all()
                 .stream()
                 .collect(Collectors.toMap(Header::getName, Header::getValue));
+    }
+
+    protected ProblemDetails deserializeToProblemDetails(String jsonString) throws JsonProcessingException {
+        ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+        if (problemDetails.get("title") != null)
+            problemDetails.setTitle(problemDetails
+                    .get("title")
+                    .toString());
+        if (problemDetails.get("type") != null)
+            problemDetails.setType(problemDetails
+                    .get("type")
+                    .toString());
+        if (problemDetails.get("instance") != null)
+            problemDetails.setInstance(problemDetails
+                    .get("instance")
+                    .toString());
+        if (problemDetails.get("detail") != null)
+            problemDetails.setDetail(problemDetails
+                    .get("detail")
+                    .toString());
+        problemDetails.setStatus(Integer.parseInt(problemDetails
+                .get("status")
+                .toString()));
+        problemDetails.setExtensions((Map<String, Object>) problemDetails.get("extensions"));
+        return problemDetails;
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -47,7 +47,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -118,7 +118,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -40,7 +40,7 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -66,7 +66,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -151,7 +151,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -214,7 +214,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -292,7 +292,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -375,7 +375,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -437,7 +437,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -494,7 +494,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -554,7 +554,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -612,7 +612,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -672,7 +672,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -728,7 +728,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -788,7 +788,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -851,7 +851,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -907,7 +907,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
                             try {
                                 String jsonString = rawResponse.getContentAsString();
-                                problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                                problemDetails = deserializeToProblemDetails(jsonString);
                             } catch (JsonProcessingException | IllegalStateException e) {
                                 exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
                                         rawResponse.getContentAsString(), headersMap, null);
@@ -968,7 +968,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
                             try {
                                 String jsonString = rawResponse.getContentAsString();
-                                problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                                problemDetails = deserializeToProblemDetails(jsonString);
                             } catch (JsonProcessingException | IllegalStateException e) {
                                 exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
                                         rawResponse.getContentAsString(), headersMap, null);
@@ -1029,7 +1029,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1083,7 +1083,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1142,7 +1142,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1219,7 +1219,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1306,7 +1306,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1380,7 +1380,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -1463,7 +1463,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -48,7 +48,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -118,7 +118,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -47,7 +47,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -118,7 +118,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -40,7 +40,7 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -42,7 +42,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -96,7 +96,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -170,7 +170,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -252,7 +252,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -326,7 +326,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -41,7 +41,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -94,7 +94,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -138,7 +138,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -49,7 +49,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -60,7 +60,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -144,7 +144,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -41,7 +41,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -88,7 +88,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -63,7 +63,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -163,7 +163,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -264,7 +264,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()
@@ -348,7 +348,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
+                            problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             UnirestParsingException parsingException = httpResponse
                                     .getParsingError()

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -2,7 +2,9 @@ package integration;
 
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.EntriesClient;
+import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -406,5 +409,23 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(headers.get("Content-Length"));
     }
 
+    @Test
+    void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() throws InterruptedException {
+        Exception thrown = Assertions.assertThrows(CompletionException.class, () -> {
+            client
+                    .getEntryListing(repoId, -1, false, null, false, "maxpagesize=100", null, null, null, null, null,
+                            false)
+                    .join();
+        });
+        assertNotNull(thrown);
+        assertTrue(thrown.getCause() instanceof ApiException);
+        ApiException apiException = (ApiException) thrown.getCause();
+        ProblemDetails problemDetails = apiException.getProblemDetails();
+        assertNotNull(problemDetails);
+        assertNotNull(problemDetails.getTitle());
+        assertNotNull(problemDetails.getType());
+        assertNotNull(problemDetails.getInstance());
+        assertNotNull(problemDetails.getStatus());
+    }
 
 }

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -75,7 +75,7 @@ public class ExportDocumentApiTest extends BaseTest {
         };
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client
-                    .exportDocument(repoId, -createdEntryId, null, null);
+                    .exportDocument(repoId, -createdEntryId, null, consumer);
         });
         Assertions.assertEquals("Invalid or bad request.", thrown.getMessage());
         File exportedFile = new File(FILE_NAME);


### PR DESCRIPTION
The model class generated for ProblemDetails is extending HashMap<String, Object>
As a result when the jsonString is deserialized to ProblemDetails, it is actually deserialized to a hashMap, which causes the bug that the ProblemDetails's getter methods, like getTitle return null, while the get method (from Map interface), e.g. get("title"), returns the correct value.

If the extends expression is removed from the ProblemDetails model class, then the bug is fixed. However, to keep this model class the same as the one in the client-core-library, it is not a good idea to modify this model class in Java client library.

To fix the bug, a new method is generated in ApiClient, that takes the jsonString and deserializes it into a ProblemDetails object. This method is responsible for calling get() method and then calling the setter methods.

A new integration test is added to make sure that the ProblemDetails fields (main fields) are not null.