### PR TITLE
Make it autocloseable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.0
+
+### Features
+
+- Add support for AutoCloseable for automatic managing of resources held by the underlying HTTP client.
+
 ## 1.1.1
 
 ### Fixes
@@ -11,7 +17,7 @@
 
 ### Features
 
-Add support for self-hosted API Server.
+- Add support for self-hosted API Server.
 
 ### Fixes
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>1.1.1</version>
+  <version>1.2.0</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
     <dependency>
       <groupId>com.laserfiche</groupId>
       <artifactId>lf-api-client-core</artifactId>
-      <version>1.0.0</version>
+      <version>1.1.0</version>
     </dependency>
 
     

--- a/src/main/java/com/laserfiche/repository/api/OAuthInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/OAuthInterceptor.java
@@ -5,13 +5,13 @@ import com.laserfiche.api.client.httphandlers.OAuthClientCredentialsHandler;
 import com.laserfiche.api.client.httphandlers.Request;
 import com.laserfiche.api.client.httphandlers.RequestImpl;
 import com.laserfiche.api.client.model.AccessKey;
+import com.laserfiche.repository.api.clients.RepositoryApiClientInterceptor;
 import kong.unirest.Config;
 import kong.unirest.HttpRequest;
-import kong.unirest.Interceptor;
 
 import java.util.concurrent.CompletableFuture;
 
-public class OAuthInterceptor implements Interceptor {
+public class OAuthInterceptor implements RepositoryApiClientInterceptor {
     private final OAuthClientCredentialsHandler oauthHandler;
 
     public OAuthInterceptor(String servicePrincipalKey, AccessKey accessKey) {
@@ -26,5 +26,10 @@ public class OAuthInterceptor implements Interceptor {
         request.header("Authorization", customRequest
                 .headers()
                 .get("Authorization"));
+    }
+
+    @Override
+    public void close() {
+        oauthHandler.close();
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
@@ -7,7 +7,7 @@ import java.util.Map;
 /**
  * The Laserfiche Repository API client.
  */
-public interface RepositoryApiClient {
+public interface RepositoryApiClient extends AutoCloseable {
     /**
      * @return The Laserfiche Repository Attributes API client.
      */
@@ -71,4 +71,11 @@ public interface RepositoryApiClient {
      * @return Default request headers in a key value pair of header name and value.
      */
     Map<String, String> getDefaultRequestHeaders();
+
+    /**
+     * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.
+     * We override the signature of the close() to not include any checked exception.
+     */
+    @Override
+    void close();
 }

--- a/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
@@ -5,13 +5,13 @@ import com.laserfiche.api.client.httphandlers.BeforeSendResult;
 import com.laserfiche.api.client.httphandlers.Request;
 import com.laserfiche.api.client.httphandlers.RequestImpl;
 import com.laserfiche.api.client.httphandlers.UsernamePasswordHandler;
+import com.laserfiche.repository.api.clients.RepositoryApiClientInterceptor;
 import kong.unirest.Config;
 import kong.unirest.HttpRequest;
-import kong.unirest.Interceptor;
 
 import java.util.concurrent.CompletableFuture;
 
-public class SelfHostedInterceptor implements Interceptor {
+public class SelfHostedInterceptor implements RepositoryApiClientInterceptor {
     private final UsernamePasswordHandler usernamePasswordHandler;
 
     public SelfHostedInterceptor(String repositoryId, String username, String password, String baseUrl,
@@ -27,5 +27,10 @@ public class SelfHostedInterceptor implements Interceptor {
         request.header("Authorization", customRequest
                 .headers()
                 .get("Authorization"));
+    }
+
+    @Override
+    public void close() {
+        usernamePasswordHandler.close();
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoryApiClientInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoryApiClientInterceptor.java
@@ -1,0 +1,12 @@
+package com.laserfiche.repository.api.clients;
+
+import kong.unirest.Interceptor;
+
+public interface RepositoryApiClientInterceptor extends AutoCloseable, Interceptor {
+    /**
+     * Since the underlying resource (the HTTP client) won't throw any exception during its close() invocation.
+     * We override the signature of the close() to not include any checked exception.
+     */
+    @Override
+    void close();
+}

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -8,6 +8,7 @@ import com.laserfiche.repository.api.clients.impl.model.PostEntryChildrenEntryTy
 import com.laserfiche.repository.api.clients.impl.model.PostEntryChildrenRequest;
 import com.laserfiche.repository.api.clients.impl.model.TemplateFieldInfo;
 import io.github.cdimascio.dotenv.Dotenv;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.util.HashMap;
@@ -76,6 +77,11 @@ public class BaseTest {
         testHeaders = new HashMap<>();
         testHeaders.put(testHeaderValue, "true");
         repositoryApiClient = createClient();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        repositoryApiClient.close();
     }
 
     public static RepositoryApiClient createClient() {


### PR DESCRIPTION
1. Use the latest client core library that implements AutoCloseable.
2. Add an interface for the interceptors, RepositoryApiClientInterceptor. The new interface extends AutoCloseable and adjusts the exception signature since the underlying HTTP client doesn't throw. All interceptors now implement the new interface as they all use the HTTP client under the hood.
3. The RepositoryApiClient interface now extends AutoCloseable as it needs to release resources of the HTTP client. Note, the various clients do not need to implement AutoCloseable as they all share the same HTTP client handled by RepositoryApiClient.
4. Update tests to release the HTTP client when done running.
5. Bump version number and update change log.