### PR TITLE
Add annotation for boolean getter since its name isn't regular

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+### Fixes
+
+- Serialization on models where there's at least one boolean getter no longer fails.
+
 ## 1.1.0
 
 ### Features

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ContextHit.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ContextHit.java
@@ -75,6 +75,7 @@ public class ContextHit {
     }
 
     @Schema(description = "A boolean indicating if this context hit occurs on an annotation.")
+    @JsonProperty("isAnnotationHit")
     public Boolean isAnnotationHit() {
         return isAnnotationHit;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
@@ -71,6 +71,7 @@ public class Document extends Entry {
     }
 
     @Schema(description = "A boolean indicating if there is an electronic document attached to the represented document.")
+    @JsonProperty("isElectronicDocument")
     public Boolean isElectronicDocument() {
         return isElectronicDocument;
     }
@@ -85,6 +86,7 @@ public class Document extends Entry {
     }
 
     @Schema(description = "A boolean indicating if the represented document is a record.")
+    @JsonProperty("isRecord")
     public Boolean isRecord() {
         return isRecord;
     }
@@ -127,6 +129,7 @@ public class Document extends Entry {
     }
 
     @Schema(description = "A boolean indicating if the represented document is checked out.")
+    @JsonProperty("isCheckedOut")
     public Boolean isCheckedOut() {
         return isCheckedOut;
     }
@@ -141,6 +144,7 @@ public class Document extends Entry {
     }
 
     @Schema(description = "A boolean indicating if the represented document is under version control.")
+    @JsonProperty("isUnderVersionControl")
     public Boolean isUnderVersionControl() {
         return isUnderVersionControl;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -200,6 +200,7 @@ public class Entry {
     }
 
     @Schema(description = "A boolean indicating if this entry is a container object; it can have other entries as children.")
+    @JsonProperty("isContainer")
     public Boolean isContainer() {
         return isContainer;
     }
@@ -214,6 +215,7 @@ public class Entry {
     }
 
     @Schema(description = "A boolean indicating if this entry is a leaf object; it cannot have other entries as children.")
+    @JsonProperty("isLeaf")
     public Boolean isLeaf() {
         return isLeaf;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryFieldValue.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryFieldValue.java
@@ -104,6 +104,7 @@ public class EntryFieldValue {
     }
 
     @Schema(description = "A boolean indicating if the represented field supports multiple values.")
+    @JsonProperty("isMultiValue")
     public Boolean isMultiValue() {
         return isMultiValue;
     }
@@ -118,6 +119,7 @@ public class EntryFieldValue {
     }
 
     @Schema(description = "A boolean indicating if the represented field must have a value set on entries assigned to a template that the field is a member of.")
+    @JsonProperty("isRequired")
     public Boolean isRequired() {
         return isRequired;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
@@ -27,6 +27,7 @@ public class Folder extends Entry {
     }
 
     @Schema(description = "A boolean indicating if the folder that this instance represents is known to be a record folder.")
+    @JsonProperty("isRecordFolder")
     public Boolean isRecordFolder() {
         return isRecordFolder;
     }
@@ -41,6 +42,7 @@ public class Folder extends Entry {
     }
 
     @Schema(description = "A boolean indicating if the folder that this instance represents is known to directly or indirectly under a record series in the repository.")
+    @JsonProperty("isUnderRecordSeries")
     public Boolean isUnderRecordSeries() {
         return isUnderRecordSeries;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
@@ -53,6 +53,7 @@ public class LinkToUpdate {
     }
 
     @Schema(description = "Whether the entry is the source for the link.")
+    @JsonProperty("isSource")
     public Boolean isSource() {
         return isSource;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldInfo.java
@@ -161,6 +161,7 @@ public class WFieldInfo {
     }
 
     @Schema(description = "A boolean indicating if the represented template field supports multiple values.")
+    @JsonProperty("isMultiValue")
     public Boolean isMultiValue() {
         return isMultiValue;
     }
@@ -175,6 +176,7 @@ public class WFieldInfo {
     }
 
     @Schema(description = "A boolean indicating if the represented field must have a value set on entries assigned to a template that the field is a member of.")
+    @JsonProperty("isRequired")
     public Boolean isRequired() {
         return isRequired;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTagInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTagInfo.java
@@ -90,6 +90,7 @@ public class WTagInfo {
     }
 
     @Schema(description = "A boolean indicating whether or not the tag definition is classified as a security tag (true) or an informational tag (false).")
+    @JsonProperty("isSecure")
     public Boolean isSecure() {
         return isSecure;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Watermark.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Watermark.java
@@ -90,6 +90,7 @@ public class Watermark {
     }
 
     @Schema(description = "A boolean indicating whether or not the watermark associated with the tag is mandatory.")
+    @JsonProperty("isWatermarkMandatory")
     public Boolean isWatermarkMandatory() {
         return isWatermarkMandatory;
     }


### PR DESCRIPTION
The `isXxx` for variable isXxx if the type of isXxx is Boolean or boolean is the convention but Jackson isn't smart enough to know that (it still thinks the getter name of isXxx is getIsXxx). This causes serialization failure. In this PR, we added an annotation explicitly telling Jackson for which private field the getter is returning value.