### PR TITLE
Escape illegal charaters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>1.0.1</version>
+  <version>1.0.2</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -159,7 +159,7 @@ public interface EntriesClient {
      *
      * @param repoId      The request repository ID.
      * @param entryId     The requested entry ID.
-     * @param requestBody A value of type List<PutLinksRequest>.
+     * @param requestBody A value of type List&lt;PutLinksRequest&gt;.
      * @return CompletableFuture&lt;ODataValueOfIListOfWEntryLinkInfo&gt; The return value
      */
     CompletableFuture<ODataValueOfIListOfWEntryLinkInfo> assignEntryLinks(String repoId, Integer entryId,


### PR DESCRIPTION
1. In comment, the characters that are significant in XML should be escaped. In this PR, we fixed it.
2. Also bumped version number.