### PR TITLE
Use a separate call to queryString for the query parameters that thei…

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -13,7 +13,9 @@ import kong.unirest.Headers;
 import kong.unirest.UnirestInstance;
 import org.threeten.bp.OffsetDateTime;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -57,8 +59,20 @@ public class ApiClient {
         Map<String, Object> paramKeyValuePairs = new HashMap<>();
         for (int i = 0; i < parameters.length; i++) {
             if (parameters[i] != null) {
-                paramKeyValuePairs.put(parameterNames[i],
-                        parameters[i] instanceof String ? parameters[i] : String.valueOf(parameters[i]));
+                List<Object> values = new ArrayList<>();
+                if (parameters[i] instanceof Object[]) {
+                    Object[] objects = (Object[]) parameters[i];
+                    for (Object object : objects) {
+                        values.add(object);
+                    }
+                } else {
+                    values.add(parameters[i]);
+                }
+                if (values.size() == 1) {
+                    paramKeyValuePairs.put(parameterNames[i], values.get(0));
+                } else {
+                    paramKeyValuePairs.put(parameterNames[i], values);
+                }
             }
         }
         return paramKeyValuePairs;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -9,6 +9,7 @@ import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -1199,6 +1200,8 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         return httpClient
                 .get(url)
+                .queryString("fields", (queryParameters.get("fields") != null) ? (List) queryParameters.remove(
+                        "fields") : new ArrayList())
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -7,6 +7,8 @@ import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -306,6 +308,8 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         return httpClient
                 .get(url)
+                .queryString("fields", (queryParameters.get("fields") != null) ? (List) queryParameters.remove(
+                        "fields") : new ArrayList())
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .headers(headerParametersWithStringTypeValue)

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -9,6 +9,8 @@ import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -28,6 +30,8 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
         Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
         return httpClient
                 .post(baseUrl + "/v1/Repositories/{repoId}/SimpleSearches")
+                .queryString("fields", (queryParameters.get("fields") != null) ? (List) queryParameters.remove(
+                        "fields") : new ArrayList())
                 .queryString(queryParameters)
                 .routeParam(pathParameters)
                 .contentType("application/json")

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -428,4 +428,25 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(problemDetails.getStatus());
     }
 
+    @Test
+    void getEntryListing_WithFields_ReturnEntries() {
+        String[] fieldNames = {"Sender", "Subject"};
+        ODataValueContextOfIListOfEntry entries = client
+                .getEntryListing(repoId, 1, false, fieldNames, false, "maxpagesize=5", null, null, null, null, null,
+                        false)
+                .join();
+        assertNotNull(entries);
+        for (Entry entry : entries.getValue()) {
+            int numberOfReturnedFields = (int) entry
+                    .getFields()
+                    .stream()
+                    .filter(entryFieldValue -> entryFieldValue
+                            .getFieldName()
+                            .equalsIgnoreCase(fieldNames[0]) || entryFieldValue
+                            .getFieldName()
+                            .equalsIgnoreCase(fieldNames[1]))
+                    .count();
+            assertEquals(fieldNames.length, numberOfReturnedFields);
+        }
+    }
 }


### PR DESCRIPTION
The generated code uses a single call to queryString method to set the query parameters in the url
There are two versions of this method in [kong.unirest.Path](https://github.com/Kong/unirest-java/blob/main/unirest/src/main/java/kong/unirest/Path.java):

1. one that takes an argument of type **Map<String, Object>**
2. one that takes two arguments (queryParameterName, and a collection of its values).

Now, the problem is that the code-generator generates a single call to queryString method, which is actually calling the first version of the method, and this method cannot handle query parameters that their value is an array. For such query parameters, it is needed to use the second version of the queryString method.

Our getEntryListing api has a query parameter named **fields**, which its value is a string array.

So, **the fix is to** update the code-generator to generate a separate call to queryString method, for each query parameter that its type is an array. For all the rest of the query parameters, a single call to the queryString is enough.

A new integration test is added to use getEntryListing api with fields, as all the previous tests use null for this parameter.