### PR TITLE
Bug/399060 misleading error message

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -119,4 +119,11 @@ public class ApiClient {
         problemDetails.setExtensions((Map<String, Object>) problemDetails.get("extensions"));
         return problemDetails;
     }
+
+    protected String decideErrorMessage(ProblemDetails problemDetails, String genericErrorMessage) {
+        return (problemDetails != null && problemDetails.getTitle() != null && problemDetails
+                .getTitle()
+                .trim()
+                .length() > 0) ? problemDetails.getTitle() : genericErrorMessage;
+    }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -57,20 +57,23 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested attribute key not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Requested attribute key not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -127,20 +130,22 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -50,20 +50,22 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -73,20 +73,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -157,23 +159,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -219,26 +223,30 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Parent entry is not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 409)
-                            throw new ApiException("Document creation is partial success.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Document creation is partial success."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 500)
-                            throw new ApiException("Document creation is complete failure.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Document creation is complete failure."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -296,20 +304,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -378,23 +388,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -439,23 +451,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -495,23 +509,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -554,20 +570,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -611,20 +629,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested entry path not found", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -670,19 +690,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Operation limit or request limit reached.",
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
@@ -725,20 +748,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -784,26 +809,28 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 409)
-                            throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -846,19 +873,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Operation limit or request limit reached.",
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
@@ -898,25 +928,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                         rawResponse.getContentAsString(), headersMap, null);
                             }
                             if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException("Invalid or bad request.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException("Access token is invalid or expired.",
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
                                         rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
                                         problemDetails);
                             else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException("Access denied for the operation.",
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
                                         rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
                                         problemDetails);
                             else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException("Request entry id not found.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Request entry id not found."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException("Entry is locked.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException("Rate limit is reached.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else
                                 exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
@@ -959,25 +998,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                         rawResponse.getContentAsString(), headersMap, null);
                             }
                             if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException("Invalid or bad request.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException("Access token is invalid or expired.",
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
                                         rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
                                         problemDetails);
                             else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException("Access denied for the operation.",
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
                                         rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
                                         problemDetails);
                             else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException("Request entry id not found.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Request entry id not found."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException("Entry is locked.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException("Rate limit is reached.", rawResponse.getStatus(),
-                                        rawResponse.getStatusText(), headersMap, problemDetails);
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
                             else
                                 exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
@@ -1023,23 +1071,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1076,23 +1126,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1134,23 +1186,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1213,20 +1267,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1299,23 +1355,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 409)
-                            throw new ApiException("Entry name conflicts.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1372,20 +1430,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request entry id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -1454,23 +1514,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 423)
-                            throw new ApiException("Entry is locked.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -58,20 +58,23 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested field definition id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Requested field definition id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -127,20 +130,22 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -57,20 +57,23 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Requested link type definition ID not found",
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Requested link type definition ID not found"),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -127,20 +130,22 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -50,17 +50,19 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -7,11 +7,7 @@ import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -55,20 +51,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request search token not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -108,20 +107,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request search token not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -181,20 +183,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request search token not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -262,19 +267,22 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Operation limit or request limit reached.",
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
@@ -338,20 +346,23 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request search token not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request search token not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -51,20 +51,22 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -103,11 +105,13 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -146,20 +150,22 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -9,11 +9,7 @@ import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 
 public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearchesClient {
@@ -65,19 +61,22 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Operation limit or request limit reached.",
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -70,20 +70,22 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Not found.", httpResponse.getStatus(), httpResponse.getStatusText(),
-                                    headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -153,20 +155,23 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request tag definition id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request tag definition id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -51,20 +51,23 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request operationToken not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -97,20 +100,23 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request operationToken not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request operationToken not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -73,20 +73,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request template name not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request template name not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -172,20 +175,23 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request template name not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Request template name not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -272,20 +278,22 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request template id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
@@ -355,20 +363,22 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                                             .getOriginalBody() : null), headersMap, null);
                         }
                         if (httpResponse.getStatus() == 400)
-                            throw new ApiException("Invalid or bad request.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 401)
-                            throw new ApiException("Access token is invalid or expired.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 403)
-                            throw new ApiException("Access denied for the operation.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(
+                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
-                            throw new ApiException("Request template id not found.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
-                            throw new ApiException("Rate limit is reached.", httpResponse.getStatus(),
-                                    httpResponse.getStatusText(), headersMap, problemDetails);
+                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -486,4 +486,22 @@ class EntriesApiTest extends BaseTest {
         ProblemDetails problemDetails = apiException.getProblemDetails();
         assertNull(problemDetails);
     }
+
+    @Test
+    void writeTemplateValueToEntry_ReturnsCorrectErrorMessage_For_Invalid_TemplateName() {
+        PutTemplateRequest request = new PutTemplateRequest();
+        request.setTemplateName("fake_template");
+        Exception thrown = Assertions.assertThrows(CompletionException.class, () -> client
+                .writeTemplateValueToEntry(repoId, 3, request, null)
+                .join());
+        assertNotNull(thrown);
+        assertTrue(thrown.getCause() instanceof ApiException);
+        ApiException apiException = (ApiException) thrown.getCause();
+        assertEquals(404, apiException.getStatusCode());
+        assertTrue(apiException
+                .getMessage()
+                .startsWith("Template not found."), apiException.getMessage());
+        ProblemDetails problemDetails = apiException.getProblemDetails();
+        assertNotNull(problemDetails);
+    }
 }

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -77,7 +77,7 @@ public class ExportDocumentApiTest extends BaseTest {
             client
                     .exportDocument(repoId, -createdEntryId, null, consumer);
         });
-        Assertions.assertEquals("Invalid or bad request.", thrown.getMessage());
+        Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')", thrown.getMessage());
         File exportedFile = new File(FILE_NAME);
         assertNotNull(exportedFile);
         assertFalse(exportedFile.exists());

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -49,7 +49,7 @@ public class TasksApiTest extends BaseTest {
                     .join();
         });
 
-        Assertions.assertEquals(String.format("%s: Invalid or bad request.", ApiException.class.getCanonicalName()),
+        Assertions.assertEquals(String.format("%s: Error: Cannot cancel ended operation.", ApiException.class.getCanonicalName()),
                 thrown.getMessage());
     }
 


### PR DESCRIPTION
When throwing an ApiException in the error handling path, instead of using the **generic error message** (the one used to document the api in the swagger.json), we need to use the specific message from the ProblemDetails object returned from APIServer.

2 new integration tests are added for this fix.
