### PR TITLE
Fix bug by handling 409 status in ImportDocument in the success path instead of error path.

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,6 +1,6 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 
 import java.util.concurrent.CompletableFuture;
@@ -25,9 +25,9 @@ public interface SimpleSearchesClient {
      * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
      *                     The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
      *                     culture will not be used for formatting.
-     * @return CompletableFuture&lt;ODataValueOfIListOfEntry&gt; The return value
+     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
      */
-    CompletableFuture<ODataValueOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
+    CompletableFuture<ODataValueContextOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
             Boolean count, String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody,
             String culture);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,6 +1,6 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 
 import java.util.concurrent.CompletableFuture;
@@ -25,9 +25,9 @@ public interface SimpleSearchesClient {
      * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
      *                     The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
      *                     culture will not be used for formatting.
-     * @return CompletableFuture&lt;ODataValueContextOfIListOfEntry&gt; The return value
+     * @return CompletableFuture&lt;ODataValueOfIListOfEntry&gt; The return value
      */
-    CompletableFuture<ODataValueContextOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
+    CompletableFuture<ODataValueOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
             Boolean count, String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody,
             String culture);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -34,10 +34,9 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Attribute.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -47,7 +46,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -107,10 +106,9 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -120,7 +118,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -33,21 +33,21 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Attribute.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -106,21 +106,21 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -26,21 +26,21 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AuditReasons.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -27,10 +27,9 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AuditReasons.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -40,7 +39,7 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -50,10 +50,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -63,7 +62,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -136,10 +135,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -149,7 +147,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -200,10 +198,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, CreateEntryResult.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -213,7 +210,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -277,10 +274,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -290,7 +286,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -361,10 +357,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -374,7 +369,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -424,10 +419,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -437,7 +431,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -482,10 +476,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -495,7 +488,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -543,10 +536,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync((new HashMap<String, String[]>()).getClass())
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -556,7 +548,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -602,10 +594,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, FindEntryResult.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -615,7 +606,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -663,10 +654,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -676,7 +666,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -721,10 +711,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -734,7 +723,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -782,10 +771,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -795,7 +783,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -846,10 +834,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -859,7 +846,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1044,10 +1031,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1057,7 +1043,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1102,7 +1088,6 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(new HashMap<String, String>().getClass())
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         return httpResponse
                                 .getHeaders()
@@ -1113,7 +1098,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1160,10 +1145,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1173,7 +1157,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1241,10 +1225,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1254,7 +1237,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1329,10 +1312,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1342,7 +1324,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1404,10 +1386,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1417,7 +1398,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1488,10 +1469,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -1501,7 +1481,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -49,21 +49,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -135,21 +135,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -199,21 +199,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
-                    if (httpResponse.getStatus() == 201) {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
+                    if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, CreateEntryResult.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -235,10 +235,6 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 404)
                             throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 409)
