### PR TITLE
Update HitType to have better named enum values

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
@@ -5,21 +5,21 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum HitType {
 
-    PAGECONTENT("PageContent"),
+    PAGE_CONTENT("PageContent"),
     NOTE("Note"),
     CALLOUT("Callout"),
-    TEXTBOX("TextBox"),
+    TEXT_BOX("TextBox"),
     EDOC("Edoc"),
     PROP("Prop"),
     NAME("Name"),
     EXTENSION("Extension"),
-    VERSIONGROUPNOTE("VersionGroupNote"),
-    VERSIONCOMMENT("VersionComment"),
+    VERSION_GROUP_NOTE("VersionGroupNote"),
+    VERSION_COMMENT("VersionComment"),
     FIELD("Field"),
-    SIGNATURECOMMENT("SignatureComment"),
-    CERTIFICATESUBJECT("CertificateSubject"),
-    TAGCOMMENT("TagComment"),
-    ANNOTATIONCOMMENT("AnnotationComment"),
+    SIGNATURE_COMMENT("SignatureComment"),
+    CERTIFICATE_SUBJECT("CertificateSubject"),
+    TAG_COMMENT("TagComment"),
+    ANNOTATION_COMMENT("AnnotationComment"),
     ATTACHMENT("Attachment");
 
     private String value;


### PR DESCRIPTION
In this previous [PR](https://github.com/Laserfiche/lf-repository-api-client-java/pull/76), we missed the HitType enum class. In this PR, we fixed it by updating the enum class with better naming (upper snake case instead of all upper case without delimiter).