### PR TITLE
add selfhosted implementation

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -62,9 +62,9 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return createFromAccessKey(servicePrincipalKey, accessKey, null);
     }
 
-    public static RepositoryApiClient createFromUsernamePassword(String repoId, String username, String password,
+    public static RepositoryApiClient createFromUsernamePassword(String repositoryId, String username, String password,
             String baseUrl) {
-        Interceptor interceptor = new SelfHostedInterceptor(repoId, username, password, baseUrl, null);
+        Interceptor interceptor = new SelfHostedInterceptor(repositoryId, username, password, baseUrl, null);
         return new RepositoryApiClientImpl(interceptor, baseUrl);
     }
 

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseable {
     private Map<String, String> defaultHeaders;
-    private static UnirestInstance httpClient;
+    private static UnirestInstance httpClient = Unirest.spawnInstance();
     private final AttributesClient attributesClient;
     private final AuditReasonsClient auditReasonsClient;
     private final EntriesClient entriesClient;
@@ -44,7 +44,6 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
     public static RepositoryApiClient CreateFromHttpRequestHandler(String servicePrincipalKey, AccessKey accessKey,
             String baseUrl) {
         String baseUrlDebug = baseUrl != null ? baseUrl : "https://api." + accessKey.getDomain() + "/repository";
-        httpClient = Unirest.spawnInstance();
         httpClient
                 .config()
                 .setObjectMapper(new RepositoryClientObjectMapper())
@@ -55,7 +54,6 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
     public static RepositoryApiClient CreateFromHttpRequestHandler(String repositoryId, String username,
             String password,
             TokenClient client, String baseUrl) {
-        httpClient = Unirest.spawnInstance();
         httpClient
                 .config()
                 .setObjectMapper(new RepositoryClientObjectMapper())

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -28,13 +28,14 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     protected RepositoryApiClientImpl(String servicePrincipalKey, AccessKey accessKey, String repositoryId,
             String username,
-            String password, TokenClient client, String baseUrl) {
+            String password, TokenClient client, String baseUrlDebug) {
         httpClient = Unirest.spawnInstance();
+        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.getDomain() + "/repository";
         if (servicePrincipalKey == null && accessKey == null) {
             httpClient
                     .config()
                     .setObjectMapper(new RepositoryClientObjectMapper())
-                    .interceptor(new SelfHostedInterceptor(repositoryId, username, password, baseUrl, client));
+                    .interceptor(new SelfHostedInterceptor(repositoryId, username, password, baseUrlDebug, client));
         } else {
             httpClient
                     .config()

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -41,7 +41,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         templateDefinitionsClient = new TemplateDefinitionsClientImpl(baseUrl, httpClient);
     }
 
-    public static RepositoryApiClient CreateFromHttpRequestHandler(String servicePrincipalKey, AccessKey accessKey,
+    public static RepositoryApiClient createFromHttpRequestHandler(String servicePrincipalKey, AccessKey accessKey,
             String baseUrl) {
         String baseUrlDebug = baseUrl != null ? baseUrl : "https://api." + accessKey.getDomain() + "/repository";
         httpClient
@@ -51,7 +51,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return new RepositoryApiClientImpl(httpClient, baseUrlDebug);
     }
 
-    public static RepositoryApiClient CreateFromHttpRequestHandler(String repositoryId, String username,
+    public static RepositoryApiClient createFromHttpRequestHandler(String repositoryId, String username,
             String password,
             TokenClient client, String baseUrl) {
         httpClient
@@ -61,14 +61,14 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return new RepositoryApiClientImpl(httpClient, baseUrl);
     }
 
-    public static RepositoryApiClient CreateFromAccessKey(String servicePrincipalKey, AccessKey accessKey) {
-        return CreateFromHttpRequestHandler(servicePrincipalKey, accessKey, null);
+    public static RepositoryApiClient createFromAccessKey(String servicePrincipalKey, AccessKey accessKey) {
+        return createFromHttpRequestHandler(servicePrincipalKey, accessKey, null);
     }
 
-    public static RepositoryApiClient CreateFromUsernamePassword(String repoId, String username, String password,
+    public static RepositoryApiClient createFromUsernamePassword(String repoId, String username, String password,
             String baseUrl) {
         String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.lastIndexOf("/")) : baseUrl;
-        return CreateFromHttpRequestHandler(repoId, username, password, null, baseUrlWithSlash);
+        return createFromHttpRequestHandler(repoId, username, password, null, baseUrlWithSlash);
     }
 
     @Override

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -5,7 +5,6 @@ import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.repository.api.clients.*;
 import com.laserfiche.repository.api.clients.impl.*;
 import com.laserfiche.repository.api.clients.impl.deserialization.RepositoryClientObjectMapper;
-import kong.unirest.Unirest;
 import kong.unirest.UnirestInstance;
 
 import java.util.Map;
@@ -67,7 +66,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     public static RepositoryApiClient createFromUsernamePassword(String repoId, String username, String password,
             String baseUrl) {
-        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length()) : baseUrl;
+        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
         return createFromHttpRequestHandler(repoId, username, password, null, baseUrlWithSlash);
     }
 

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -33,7 +33,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         if (baseUrl == null) {
             baseUrl = "https://api." + accessKey.getDomain() + "/repository";
         } else if (baseUrl.endsWith("/")) {
-            baseUrl.substring(0, baseUrl.length() - 1);
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
         if (servicePrincipalKey == null && accessKey == null) {
             httpClient

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -1,8 +1,6 @@
 package com.laserfiche.repository.api;
 
 import com.laserfiche.api.client.apiserver.TokenClient;
-import com.laserfiche.api.client.httphandlers.HttpRequestHandler;
-import com.laserfiche.api.client.httphandlers.UsernamePasswordHandler;
 import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.repository.api.clients.*;
 import com.laserfiche.repository.api.clients.impl.*;
@@ -43,7 +41,8 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         templateDefinitionsClient = new TemplateDefinitionsClientImpl(baseUrl, httpClient);
     }
 
-    public static RepositoryApiClient CreateFromHttpRequestHandler(String servicePrincipalKey, AccessKey accessKey, String baseUrl){
+    public static RepositoryApiClient CreateFromHttpRequestHandler(String servicePrincipalKey, AccessKey accessKey,
+            String baseUrl) {
         String baseUrlDebug = baseUrl != null ? baseUrl : "https://api." + accessKey.getDomain() + "/repository";
         httpClient = Unirest.spawnInstance();
         httpClient
@@ -53,13 +52,14 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return new RepositoryApiClientImpl(httpClient, baseUrlDebug);
     }
 
-    public static RepositoryApiClient CreateFromHttpRequestHandler(String repositoryId, String username, String password,
-            TokenClient client, String baseUrl){
-            httpClient = Unirest.spawnInstance();
-            httpClient
-                    .config()
-                    .setObjectMapper(new RepositoryClientObjectMapper())
-                    .interceptor(new SelfHostedInterceptor(repositoryId,username,password,baseUrl,client));
+    public static RepositoryApiClient CreateFromHttpRequestHandler(String repositoryId, String username,
+            String password,
+            TokenClient client, String baseUrl) {
+        httpClient = Unirest.spawnInstance();
+        httpClient
+                .config()
+                .setObjectMapper(new RepositoryClientObjectMapper())
+                .interceptor(new SelfHostedInterceptor(repositoryId, username, password, baseUrl, client));
         return new RepositoryApiClientImpl(httpClient, baseUrl);
     }
 
@@ -67,8 +67,9 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return CreateFromHttpRequestHandler(servicePrincipalKey, accessKey, null);
     }
 
-    public static RepositoryApiClient CreateFromUsernamePassword(String repoId, String username, String password, String baseUrl){
-        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.lastIndexOf("/")) : baseUrl;;
+    public static RepositoryApiClient CreateFromUsernamePassword(String repoId, String username, String password,
+            String baseUrl) {
+        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.lastIndexOf("/")) : baseUrl;
         return CreateFromHttpRequestHandler(repoId, username, password, null, baseUrlWithSlash);
     }
 

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseable {
     private Map<String, String> defaultHeaders;
-    private static UnirestInstance httpClient = Unirest.spawnInstance();
+    private static UnirestInstance httpClient;
     private final AttributesClient attributesClient;
     private final AuditReasonsClient auditReasonsClient;
     private final EntriesClient entriesClient;
@@ -67,7 +67,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     public static RepositoryApiClient createFromUsernamePassword(String repoId, String username, String password,
             String baseUrl) {
-        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.lastIndexOf("/")) : baseUrl;
+        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length()) : baseUrl;
         return createFromHttpRequestHandler(repoId, username, password, null, baseUrlWithSlash);
     }
 

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -71,8 +71,7 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     public static RepositoryApiClient createFromUsernamePassword(String repoId, String username, String password,
             String baseUrl) {
-        String baseUrlWithSlash = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
-        return new RepositoryApiClientImpl(null, null, repoId, username, password, null, baseUrlWithSlash);
+        return new RepositoryApiClientImpl(null, null, repoId, username, password, null, baseUrl);
     }
 
     @Override

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -28,14 +28,18 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     protected RepositoryApiClientImpl(String servicePrincipalKey, AccessKey accessKey, String repositoryId,
             String username,
-            String password, TokenClient client, String baseUrlDebug) {
+            String password, TokenClient client, String baseUrl) {
         httpClient = Unirest.spawnInstance();
-        String baseUrl = baseUrlDebug != null ? baseUrlDebug : "https://api." + accessKey.getDomain() + "/repository";
+        if (baseUrl == null) {
+            baseUrl = "https://api." + accessKey.getDomain() + "/repository";
+        } else if (baseUrl.endsWith("/")) {
+            baseUrl.substring(0, baseUrl.length() - 1);
+        }
         if (servicePrincipalKey == null && accessKey == null) {
             httpClient
                     .config()
                     .setObjectMapper(new RepositoryClientObjectMapper())
-                    .interceptor(new SelfHostedInterceptor(repositoryId, username, password, baseUrlDebug, client));
+                    .interceptor(new SelfHostedInterceptor(repositoryId, username, password, baseUrl, client));
         } else {
             httpClient
                     .config()

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -12,7 +12,7 @@ import java.util.Map;
 
 public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseable {
     private Map<String, String> defaultHeaders;
-    private static UnirestInstance httpClient;
+    private UnirestInstance httpClient;
     private final AttributesClient attributesClient;
     private final AuditReasonsClient auditReasonsClient;
     private final EntriesClient entriesClient;

--- a/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
@@ -1,0 +1,29 @@
+package com.laserfiche.repository.api;
+
+import com.laserfiche.api.client.apiserver.TokenClient;
+import com.laserfiche.api.client.httphandlers.*;
+import com.laserfiche.api.client.model.AccessKey;
+import kong.unirest.Config;
+import kong.unirest.HttpRequest;
+import kong.unirest.Interceptor;
+
+import java.util.concurrent.CompletableFuture;
+
+public class SelfHostedInterceptor implements Interceptor {
+    private final UsernamePasswordHandler usernamePasswordHandler;
+
+    public SelfHostedInterceptor(String repositoryId, String username, String password, String baseUrl,
+            TokenClient client) {
+        usernamePasswordHandler = new UsernamePasswordHandler(repositoryId, username, password, baseUrl, client);
+    }
+
+    @Override
+    public void onRequest(HttpRequest<?> request, Config config) {
+        Request customRequest = new RequestImpl();
+        CompletableFuture<BeforeSendResult> future = usernamePasswordHandler.beforeSendAsync(customRequest);
+        future.join(); // We are blocked by the HTTP handler
+        request.header("Authorization", customRequest
+                .headers()
+                .get("Authorization"));
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
@@ -1,8 +1,10 @@
 package com.laserfiche.repository.api;
 
 import com.laserfiche.api.client.apiserver.TokenClient;
-import com.laserfiche.api.client.httphandlers.*;
-import com.laserfiche.api.client.model.AccessKey;
+import com.laserfiche.api.client.httphandlers.BeforeSendResult;
+import com.laserfiche.api.client.httphandlers.Request;
+import com.laserfiche.api.client.httphandlers.RequestImpl;
+import com.laserfiche.api.client.httphandlers.UsernamePasswordHandler;
 import kong.unirest.Config;
 import kong.unirest.HttpRequest;
 import kong.unirest.Interceptor;

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -14,7 +14,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-//use enumerators
+
+enum authorizationTypes {
+    CLOUDACCESSKEY,
+    APISERVERUSERNAMEPASSWORD
+}
+
 public class BaseTest {
     protected static String spKey;
     protected static AccessKey accessKey;
@@ -45,15 +50,14 @@ public class BaseTest {
                     .load();
             authorizationType = dotenv.get("AUTHORIZATION_TYPE");
             testHeaderValue = dotenv.get("TEST_HEADER");
-            if (authorizationType.equalsIgnoreCase("CloudAccessKey")) {
-                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64) && nullOrEmpty(repoId) && nullOrEmpty(
-                        testHeaderValue)) {
+            if (authorizationType.equalsIgnoreCase(authorizationTypes.CLOUDACCESSKEY.name())) {
+                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64) && nullOrEmpty(repoId)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
                     repoId = dotenv.get("REPOSITORY_ID");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
-            } else if (authorizationType.equalsIgnoreCase("APIServerUsernamePassword")) {
+            } else if (authorizationType.equalsIgnoreCase(authorizationTypes.APISERVERUSERNAMEPASSWORD.name())) {
                 if (nullOrEmpty(repoId) && nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
                     repoId = dotenv.get("REPOSITORY_ID");
                     username = dotenv.get("APISERVER_USERNAME");

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-
+//use enumerators
 public class BaseTest {
     protected static String spKey;
     protected static AccessKey accessKey;
@@ -74,11 +74,11 @@ public class BaseTest {
             if (authorizationType.equalsIgnoreCase("CloudAccessKey")) {
                 if (nullOrEmpty(spKey) || accessKey == null)
                     return null;
-                repositoryApiClient = RepositoryApiClientImpl.CreateFromAccessKey(spKey, accessKey);
+                repositoryApiClient = RepositoryApiClientImpl.createFromAccessKey(spKey, accessKey);
             } else if (authorizationType.equalsIgnoreCase("APIServerUsernamePassword")) {
                 if (nullOrEmpty(repoId) || nullOrEmpty(username) || nullOrEmpty(password) || nullOrEmpty(baseUrl))
                     return null;
-                repositoryApiClient = RepositoryApiClientImpl.CreateFromUsernamePassword(repoId, username, password,
+                repositoryApiClient = RepositoryApiClientImpl.createFromUsernamePassword(repoId, username, password,
                         baseUrl);
             }
             repositoryApiClient.setDefaultRequestHeaders(testHeaders);

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -22,6 +22,11 @@ public class BaseTest {
     protected static Map<String, String> testHeaders;
     protected static RepositoryApiClient repositoryApiClient;
 
+    private enum AuthorizationType{
+        CloudAccessKey,
+        APIServerUsernamePassword
+    }
+
     @BeforeAll
     public static void setUp() {
         spKey = System.getenv("SERVICE_PRINCIPAL_KEY");

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-enum authorizationType {
+enum AuthorizationType {
     CLOUDACCESSKEY,
     APISERVERUSERNAMEPASSWORD
 }
@@ -54,13 +54,13 @@ public class BaseTest {
             if (nullOrEmpty(repoId)) {
                 throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
             }
-            if (authorizationType.equalsIgnoreCase(integration.authorizationType.CLOUDACCESSKEY.name())) {
+            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUDACCESSKEY.name())) {
                 if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
-            } else if (authorizationType.equalsIgnoreCase(integration.authorizationType.APISERVERUSERNAMEPASSWORD.name())) {
+            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.APISERVERUSERNAMEPASSWORD.name())) {
                 if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
                     username = dotenv.get("APISERVER_USERNAME");
                     password = dotenv.get("APISERVER_PASSWORD");

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
-enum authorizationTypes {
+enum authorizationType {
     CLOUDACCESSKEY,
     APISERVERUSERNAMEPASSWORD
 }
@@ -54,13 +54,13 @@ public class BaseTest {
             if (nullOrEmpty(repoId)) {
                 throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
             }
-            if (authorizationType.equalsIgnoreCase(authorizationTypes.CLOUDACCESSKEY.name())) {
+            if (authorizationType.equalsIgnoreCase(integration.authorizationType.CLOUDACCESSKEY.name())) {
                 if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
-            } else if (authorizationType.equalsIgnoreCase(authorizationTypes.APISERVERUSERNAMEPASSWORD.name())) {
+            } else if (authorizationType.equalsIgnoreCase(integration.authorizationType.APISERVERUSERNAMEPASSWORD.name())) {
                 if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
                     username = dotenv.get("APISERVER_USERNAME");
                     password = dotenv.get("APISERVER_PASSWORD");

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -16,8 +16,8 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 enum AuthorizationType {
-    CLOUDACCESSKEY,
-    APISERVERUSERNAMEPASSWORD
+    CLOUD_ACCESS_KEY,
+    API_SERVER_USERNAME_PASSWORD
 }
 
 public class BaseTest {
@@ -54,13 +54,13 @@ public class BaseTest {
             if (nullOrEmpty(repoId)) {
                 throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
             }
-            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUDACCESSKEY.name())) {
+            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
                 if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
-            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.APISERVERUSERNAMEPASSWORD.name())) {
+            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
                 if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
                     username = dotenv.get("APISERVER_USERNAME");
                     password = dotenv.get("APISERVER_PASSWORD");
@@ -77,11 +77,11 @@ public class BaseTest {
 
     public static RepositoryApiClient createClient() {
         if (repositoryApiClient == null) {
-            if (authorizationType.equalsIgnoreCase("CloudAccessKey")) {
+            if (authorizationType.equalsIgnoreCase("Cloud_Access_Key")) {
                 if (nullOrEmpty(spKey) || accessKey == null)
                     return null;
                 repositoryApiClient = RepositoryApiClientImpl.createFromAccessKey(spKey, accessKey);
-            } else if (authorizationType.equalsIgnoreCase("APIServerUsernamePassword")) {
+            } else if (authorizationType.equalsIgnoreCase("API_Server_Username_Password")) {
                 if (nullOrEmpty(repoId) || nullOrEmpty(username) || nullOrEmpty(password) || nullOrEmpty(baseUrl))
                     return null;
                 repositoryApiClient = RepositoryApiClientImpl.createFromUsernamePassword(repoId, username, password,

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -55,13 +55,13 @@ public class BaseTest {
                 throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
             }
             if (authorizationType.equalsIgnoreCase(authorizationTypes.CLOUDACCESSKEY.name())) {
-                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64) && nullOrEmpty(repoId)) {
+                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
             } else if (authorizationType.equalsIgnoreCase(authorizationTypes.APISERVERUSERNAMEPASSWORD.name())) {
-                if (nullOrEmpty(repoId) && nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
+                if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
                     username = dotenv.get("APISERVER_USERNAME");
                     password = dotenv.get("APISERVER_PASSWORD");
                     baseUrl = dotenv.get("APISERVER_REPOSITORY_API_BASE_URL");

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -50,22 +50,24 @@ public class BaseTest {
                     .load();
             authorizationType = dotenv.get("AUTHORIZATION_TYPE");
             testHeaderValue = dotenv.get("TEST_HEADER");
+            repoId = dotenv.get("REPOSITORY_ID");
+            if (nullOrEmpty(repoId)) {
+                throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
+            }
             if (authorizationType.equalsIgnoreCase(authorizationTypes.CLOUDACCESSKEY.name())) {
                 if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64) && nullOrEmpty(repoId)) {
                     accessKeyBase64 = dotenv.get("ACCESS_KEY");
                     spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
-                    repoId = dotenv.get("REPOSITORY_ID");
                     accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
                 }
             } else if (authorizationType.equalsIgnoreCase(authorizationTypes.APISERVERUSERNAMEPASSWORD.name())) {
                 if (nullOrEmpty(repoId) && nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
-                    repoId = dotenv.get("REPOSITORY_ID");
                     username = dotenv.get("APISERVER_USERNAME");
                     password = dotenv.get("APISERVER_PASSWORD");
                     baseUrl = dotenv.get("APISERVER_REPOSITORY_API_BASE_URL");
                 }
             } else {
-                throw new IllegalArgumentException("Invalid Authorization Type Value");
+                throw new IllegalStateException("Invalid Authorization Type Value");
             }
         }
         testHeaders = new HashMap<>();

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -77,11 +77,11 @@ public class BaseTest {
 
     public static RepositoryApiClient createClient() {
         if (repositoryApiClient == null) {
-            if (authorizationType.equalsIgnoreCase("Cloud_Access_Key")) {
+            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
                 if (nullOrEmpty(spKey) || accessKey == null)
                     return null;
                 repositoryApiClient = RepositoryApiClientImpl.createFromAccessKey(spKey, accessKey);
-            } else if (authorizationType.equalsIgnoreCase("API_Server_Username_Password")) {
+            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
                 if (nullOrEmpty(repoId) || nullOrEmpty(username) || nullOrEmpty(password) || nullOrEmpty(baseUrl))
                     return null;
                 repositoryApiClient = RepositoryApiClientImpl.createFromUsernamePassword(repoId, username, password,


### PR DESCRIPTION
add a function that initializes the repository client from user name and password
Add a self hosted interceptor object that implements the interceptor interface
Make sure repo client uses the APIException, and the OffsetDateTimeDeserializer class from the client core repo
configure baseTest to be able to run all the same integration tests on selfhosted
test locally 

Reference -> https://github.com/Laserfiche/lf-repository-api-client-dotnet/blob/1.x/src/RepositoryApiClient.cs