-                            throw new ApiException(
-                                    decideErrorMessage(problemDetails, "Document creation is partial success."),
                                     httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
                         else if (httpResponse.getStatus() == 429)
                             throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
@@ -280,21 +276,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -364,21 +360,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -427,21 +423,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -485,21 +481,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -546,21 +542,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync((new HashMap<String, String[]>()).getClass())
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -605,21 +601,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, FindEntryResult.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -666,21 +662,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -724,21 +720,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -785,21 +781,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -849,21 +845,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1047,21 +1043,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1105,6 +1101,8 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(new HashMap<String, String>().getClass())
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         return httpResponse
                                 .getHeaders()
@@ -1112,11 +1110,10 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                 .stream()
                                 .collect(Collectors.toMap(Header::getName, Header::getValue));
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1162,21 +1159,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1243,21 +1240,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1331,21 +1328,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, Entry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1406,21 +1403,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -1490,21 +1487,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -34,21 +34,21 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -106,21 +106,21 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -35,10 +35,9 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -48,7 +47,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -107,10 +106,9 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -120,7 +118,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -33,21 +33,21 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -105,10 +105,11 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfEntryLinkTypeInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -116,11 +117,10 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -34,10 +34,9 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -47,7 +46,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -106,10 +105,9 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfEntryLinkTypeInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -120,7 +118,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -27,10 +27,9 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
+                            String jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
                             return objectMapper.readValue(jsonString, RepositoryInfo[].class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -40,7 +39,7 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -26,21 +26,21 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 .get(baseUrl + "/v1/Repositories")
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
+                            jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
                             return objectMapper.readValue(jsonString, RepositoryInfo[].class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -27,21 +27,21 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -83,21 +83,21 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -159,21 +159,21 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -243,21 +243,21 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -322,21 +322,21 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -28,10 +28,9 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -41,7 +40,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -84,10 +83,9 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -97,7 +95,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -160,10 +158,9 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -173,7 +170,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -244,10 +241,9 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 201) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, AcceptedOperation.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -257,7 +253,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -323,10 +319,9 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -336,7 +331,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -28,10 +28,9 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -41,7 +40,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -82,10 +81,9 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -95,7 +93,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -127,10 +125,9 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -140,7 +137,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -27,21 +27,21 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -81,21 +81,21 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -126,21 +126,21 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -2,7 +2,7 @@ package com.laserfiche.repository.api.clients.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.SimpleSearchesClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 import kong.unirest.UnirestInstance;
@@ -19,7 +19,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
     }
 
     @Override
-    public CompletableFuture<ODataValueContextOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
+    public CompletableFuture<ODataValueOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
             Boolean count, String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody,
             String culture) {
         Map<String, Object> queryParameters = getNonNullParameters(
@@ -37,21 +37,21 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 .body(requestBody)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
-                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
+                            jsonString = new JSONObject(body).toString();
+                            return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -38,10 +38,9 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -51,7 +50,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -2,7 +2,7 @@ package com.laserfiche.repository.api.clients.impl;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.SimpleSearchesClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
 import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 import kong.unirest.UnirestInstance;
@@ -19,7 +19,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
     }
 
     @Override
-    public CompletableFuture<ODataValueOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
+    public CompletableFuture<ODataValueContextOfIListOfEntry> createSimpleSearchOperation(String select, String orderby,
             Boolean count, String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody,
             String culture) {
         Map<String, Object> queryParameters = getNonNullParameters(
@@ -41,7 +41,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
                         try {
                             String jsonString = new JSONObject(body).toString();
-                            return objectMapper.readValue(jsonString, ODataValueOfIListOfEntry.class);
+                            return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -46,21 +46,21 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -131,21 +131,21 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -47,10 +47,9 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -60,7 +59,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -132,10 +131,9 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTagInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -145,7 +143,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -28,10 +28,9 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -41,7 +40,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -84,14 +83,13 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 204) {
                         return true;
                     } else {
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -27,21 +27,21 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, OperationProgress.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -83,14 +83,15 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 204) {
                         return true;
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -49,21 +49,21 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -150,10 +150,11 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -161,11 +162,10 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -253,10 +253,11 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -264,11 +265,10 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -339,21 +339,21 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .routeParam(pathParameters)
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
+                    Object body = httpResponse.getBody();
+                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            Object body = httpResponse.getBody();
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTemplateInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
                             return null;
                         }
                     } else {
-                        Object body = httpResponse.getBody();
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            String jsonString = new JSONObject(body).toString();
+                            jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -50,10 +50,9 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -63,7 +62,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -151,10 +150,9 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -165,7 +163,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -254,10 +252,9 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString,
                                     ODataValueContextOfIListOfTemplateFieldInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
@@ -268,7 +265,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
@@ -340,10 +337,9 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    String jsonString = null;
                     if (httpResponse.getStatus() == 200) {
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             return objectMapper.readValue(jsonString, WTemplateInfo.class);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             e.printStackTrace();
@@ -353,7 +349,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                         ProblemDetails problemDetails;
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         try {
-                            jsonString = new JSONObject(body).toString();
+                            String jsonString = new JSONObject(body).toString();
                             problemDetails = deserializeToProblemDetails(jsonString);
                         } catch (JsonProcessingException | IllegalStateException e) {
                             Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -36,6 +36,9 @@ public class BaseTest {
     public static void setUp() {
         spKey = System.getenv("SERVICE_PRINCIPAL_KEY");
         String accessKeyBase64 = System.getenv("ACCESS_KEY");
+        if (!nullOrEmpty(accessKeyBase64)) {
+            accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
+        }
         repoId = System.getenv("REPOSITORY_ID");
         username = System.getenv("APISERVER_USERNAME");
         password = System.getenv("APISERVER_PASSWORD");

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -254,7 +254,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         assertTrue(thrown.getCause() instanceof ApiException);
         ApiException apiException = (ApiException) thrown.getCause();
         assertEquals(404, apiException.getStatusCode());
-        assertEquals(String.format("Error: Repository with Id %s not found or no connection could be made.", invalidRepoId),
+        assertEquals(
+                String.format("Error: Repository with Id %s not found or no connection could be made.", invalidRepoId),
                 apiException.getMessage());
         ProblemDetails problemDetails = apiException.getProblemDetails();
         assertNotNull(problemDetails);

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -104,7 +104,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getEntryListing_ForEach() throws InterruptedException {
+    void getEntryListing_ForEach() {
         int maxPageSize = 10;
         Function<CompletableFuture<ODataValueContextOfIListOfEntry>, CompletableFuture<Boolean>> callback = data -> {
             ODataValueContextOfIListOfEntry futureResult = data.join();
@@ -171,7 +171,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getFieldValues_ForEach() throws InterruptedException {
+    void getFieldValues_ForEach() {
         int maxPageSize = 90;
         Function<CompletableFuture<ODataValueContextOfIListOfFieldValue>, CompletableFuture<Boolean>> callback = data -> {
             ODataValueContextOfIListOfFieldValue futureResult = data.join();
@@ -226,7 +226,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getLinkValuesFromEntry_ForEach() throws InterruptedException {
+    void getLinkValuesFromEntry_ForEach() {
         int maxPageSize = 90;
         Function<CompletableFuture<ODataValueContextOfIListOfWEntryLinkInfo>, CompletableFuture<Boolean>> callback = data -> {
             ODataValueContextOfIListOfWEntryLinkInfo futureResult = data.join();
@@ -295,7 +295,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getTagsAssignedToEntry_ForEach() throws InterruptedException {
+    void getTagsAssignedToEntry_ForEach() {
         int maxPageSize = 90;
         Function<CompletableFuture<ODataValueContextOfIListOfWTagInfo>, CompletableFuture<Boolean>> callback = data -> {
             ODataValueContextOfIListOfWTagInfo futureResult = data.join();
@@ -388,7 +388,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getDocumentContentType_ReturnsExpectedHeaders() throws InterruptedException {
+    void getDocumentContentType_ReturnsExpectedHeaders() {
         ODataValueContextOfIListOfEntry entryList = client
                 .getEntryListing(repoId, 1, false, null, false, "maxpagesize=100", null, null, null, null, null, false)
                 .join();
@@ -410,7 +410,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() throws InterruptedException {
+    void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() {
         Exception thrown = Assertions.assertThrows(CompletionException.class, () -> {
             client
                     .getEntryListing(repoId, -1, false, null, false, "maxpagesize=100", null, null, null, null, null,

--- a/src/test/java/integration/ErrorSource.java
+++ b/src/test/java/integration/ErrorSource.java
@@ -1,0 +1,2 @@
+package integration;public enum ErrorSource {
+}

--- a/src/test/java/integration/ErrorSource.java
+++ b/src/test/java/integration/ErrorSource.java
@@ -1,2 +1,19 @@
-package integration;public enum ErrorSource {
+package integration;
+
+public enum ErrorSource {
+    API_SERVER("Api Server"),
+    LASERFICHE_SERVER("Laserfiche Server"),
+    AUTHENTICATION_SERVICE("Authentication Services"),
+    ACCOUNT_CONTROL_SYSTEM("Account Control System"),
+    RWS("RWS");
+
+    private String name;
+
+    ErrorSource(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
 }

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -77,7 +77,8 @@ public class ExportDocumentApiTest extends BaseTest {
             client
                     .exportDocument(repoId, -createdEntryId, null, consumer);
         });
-        Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')", thrown.getMessage());
+        Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')",
+                thrown.getMessage());
         File exportedFile = new File(FILE_NAME);
         assertNotNull(exportedFile);
         assertFalse(exportedFile.exists());

--- a/src/test/java/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/integration/FieldDefinitionsApiTest.java
@@ -66,7 +66,7 @@ class FieldDefinitionsApiTest extends BaseTest {
     }
 
     @Test
-    void getFieldDefinitions_ForEach() throws InterruptedException {
+    void getFieldDefinitions_ForEach() {
         int maxPageSize = 10;
         Function<CompletableFuture<ODataValueContextOfIListOfWFieldInfo>, CompletableFuture<Boolean>> callback = data -> {
             ODataValueContextOfIListOfWFieldInfo result = data.join();

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -53,14 +53,15 @@ public class ImportDocumentApiTest extends BaseTest {
                         new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest())
                 .join();
 
+        assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
 
-        assertNotNull(result);
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        assertNotEquals(0, operations
+        createdEntryId = operations
                 .getEntryCreate()
-                .getEntryId());
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
         assertEquals(0, operations
                 .getEntryCreate()
                 .getExceptions()
@@ -69,10 +70,6 @@ public class ImportDocumentApiTest extends BaseTest {
                 .getSetEdoc()
                 .getExceptions()
                 .size());
-        createdEntryId = operations
-                .getEntryCreate()
-                .getEntryId();
-        assertTrue(createdEntryId > 0);
     }
 
     @Test
@@ -123,9 +120,10 @@ public class ImportDocumentApiTest extends BaseTest {
                 .getEntryCreate()
                 .getExceptions()
                 .size());
-        assertNotEquals(0, operations
+        createdEntryId = operations
                 .getEntryCreate()
-                .getEntryId());
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
         assertEquals(0, operations
                 .getSetEdoc()
                 .getExceptions()
@@ -137,10 +135,6 @@ public class ImportDocumentApiTest extends BaseTest {
         assertEquals(template.getName(), operations
                 .getSetTemplate()
                 .getTemplate());
-        createdEntryId = operations
-                .getEntryCreate()
-                .getEntryId();
-        assertTrue(createdEntryId > 0);
     }
 
     @Test
@@ -160,12 +154,12 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
 
-        assertNotNull(result);
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        assertNotEquals(0, operations
+        createdEntryId = operations
                 .getEntryCreate()
-                .getEntryId());
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
         assertEquals(0, operations
                 .getEntryCreate()
                 .getExceptions()
@@ -174,14 +168,10 @@ public class ImportDocumentApiTest extends BaseTest {
                 .getSetEdoc()
                 .getExceptions()
                 .size());
-        createdEntryId = operations
-                .getEntryCreate()
-                .getEntryId();
-        assertTrue(createdEntryId > 0);
     }
 
     @Test
-    void importDocument_DocumentCreated_FromString() throws IOException {
+    void importDocument_DocumentCreated_FromString() {
         String fileName = "myFile";
         CreateEntryResult result = null;
         String fileContent = "This is the file content";
@@ -196,12 +186,12 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
 
-        assertNotNull(result);
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        assertNotEquals(0, operations
+        createdEntryId = operations
                 .getEntryCreate()
-                .getEntryId());
+                .getEntryId();
+        assertTrue(createdEntryId > 0);
         assertEquals(0, operations
                 .getEntryCreate()
                 .getExceptions()
@@ -210,14 +200,10 @@ public class ImportDocumentApiTest extends BaseTest {
                 .getSetEdoc()
                 .getExceptions()
                 .size());
-        createdEntryId = operations
-                .getEntryCreate()
-                .getEntryId();
-        assertTrue(createdEntryId > 0);
     }
 
     @Test
-    void importDocument_Returns_Detail_When_PartialSuccess_Happens() throws IOException {
+    void importDocument_Returns_Detail_When_PartialSuccess_Happens() {
         String fileName = "myFile";
         CreateEntryResult result = null;
         String fileContent = "This is the file content";

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -55,7 +55,7 @@ public class TasksApiTest extends BaseTest {
     }
 
     @Test
-    void cancelOperation_OperationCancelledSuccessfully() throws InterruptedException {
+    void cancelOperation_OperationCancelledSuccessfully() {
         Entry deleteEntry = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java CancelOperation", 1,
                 true).join();
 

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -49,7 +49,8 @@ public class TasksApiTest extends BaseTest {
                     .join();
         });
 
-        Assertions.assertEquals(String.format("%s: Error: Cannot cancel ended operation.", ApiException.class.getCanonicalName()),
+        Assertions.assertEquals(
+                String.format("%s: Error: Cannot cancel ended operation.", ApiException.class.getCanonicalName()),
                 thrown.getMessage());
     }
 


### PR DESCRIPTION
For importDocument api, if we have partial success, APIServer does not return a success status code (e.g. 207). Instead, it returns 409. As in this case the response includes an CreateEntryResult object, we should handle this status code like other success status code, not like error status codes, (i.e. we need to return the CreateEntryResult object, instead of throwing exception)

So, to fix the issue, the code generator is updated to (only for importDocument api) handle 409 in the success path, instead of error path.

A new integration test is added for this fix: importDocument_Returns_Detail_When_PartialSuccess_Happens(
Some minor changes:

- Reduce duplication by initializing body once, instead of twice (one in the success and one in the error path)
- Some minor formatting changes
- Adding an enum for ErorrSource, to be used in the integration tests
- Removing unnecessary **throws** expression from some integration tests
- Removing some unneeded/duplicate assertions
