### PR TITLE
Story/404922 encapsulate params

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -255,6 +255,11 @@
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>
     </dependency>
+    <dependency>
+      <groupId>com.laserfiche</groupId>
+      <artifactId>lf-api-client-core</artifactId>
+      <version>2.0.0</version>
+    </dependency>
 
     
 

--- a/pom.xml
+++ b/pom.xml
@@ -255,11 +255,6 @@
       <artifactId>javax.annotation-api</artifactId>
       <version>1.3.2</version>
     </dependency>
-    <dependency>
-      <groupId>com.laserfiche</groupId>
-      <artifactId>lf-api-client-core</artifactId>
-      <version>2.0.0</version>
-    </dependency>
 
     
 

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -4,7 +4,6 @@ import com.laserfiche.api.client.model.AccessKey;
 import com.laserfiche.repository.api.clients.*;
 import com.laserfiche.repository.api.clients.impl.*;
 import com.laserfiche.repository.api.clients.impl.deserialization.RepositoryClientObjectMapper;
-import kong.unirest.Interceptor;
 import kong.unirest.Unirest;
 import kong.unirest.UnirestInstance;
 
@@ -70,7 +69,8 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
 
     public static RepositoryApiClient createFromUsernamePassword(String repositoryId, String username, String password,
             String baseUrl) {
-        RepositoryApiClientInterceptor interceptor = new SelfHostedInterceptor(repositoryId, username, password, baseUrl, null);
+        RepositoryApiClientInterceptor interceptor = new SelfHostedInterceptor(repositoryId, username, password,
+                baseUrl, null);
         return new RepositoryApiClientImpl(interceptor, baseUrl);
     }
 

--- a/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
+++ b/src/main/java/com/laserfiche/repository/api/SelfHostedInterceptor.java
@@ -1,15 +1,12 @@
 package com.laserfiche.repository.api;
 
 import com.laserfiche.api.client.apiserver.TokenClient;
-import com.laserfiche.api.client.httphandlers.BeforeSendResult;
 import com.laserfiche.api.client.httphandlers.Request;
 import com.laserfiche.api.client.httphandlers.RequestImpl;
 import com.laserfiche.api.client.httphandlers.UsernamePasswordHandler;
 import com.laserfiche.repository.api.clients.RepositoryApiClientInterceptor;
 import kong.unirest.Config;
 import kong.unirest.HttpRequest;
-
-import java.util.concurrent.CompletableFuture;
 
 public class SelfHostedInterceptor implements RepositoryApiClientInterceptor {
     private final UsernamePasswordHandler usernamePasswordHandler;

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -1,65 +1,65 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.Attribute;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface AttributesClient {
 
     /**
-     * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
+     *  - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
-     * @param repoId       The requested repository ID.
-     * @param attributeKey The requested attribute key.
-     * @param everyone     Boolean value that indicates whether to return attributes associated with everyone or the currently authenticated user.
-     * @return Attribute The return value
+     *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
+     *  @return Attribute The return value
      */
-    Attribute getTrusteeAttributeValueByKey(String repoId, String attributeKey, Boolean everyone);
+    Attribute getTrusteeAttributeValueByKey(ParametersForGetTrusteeAttributeValueByKey parameters);
 
     /**
-     * - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
+     *  - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
      * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *
-     * @param repoId   The requested repository ID.
-     * @param everyone Boolean value that indicates whether to return attributes key value pairs associated with everyone or the currently authenticated user.
-     * @param prefer   An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select   Limits the properties returned in the result.
-     * @param orderby  Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top      Limits the number of items returned from a collection.
-     * @param skip     Excludes the specified number of items of the queried collection from the result.
-     * @param count    Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfListOfAttribute The return value
+     *  @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
+     *  @return ODataValueContextOfListOfAttribute The return value
      */
-    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(String repoId, Boolean everyone, String prefer,
-            String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(ParametersForGetTrusteeAttributeKeyValuePairs parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfListOfAttribute The return value
      */
-    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTrusteeAttributeKeyValuePairs&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param everyone    Boolean value that indicates whether to return attributes key value pairs associated with everyone or the currently authenticated user.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback,
-            Integer maxPageSize, String repoId, Boolean everyone, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count);
+    void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback, Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -1,29 +1,11 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
+import com.laserfiche.repository.api.clients.impl.model.Attribute;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeKeyValuePairs;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeValueByKey;
+
 import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
 
 public interface AttributesClient {
 
@@ -31,8 +13,8 @@ public interface AttributesClient {
      * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
-     *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
-     *  @return Attribute The return value
+     * @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
+     * @return Attribute The return value
      */
     Attribute getTrusteeAttributeValueByKey(ParametersForGetTrusteeAttributeValueByKey parameters);
 
@@ -41,15 +23,16 @@ public interface AttributesClient {
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
      * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *
-     *  @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
-     *  @return ODataValueContextOfListOfAttribute The return value
+     * @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
+     * @return ODataValueContextOfListOfAttribute The return value
      */
-    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(ParametersForGetTrusteeAttributeKeyValuePairs parameters);
+    ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(
+            ParametersForGetTrusteeAttributeKeyValuePairs parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfListOfAttribute The return value
      */
@@ -58,8 +41,9 @@ public interface AttributesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTrusteeAttributeKeyValuePairs&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback, Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters);
+    void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface AttributesClient {
 
     /**
-     *  - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
+     * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
      *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
@@ -37,7 +37,7 @@ public interface AttributesClient {
     Attribute getTrusteeAttributeValueByKey(ParametersForGetTrusteeAttributeValueByKey parameters);
 
     /**
-     *  - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
+     * - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
      * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface AuditReasonsClient {
 
     /**
-     *  - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
+     * - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
      * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -1,29 +1,7 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
+import com.laserfiche.repository.api.clients.params.ParametersForGetAuditReasons;
 
 public interface AuditReasonsClient {
 
@@ -32,8 +10,8 @@ public interface AuditReasonsClient {
      * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *
-     *  @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
-     *  @return AuditReasons The return value
+     * @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
+     * @return AuditReasons The return value
      */
     AuditReasons getAuditReasons(ParametersForGetAuditReasons parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -1,16 +1,39 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface AuditReasonsClient {
 
     /**
-     * - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
+     *  - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
      * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *
-     * @param repoId The requested repository ID.
-     * @return AuditReasons The return value
+     *  @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
+     *  @return AuditReasons The return value
      */
-    AuditReasons getAuditReasons(String repoId);
+    AuditReasons getAuditReasons(ParametersForGetAuditReasons parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -1,29 +1,10 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
 import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.params.*;
+
+import java.util.Map;
+import java.util.function.Function;
 
 public interface EntriesClient {
 
@@ -32,15 +13,15 @@ public interface EntriesClient {
      * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
-     *  @return ODataValueContextOfIListOfFieldValue The return value
+     * @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
+     * @return ODataValueContextOfIListOfFieldValue The return value
      */
     ODataValueContextOfIListOfFieldValue getFieldValues(ParametersForGetFieldValues parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfFieldValue The return value
      */
@@ -49,18 +30,19 @@ public interface EntriesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldValues&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize, ParametersForGetFieldValues parameters);
+    void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize,
+            ParametersForGetFieldValues parameters);
 
     /**
      * - Update the field values assigned to an entry.
      * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
      * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
      *
-     *  @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
-     *  @return ODataValueOfIListOfFieldValue The return value
+     * @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
+     * @return ODataValueOfIListOfFieldValue The return value
      */
     ODataValueOfIListOfFieldValue assignFieldValues(ParametersForAssignFieldValues parameters);
 
@@ -69,8 +51,8 @@ public interface EntriesClient {
      * - Optionally sets metadata and electronic document component.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
      *
-     *  @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
-     *  @return CreateEntryResult The return value
+     * @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
+     * @return CreateEntryResult The return value
      */
     CreateEntryResult importDocument(ParametersForImportDocument parameters);
 
@@ -79,15 +61,15 @@ public interface EntriesClient {
      * - Provide an entry ID, and get a paged listing of links assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
-     *  @return ODataValueContextOfIListOfWEntryLinkInfo The return value
+     * @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
+     * @return ODataValueContextOfIListOfWEntryLinkInfo The return value
      */
     ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(ParametersForGetLinkValuesFromEntry parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWEntryLinkInfo The return value
      */
@@ -96,18 +78,19 @@ public interface EntriesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkValuesFromEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters);
+    void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters);
 
     /**
      * - Assign links to an entry.
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
-     *  @return ODataValueOfIListOfWEntryLinkInfo The return value
+     * @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
+     * @return ODataValueOfIListOfWEntryLinkInfo The return value
      */
     ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(ParametersForAssignEntryLinks parameters);
 
@@ -116,8 +99,8 @@ public interface EntriesClient {
      * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
      * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
      *
-     *  @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
+     * @return Entry The return value
      */
     Entry writeTemplateValueToEntry(ParametersForWriteTemplateValueToEntry parameters);
 
@@ -126,18 +109,18 @@ public interface EntriesClient {
      * - Provide an entry ID to clear template value on.
      * - If the entry does not have a template assigned, no change will be made.
      *
-     *  @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
+     * @return Entry The return value
      */
     Entry deleteAssignedTemplate(ParametersForDeleteAssignedTemplate parameters);
 
     /**
      * - Returns dynamic field logic values with the current values of the fields in the template.
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
-     *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+     * Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
-     *  @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
-     *  @return Map&lt;String,String[]&gt; The return value
+     * @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
+     * @return Map&lt;String,String[]&gt; The return value
      */
     Map<String, String[]> getDynamicFieldValues(ParametersForGetDynamicFieldValues parameters);
 
@@ -145,8 +128,8 @@ public interface EntriesClient {
      * - Returns a single entry object using the entry path.
      * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
      *
-     *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
-     *  @return FindEntryResult The return value
+     * @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
+     * @return FindEntryResult The return value
      */
     FindEntryResult getEntryByPath(ParametersForGetEntryByPath parameters);
 
@@ -156,8 +139,8 @@ public interface EntriesClient {
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      * - The status of the operation can be checked via the Tasks/{operationToken} route.
      *
-     *  @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
+     * @return AcceptedOperation The return value
      */
     AcceptedOperation copyEntryAsync(ParametersForCopyEntryAsync parameters);
 
@@ -166,8 +149,8 @@ public interface EntriesClient {
      * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
      * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
      *
-     *  @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
+     * @return Entry The return value
      */
     Entry getEntry(ParametersForGetEntry parameters);
 
@@ -176,8 +159,8 @@ public interface EntriesClient {
      * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     *  @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
+     * @return Entry The return value
      */
     Entry moveOrRenameEntry(ParametersForMoveOrRenameEntry parameters);
 
@@ -186,8 +169,8 @@ public interface EntriesClient {
      * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
      * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
      *
-     *  @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
+     * @return AcceptedOperation The return value
      */
     AcceptedOperation deleteEntryInfo(ParametersForDeleteEntryInfo parameters);
 
@@ -196,7 +179,7 @@ public interface EntriesClient {
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     *  @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
+     * @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
      */
     void exportDocumentWithAuditReason(ParametersForExportDocumentWithAuditReason parameters);
 
@@ -205,7 +188,7 @@ public interface EntriesClient {
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
-     *  @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
+     * @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
      */
     void exportDocument(ParametersForExportDocument parameters);
 
@@ -222,8 +205,8 @@ public interface EntriesClient {
      * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
      * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
      *
-     *  @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
-     *  @return Map&lt;String,String&gt; The return value
+     * @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
+     * @return Map&lt;String,String&gt; The return value
      */
     Map<String, String> getDocumentContentType(ParametersForGetDocumentContentType parameters);
 
@@ -231,8 +214,8 @@ public interface EntriesClient {
      * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
      * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
-     *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
+     * @return ODataValueOfBoolean The return value
      */
     ODataValueOfBoolean deletePages(ParametersForDeletePages parameters);
 
@@ -244,15 +227,15 @@ public interface EntriesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     ODataValueContextOfIListOfEntry getEntryListing(ParametersForGetEntryListing parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntry The return value
      */
@@ -261,18 +244,19 @@ public interface EntriesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getEntryListing&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetEntryListing parameters);
+    void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
+            ParametersForGetEntryListing parameters);
 
     /**
      * - Create/copy a new child entry in the designated folder.
      * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     *  @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
+     * @return Entry The return value
      */
     Entry createOrCopyEntry(ParametersForCreateOrCopyEntry parameters);
 
@@ -281,15 +265,15 @@ public interface EntriesClient {
      * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
-     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
+     * @return ODataValueContextOfIListOfWTagInfo The return value
      */
     ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(ParametersForGetTagsAssignedToEntry parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTagInfo The return value
      */
@@ -298,18 +282,19 @@ public interface EntriesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagsAssignedToEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters);
+    void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters);
 
     /**
      * - Assign tags to an entry.
      * - Provide an entry ID and a list of tags to assign to that entry.
      * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
-     *  @return ODataValueOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
+     * @return ODataValueOfIListOfWTagInfo The return value
      */
     ODataValueOfIListOfWTagInfo assignTags(ParametersForAssignTags parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -1,463 +1,315 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-
-import java.io.InputStream;
-import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface EntriesClient {
 
     /**
-     * - Returns the fields assigned to an entry.
+     *  - Returns the fields assigned to an entry.
      * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param formatValue An optional query parameter used to indicate if the field values should be formatted.
-     *                    The default value is false.
-     * @param culture     An optional query parameter used to indicate the locale that should be used for formatting.
-     *                    The value should be a standard language tag. The formatValue query parameter must be set to true, otherwise
-     *                    culture will not be used for formatting.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfFieldValue The return value
+     *  @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
+     *  @return ODataValueContextOfIListOfFieldValue The return value
      */
-    ODataValueContextOfIListOfFieldValue getFieldValues(String repoId, Integer entryId, String prefer,
-            Boolean formatValue, String culture, String select, String orderby, Integer top, Integer skip,
-            Boolean count);
+    ODataValueContextOfIListOfFieldValue getFieldValues(ParametersForGetFieldValues parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfFieldValue The return value
      */
-    ODataValueContextOfIListOfFieldValue getFieldValuesNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfFieldValue getFieldValuesNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldValues&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param formatValue An optional query parameter used to indicate if the field values should be formatted.
-     *                    The default value is false.
-     * @param culture     An optional query parameter used to indicate the locale that should be used for formatting.
-     *                    The value should be a standard language tag. The formatValue query parameter must be set to true, otherwise
-     *                    culture will not be used for formatting.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize,
-            String repoId, Integer entryId, String prefer, Boolean formatValue, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize, ParametersForGetFieldValues parameters);
 
     /**
-     * - Update the field values assigned to an entry.
+     *  - Update the field values assigned to an entry.
      * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
      * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The entry ID of the entry that will have its fields updated.
-     * @param requestBody
-     * @param culture     An optional query parameter used to indicate the locale that should be used.
-     *                    The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @return ODataValueOfIListOfFieldValue The return value
+     *  @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
+     *  @return ODataValueOfIListOfFieldValue The return value
      */
-    ODataValueOfIListOfFieldValue assignFieldValues(String repoId, Integer entryId,
-            Map<String, FieldToUpdate> requestBody, String culture);
+    ODataValueOfIListOfFieldValue assignFieldValues(ParametersForAssignFieldValues parameters);
 
     /**
-     * - Creates a new document in the specified folder with file (no more than 100 MB).
+     *  - Creates a new document in the specified folder with file (no more than 100 MB).
      * - Optionally sets metadata and electronic document component.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
      *
-     * @param repoId        The requested repository ID.
-     * @param parentEntryId The entry ID of the folder that the document will be created in.
-     * @param fileName      The created document's file name.
-     * @param autoRename    An optional query parameter used to indicate if the new document should be automatically
-     *                      renamed if an entry already exists with the given name in the folder. The default value is false.
-     * @param culture       An optional query parameter used to indicate the locale that should be used.
-     *                      The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @param inputStream   An InputStream object to read the raw bytes for the file to be uploaded.
-     * @param requestBody   A value of type PostEntryWithEdocMetadataRequest.
-     * @return CreateEntryResult The return value
+     *  @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
+     *  @return CreateEntryResult The return value
      */
-    CreateEntryResult importDocument(String repoId, Integer parentEntryId, String fileName, Boolean autoRename,
-            String culture, InputStream inputStream, PostEntryWithEdocMetadataRequest requestBody);
+    CreateEntryResult importDocument(ParametersForImportDocument parameters);
 
     /**
-     * - Returns the links assigned to an entry.
+     *  - Returns the links assigned to an entry.
      * - Provide an entry ID, and get a paged listing of links assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested entry ID.
-     * @param prefer  An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select  Limits the properties returned in the result.
-     * @param orderby Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top     Limits the number of items returned from a collection.
-     * @param skip    Excludes the specified number of items of the queried collection from the result.
-     * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfWEntryLinkInfo The return value
+     *  @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
+     *  @return ODataValueContextOfIListOfWEntryLinkInfo The return value
      */
-    ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(String repoId, Integer entryId, String prefer,
-            String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(ParametersForGetLinkValuesFromEntry parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWEntryLinkInfo The return value
      */
-    ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntryNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntryNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkValuesFromEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param prefer      An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer entryId, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count);
+    void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters);
 
     /**
-     * - Assign links to an entry.
+     *  - Assign links to an entry.
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
-     * @param repoId      The request repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody A value of type List&lt;PutLinksRequest&gt;.
-     * @return ODataValueOfIListOfWEntryLinkInfo The return value
+     *  @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
+     *  @return ODataValueOfIListOfWEntryLinkInfo The return value
      */
-    ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(String repoId, Integer entryId,
-            List<PutLinksRequest> requestBody);
+    ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(ParametersForAssignEntryLinks parameters);
 
     /**
-     * - Assign a template to an entry.
+     *  - Assign a template to an entry.
      * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
      * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The ID of entry that will have its template updated.
-     * @param requestBody The template and template fields that will be assigned to the entry.
-     * @param culture     An optional query parameter used to indicate the locale that should be used.
-     *                    The value should be a standard language tag. This may be used when setting field values with tokens.
-     * @return Entry The return value
+     *  @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
+     *  @return Entry The return value
      */
-    Entry writeTemplateValueToEntry(String repoId, Integer entryId, PutTemplateRequest requestBody, String culture);
+    Entry writeTemplateValueToEntry(ParametersForWriteTemplateValueToEntry parameters);
 
     /**
-     * - Remove the currently assigned template from the specified entry.
+     *  - Remove the currently assigned template from the specified entry.
      * - Provide an entry ID to clear template value on.
      * - If the entry does not have a template assigned, no change will be made.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The ID of the entry that will have its template removed.
-     * @return Entry The return value
+     *  @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
+     *  @return Entry The return value
      */
-    Entry deleteAssignedTemplate(String repoId, Integer entryId);
+    Entry deleteAssignedTemplate(ParametersForDeleteAssignedTemplate parameters);
 
     /**
-     * - Returns dynamic field logic values with the current values of the fields in the template.
+     *  - Returns dynamic field logic values with the current values of the fields in the template.
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
-     * Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+     *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody A value of type GetDynamicFieldLogicValueRequest.
-     * @return Map&lt;String,String[]&gt; The return value
+     *  @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
+     *  @return Map&lt;String,String[]&gt; The return value
      */
-    Map<String, String[]> getDynamicFieldValues(String repoId, Integer entryId,
-            GetDynamicFieldLogicValueRequest requestBody);
+    Map<String, String[]> getDynamicFieldValues(ParametersForGetDynamicFieldValues parameters);
 
     /**
-     * - Returns a single entry object using the entry path.
+     *  - Returns a single entry object using the entry path.
      * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
      *
-     * @param repoId                    The requested repository ID.
-     * @param fullPath                  The requested entry path.
-     * @param fallbackToClosestAncestor An optional query parameter used to indicate whether or not the closest ancestor in the path should be returned if the initial entry path is not found. The default value is false.
-     * @return FindEntryResult The return value
+     *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
+     *  @return FindEntryResult The return value
      */
-    FindEntryResult getEntryByPath(String repoId, String fullPath, Boolean fallbackToClosestAncestor);
+    FindEntryResult getEntryByPath(ParametersForGetEntryByPath parameters);
 
     /**
-     * - Copy a new child entry in the designated folder async, and potentially return an operationToken.
+     *  - Copy a new child entry in the designated folder async, and potentially return an operationToken.
      * - Provide the parent folder ID, and copy an entry as a child of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      * - The status of the operation can be checked via the Tasks/{operationToken} route.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The folder ID that the entry will be created in.
-     * @param requestBody Copy entry request.
-     * @param autoRename  An optional query parameter used to indicate if the new entry should be automatically
-     *                    renamed if an entry already exists with the given name in the folder. The default value is false.
-     * @param culture     An optional query parameter used to indicate the locale that should be used.
-     *                    The value should be a standard language tag.
-     * @return AcceptedOperation The return value
+     *  @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
+     *  @return AcceptedOperation The return value
      */
-    AcceptedOperation copyEntryAsync(String repoId, Integer entryId, CopyAsyncRequest requestBody, Boolean autoRename,
-            String culture);
+    AcceptedOperation copyEntryAsync(ParametersForCopyEntryAsync parameters);
 
     /**
-     * - Returns a single entry object.
+     *  - Returns a single entry object.
      * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
      * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested entry ID.
-     * @param select  Limits the properties returned in the result.
-     * @return Entry The return value
+     *  @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
+     *  @return Entry The return value
      */
-    Entry getEntry(String repoId, Integer entryId, String select);
+    Entry getEntry(ParametersForGetEntry parameters);
 
     /**
-     * - Moves and/or renames an entry.
+     *  - Moves and/or renames an entry.
      * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody The request containing the folder ID that the entry will be moved to and the new name
-     *                    the entry will be renamed to.
-     * @param autoRename  An optional query parameter used to indicate if the entry should be automatically
-     *                    renamed if another entry already exists with the same name in the folder. The default value is false.
-     * @param culture     An optional query parameter used to indicate the locale that should be used.
-     *                    The value should be a standard language tag.
-     * @return Entry The return value
+     *  @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
+     *  @return Entry The return value
      */
-    Entry moveOrRenameEntry(String repoId, Integer entryId, PatchEntryRequest requestBody, Boolean autoRename,
-            String culture);
+    Entry moveOrRenameEntry(ParametersForMoveOrRenameEntry parameters);
 
     /**
-     * - Begins a task to delete an entry, and returns an operationToken.
+     *  - Begins a task to delete an entry, and returns an operationToken.
      * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
      * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody The submitted audit reason.
-     * @return AcceptedOperation The return value
+     *  @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
+     *  @return AcceptedOperation The return value
      */
-    AcceptedOperation deleteEntryInfo(String repoId, Integer entryId, DeleteEntryWithAuditReason requestBody);
+    AcceptedOperation deleteEntryInfo(ParametersForDeleteEntryInfo parameters);
 
     /**
-     * - Returns an entry's edoc resource in a stream format while including an audit reason.
+     *  - Returns an entry's edoc resource in a stream format while including an audit reason.
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     * @param repoId              The requested repository ID.
-     * @param entryId             The requested document ID.
-     * @param requestBody         A value of type GetEdocWithAuditReasonRequest.
-     * @param range               An optional header used to retrieve partial content of the edoc. Only supports single
-     *                            range with byte unit.
-     * @param inputStreamConsumer A Consumer&lt;InputStream&gt; object that the is provided with the response's inputStream to consume it, if the request has been successful.
+     *  @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
      */
-    void exportDocumentWithAuditReason(String repoId, Integer entryId, GetEdocWithAuditReasonRequest requestBody,
-            String range, Consumer<InputStream> inputStreamConsumer);
+    void exportDocumentWithAuditReason(ParametersForExportDocumentWithAuditReason parameters);
 
     /**
-     * - Returns an entry's edoc resource in a stream format.
+     *  - Returns an entry's edoc resource in a stream format.
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
-     * @param repoId              The requested repository ID.
-     * @param entryId             The requested document ID.
-     * @param range               An optional header used to retrieve partial content of the edoc. Only supports single
-     *                            range with byte unit.
-     * @param inputStreamConsumer A Consumer&lt;InputStream&gt; object that the is provided with the response's inputStream to consume it, if the request has been successful.
+     *  @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
      */
-    void exportDocument(String repoId, Integer entryId, String range, Consumer<InputStream> inputStreamConsumer);
+    void exportDocument(ParametersForExportDocument parameters);
 
     /**
      * - Delete the edoc associated with the provided entry ID.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested document ID.
+     * @param parameters An object of type ParametersForDeleteDocument which encapsulates the parameters of deleteDocument method.
      * @return ODataValueOfBoolean The return value
      */
-    ODataValueOfBoolean deleteDocument(String repoId, Integer entryId);
+    ODataValueOfBoolean deleteDocument(ParametersForDeleteDocument parameters);
 
     /**
-     * - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
+     *  - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
      * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
      * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested document ID.
-     * @return Map&lt;String,String&gt; The return value
+     *  @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
+     *  @return Map&lt;String,String&gt; The return value
      */
-    Map<String, String> getDocumentContentType(String repoId, Integer entryId);
+    Map<String, String> getDocumentContentType(ParametersForGetDocumentContentType parameters);
 
     /**
-     * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
+     *  - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
      * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
-     * @param repoId    The requested repository ID.
-     * @param entryId   The requested document ID.
-     * @param pageRange The pages to be deleted.
-     * @return ODataValueOfBoolean The return value
+     *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
+     *  @return ODataValueOfBoolean The return value
      */
-    ODataValueOfBoolean deletePages(String repoId, Integer entryId, String pageRange);
+    ODataValueOfBoolean deletePages(ParametersForDeletePages parameters);
 
     /**
-     * - Returns the children entries of a folder in the repository.
+     *  - Returns the children entries of a folder in the repository.
      * - Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. Sort order can be either value &quot;asc&quot; or &quot;desc&quot;. Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
      * - Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     * @param repoId           The requested repository ID.
-     * @param entryId          The folder ID.
-     * @param groupByEntryType An optional query parameter used to indicate if the result should be grouped by entry type or not.
-     * @param fields           Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
-     * @param formatFields     Boolean for if field values should be formatted. Only applicable if Fields are specified.
-     * @param prefer           An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture          An optional query parameter used to indicate the locale that should be used for formatting.
-     *                         The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *                         culture will not be used for formatting.
-     * @param select           Limits the properties returned in the result.
-     * @param orderby          Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top              Limits the number of items returned from a collection.
-     * @param skip             Excludes the specified number of items of the queried collection from the result.
-     * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfEntry The return value
+     *  @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
+     *  @return ODataValueContextOfIListOfEntry The return value
      */
-    ODataValueContextOfIListOfEntry getEntryListing(String repoId, Integer entryId, Boolean groupByEntryType,
-            String[] fields, Boolean formatFields, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfEntry getEntryListing(ParametersForGetEntryListing parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntry The return value
      */
-    ODataValueContextOfIListOfEntry getEntryListingNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfEntry getEntryListingNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getEntryListing&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback         A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
-     * @param maxPageSize      Optionally specify the maximum number of items to retrieve.
-     * @param repoId           The requested repository ID.
-     * @param entryId          The folder ID.
-     * @param groupByEntryType An optional query parameter used to indicate if the result should be grouped by entry type or not.
-     * @param fields           Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
-     * @param formatFields     Boolean for if field values should be formatted. Only applicable if Fields are specified.
-     * @param prefer           An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture          An optional query parameter used to indicate the locale that should be used for formatting.
-     *                         The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *                         culture will not be used for formatting.
-     * @param select           Limits the properties returned in the result.
-     * @param orderby          Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top              Limits the number of items returned from a collection.
-     * @param skip             Excludes the specified number of items of the queried collection from the result.
-     * @param count            Indicates whether the total count of items within a collection are returned in the result.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
-            String repoId, Integer entryId, Boolean groupByEntryType, String[] fields, Boolean formatFields,
-            String prefer, String culture, String select, String orderby, Integer top, Integer skip, Boolean count);
+    void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetEntryListing parameters);
 
     /**
-     * - Create/copy a new child entry in the designated folder.
+     *  - Create/copy a new child entry in the designated folder.
      * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The folder ID that the entry will be created in.
-     * @param requestBody The entry to create.
-     * @param autoRename  An optional query parameter used to indicate if the new entry should be automatically
-     *                    renamed if an entry already exists with the given name in the folder. The default value is false.
-     * @param culture     An optional query parameter used to indicate the locale that should be used.
-     *                    The value should be a standard language tag.
-     * @return Entry The return value
+     *  @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
+     *  @return Entry The return value
      */
-    Entry createOrCopyEntry(String repoId, Integer entryId, PostEntryChildrenRequest requestBody, Boolean autoRename,
-            String culture);
+    Entry createOrCopyEntry(ParametersForCreateOrCopyEntry parameters);
 
     /**
-     * - Returns the tags assigned to an entry.
+     *  - Returns the tags assigned to an entry.
      * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId  The requested repository ID.
-     * @param entryId The requested entry ID.
-     * @param prefer  An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select  Limits the properties returned in the result.
-     * @param orderby Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top     Limits the number of items returned from a collection.
-     * @param skip    Excludes the specified number of items of the queried collection from the result.
-     * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfWTagInfo The return value
+     *  @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
+     *  @return ODataValueContextOfIListOfWTagInfo The return value
      */
-    ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(String repoId, Integer entryId, String prefer,
-            String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(ParametersForGetTagsAssignedToEntry parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTagInfo The return value
      */
-    ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntryNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntryNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagsAssignedToEntry&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer entryId, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count);
+    void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters);
 
     /**
-     * - Assign tags to an entry.
+     *  - Assign tags to an entry.
      * - Provide an entry ID and a list of tags to assign to that entry.
      * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
      *
-     * @param repoId      The requested repository ID.
-     * @param entryId     The requested entry ID.
-     * @param requestBody The tags to add.
-     * @return ODataValueOfIListOfWTagInfo The return value
+     *  @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
+     *  @return ODataValueOfIListOfWTagInfo The return value
      */
-    ODataValueOfIListOfWTagInfo assignTags(String repoId, Integer entryId, PutTagRequest requestBody);
+    ODataValueOfIListOfWTagInfo assignTags(ParametersForAssignTags parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface EntriesClient {
 
     /**
-     *  - Returns the fields assigned to an entry.
+     * - Returns the fields assigned to an entry.
      * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -55,7 +55,7 @@ public interface EntriesClient {
     void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize, ParametersForGetFieldValues parameters);
 
     /**
-     *  - Update the field values assigned to an entry.
+     * - Update the field values assigned to an entry.
      * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
      * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
      *
@@ -65,7 +65,7 @@ public interface EntriesClient {
     ODataValueOfIListOfFieldValue assignFieldValues(ParametersForAssignFieldValues parameters);
 
     /**
-     *  - Creates a new document in the specified folder with file (no more than 100 MB).
+     * - Creates a new document in the specified folder with file (no more than 100 MB).
      * - Optionally sets metadata and electronic document component.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
      *
@@ -75,7 +75,7 @@ public interface EntriesClient {
     CreateEntryResult importDocument(ParametersForImportDocument parameters);
 
     /**
-     *  - Returns the links assigned to an entry.
+     * - Returns the links assigned to an entry.
      * - Provide an entry ID, and get a paged listing of links assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -102,7 +102,7 @@ public interface EntriesClient {
     void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters);
 
     /**
-     *  - Assign links to an entry.
+     * - Assign links to an entry.
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
@@ -112,7 +112,7 @@ public interface EntriesClient {
     ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(ParametersForAssignEntryLinks parameters);
 
     /**
-     *  - Assign a template to an entry.
+     * - Assign a template to an entry.
      * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
      * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
      *
@@ -122,7 +122,7 @@ public interface EntriesClient {
     Entry writeTemplateValueToEntry(ParametersForWriteTemplateValueToEntry parameters);
 
     /**
-     *  - Remove the currently assigned template from the specified entry.
+     * - Remove the currently assigned template from the specified entry.
      * - Provide an entry ID to clear template value on.
      * - If the entry does not have a template assigned, no change will be made.
      *
@@ -132,7 +132,7 @@ public interface EntriesClient {
     Entry deleteAssignedTemplate(ParametersForDeleteAssignedTemplate parameters);
 
     /**
-     *  - Returns dynamic field logic values with the current values of the fields in the template.
+     * - Returns dynamic field logic values with the current values of the fields in the template.
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
      *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
@@ -142,7 +142,7 @@ public interface EntriesClient {
     Map<String, String[]> getDynamicFieldValues(ParametersForGetDynamicFieldValues parameters);
 
     /**
-     *  - Returns a single entry object using the entry path.
+     * - Returns a single entry object using the entry path.
      * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
      *
      *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
@@ -151,7 +151,7 @@ public interface EntriesClient {
     FindEntryResult getEntryByPath(ParametersForGetEntryByPath parameters);
 
     /**
-     *  - Copy a new child entry in the designated folder async, and potentially return an operationToken.
+     * - Copy a new child entry in the designated folder async, and potentially return an operationToken.
      * - Provide the parent folder ID, and copy an entry as a child of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      * - The status of the operation can be checked via the Tasks/{operationToken} route.
@@ -162,7 +162,7 @@ public interface EntriesClient {
     AcceptedOperation copyEntryAsync(ParametersForCopyEntryAsync parameters);
 
     /**
-     *  - Returns a single entry object.
+     * - Returns a single entry object.
      * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
      * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
      *
@@ -172,7 +172,7 @@ public interface EntriesClient {
     Entry getEntry(ParametersForGetEntry parameters);
 
     /**
-     *  - Moves and/or renames an entry.
+     * - Moves and/or renames an entry.
      * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
@@ -182,7 +182,7 @@ public interface EntriesClient {
     Entry moveOrRenameEntry(ParametersForMoveOrRenameEntry parameters);
 
     /**
-     *  - Begins a task to delete an entry, and returns an operationToken.
+     * - Begins a task to delete an entry, and returns an operationToken.
      * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
      * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
      *
@@ -192,7 +192,7 @@ public interface EntriesClient {
     AcceptedOperation deleteEntryInfo(ParametersForDeleteEntryInfo parameters);
 
     /**
-     *  - Returns an entry's edoc resource in a stream format while including an audit reason.
+     * - Returns an entry's edoc resource in a stream format while including an audit reason.
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
@@ -201,7 +201,7 @@ public interface EntriesClient {
     void exportDocumentWithAuditReason(ParametersForExportDocumentWithAuditReason parameters);
 
     /**
-     *  - Returns an entry's edoc resource in a stream format.
+     * - Returns an entry's edoc resource in a stream format.
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
@@ -218,7 +218,7 @@ public interface EntriesClient {
     ODataValueOfBoolean deleteDocument(ParametersForDeleteDocument parameters);
 
     /**
-     *  - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
+     * - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
      * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
      * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
      *
@@ -228,7 +228,7 @@ public interface EntriesClient {
     Map<String, String> getDocumentContentType(ParametersForGetDocumentContentType parameters);
 
     /**
-     *  - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
+     * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
      * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
      *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
@@ -237,7 +237,7 @@ public interface EntriesClient {
     ODataValueOfBoolean deletePages(ParametersForDeletePages parameters);
 
     /**
-     *  - Returns the children entries of a folder in the repository.
+     * - Returns the children entries of a folder in the repository.
      * - Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. Sort order can be either value &quot;asc&quot; or &quot;desc&quot;. Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
      * - Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.
@@ -267,7 +267,7 @@ public interface EntriesClient {
     void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetEntryListing parameters);
 
     /**
-     *  - Create/copy a new child entry in the designated folder.
+     * - Create/copy a new child entry in the designated folder.
      * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
@@ -277,7 +277,7 @@ public interface EntriesClient {
     Entry createOrCopyEntry(ParametersForCreateOrCopyEntry parameters);
 
     /**
-     *  - Returns the tags assigned to an entry.
+     * - Returns the tags assigned to an entry.
      * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -304,7 +304,7 @@ public interface EntriesClient {
     void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters);
 
     /**
-     *  - Assign tags to an entry.
+     * - Assign tags to an entry.
      * - Provide an entry ID and a list of tags to assign to that entry.
      * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface FieldDefinitionsClient {
 
     /**
-     *  - Returns a single field definition associated with the specified ID.
+     * - Returns a single field definition associated with the specified ID.
      * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
      * - Allowed OData query options: Select
      *
@@ -38,7 +38,7 @@ public interface FieldDefinitionsClient {
     WFieldInfo getFieldDefinitionById(ParametersForGetFieldDefinitionById parameters);
 
     /**
-     *  - Returns a paged listing of field definitions available in the specified repository.
+     * - Returns a paged listing of field definitions available in the specified repository.
      * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -1,29 +1,11 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
+import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitions;
+
 import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
 
 public interface FieldDefinitionsClient {
 
@@ -32,8 +14,8 @@ public interface FieldDefinitionsClient {
      * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
-     *  @return WFieldInfo The return value
+     * @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
+     * @return WFieldInfo The return value
      */
     WFieldInfo getFieldDefinitionById(ParametersForGetFieldDefinitionById parameters);
 
@@ -42,15 +24,15 @@ public interface FieldDefinitionsClient {
      * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
-     *  @return ODataValueContextOfIListOfWFieldInfo The return value
+     * @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
+     * @return ODataValueContextOfIListOfWFieldInfo The return value
      */
     ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(ParametersForGetFieldDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWFieldInfo The return value
      */
@@ -59,8 +41,9 @@ public interface FieldDefinitionsClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetFieldDefinitions parameters);
+    void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetFieldDefinitions parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -1,70 +1,66 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
-import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface FieldDefinitionsClient {
 
     /**
-     * - Returns a single field definition associated with the specified ID.
+     *  - Returns a single field definition associated with the specified ID.
      * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
      * - Allowed OData query options: Select
      *
-     * @param repoId            The requested repository ID.
-     * @param fieldDefinitionId The requested field definition ID.
-     * @param culture           An optional query parameter used to indicate the locale that should be used for formatting.
-     *                          The value should be a standard language tag.
-     * @param select            Limits the properties returned in the result.
-     * @return WFieldInfo The return value
+     *  @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
+     *  @return WFieldInfo The return value
      */
-    WFieldInfo getFieldDefinitionById(String repoId, Integer fieldDefinitionId, String culture, String select);
+    WFieldInfo getFieldDefinitionById(ParametersForGetFieldDefinitionById parameters);
 
     /**
-     * - Returns a paged listing of field definitions available in the specified repository.
+     *  - Returns a paged listing of field definitions available in the specified repository.
      * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId  The requested repository ID.
-     * @param prefer  An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture An optional query parameter used to indicate the locale that should be used for formatting.
-     *                The value should be a standard language tag.
-     * @param select  Limits the properties returned in the result.
-     * @param orderby Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top     Limits the number of items returned from a collection.
-     * @param skip    Excludes the specified number of items of the queried collection from the result.
-     * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfWFieldInfo The return value
+     *  @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
+     *  @return ODataValueContextOfIListOfWFieldInfo The return value
      */
-    ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(String repoId, String prefer, String culture,
-            String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(ParametersForGetFieldDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWFieldInfo The return value
      */
-    ODataValueContextOfIListOfWFieldInfo getFieldDefinitionsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfWFieldInfo getFieldDefinitionsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture     An optional query parameter used to indicate the locale that should be used for formatting.
-     *                    The value should be a standard language tag.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count);
+    void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetFieldDefinitions parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface LinkDefinitionsClient {
 
     /**
-     *  - Returns a single link definition associated with the specified ID.
+     * - Returns a single link definition associated with the specified ID.
      * - Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.
      * - Allowed OData query options: Select
      *
@@ -38,7 +38,7 @@ public interface LinkDefinitionsClient {
     EntryLinkTypeInfo getLinkDefinitionById(ParametersForGetLinkDefinitionById parameters);
 
     /**
-     *  - Returns the link definitions in the repository.
+     * - Returns the link definitions in the repository.
      * - Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -1,29 +1,11 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
+import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefinitions;
+
 import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
 
 public interface LinkDefinitionsClient {
 
@@ -32,8 +14,8 @@ public interface LinkDefinitionsClient {
      * - Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetLinkDefinitionById which encapsulates the parameters of getLinkDefinitionById method.
-     *  @return EntryLinkTypeInfo The return value
+     * @param parameters An object of type ParametersForGetLinkDefinitionById which encapsulates the parameters of getLinkDefinitionById method.
+     * @return EntryLinkTypeInfo The return value
      */
     EntryLinkTypeInfo getLinkDefinitionById(ParametersForGetLinkDefinitionById parameters);
 
@@ -42,15 +24,15 @@ public interface LinkDefinitionsClient {
      * - Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetLinkDefinitions which encapsulates the parameters of getLinkDefinitions method.
-     *  @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
+     * @param parameters An object of type ParametersForGetLinkDefinitions which encapsulates the parameters of getLinkDefinitions method.
+     * @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
      */
     ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitions(ParametersForGetLinkDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
      */
@@ -59,8 +41,9 @@ public interface LinkDefinitionsClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkDefinitions parameters);
+    void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetLinkDefinitions parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -1,64 +1,66 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface LinkDefinitionsClient {
 
     /**
-     * - Returns a single link definition associated with the specified ID.
+     *  - Returns a single link definition associated with the specified ID.
      * - Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.
      * - Allowed OData query options: Select
      *
-     * @param repoId     The requested repository ID.
-     * @param linkTypeId The requested link type ID.
-     * @param select     Limits the properties returned in the result.
-     * @return EntryLinkTypeInfo The return value
+     *  @param parameters An object of type ParametersForGetLinkDefinitionById which encapsulates the parameters of getLinkDefinitionById method.
+     *  @return EntryLinkTypeInfo The return value
      */
-    EntryLinkTypeInfo getLinkDefinitionById(String repoId, Integer linkTypeId, String select);
+    EntryLinkTypeInfo getLinkDefinitionById(ParametersForGetLinkDefinitionById parameters);
 
     /**
-     * - Returns the link definitions in the repository.
+     *  - Returns the link definitions in the repository.
      * - Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId  The requested repository ID.
-     * @param prefer  An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select  Limits the properties returned in the result.
-     * @param orderby Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top     Limits the number of items returned from a collection.
-     * @param skip    Excludes the specified number of items of the queried collection from the result.
-     * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
+     *  @param parameters An object of type ParametersForGetLinkDefinitions which encapsulates the parameters of getLinkDefinitions method.
+     *  @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
      */
-    ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitions(String repoId, String prefer, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitions(ParametersForGetLinkDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
      */
-    ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitionsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitionsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getLinkDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String prefer, String select, String orderby, Integer top, Integer skip,
-            Boolean count);
+    void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkDefinitions parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
@@ -1,29 +1,6 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 
 public interface RepositoriesClient {
 

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
@@ -1,6 +1,29 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface RepositoriesClient {
 

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -1,29 +1,9 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
 import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.laserfiche.repository.api.clients.params.*;
+
+import java.util.function.Function;
 
 public interface SearchesClient {
 
@@ -32,8 +12,8 @@ public interface SearchesClient {
      * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
      * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
      *
-     *  @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
-     *  @return OperationProgress The return value
+     * @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
+     * @return OperationProgress The return value
      */
     OperationProgress getSearchStatus(ParametersForGetSearchStatus parameters);
 
@@ -41,8 +21,8 @@ public interface SearchesClient {
      * - Cancels a currently running search.
      * - Closes a completed search.
      *
-     *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
+     * @return ODataValueOfBoolean The return value
      */
     ODataValueOfBoolean cancelOrCloseSearch(ParametersForCancelOrCloseSearch parameters);
 
@@ -51,15 +31,15 @@ public interface SearchesClient {
      * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
-     *  @return ODataValueContextOfIListOfContextHit The return value
+     * @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
+     * @return ODataValueContextOfIListOfContextHit The return value
      */
     ODataValueContextOfIListOfContextHit getSearchContextHits(ParametersForGetSearchContextHits parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfContextHit The return value
      */
@@ -68,17 +48,18 @@ public interface SearchesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchContextHits&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback, Integer maxPageSize, ParametersForGetSearchContextHits parameters);
+    void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback,
+            Integer maxPageSize, ParametersForGetSearchContextHits parameters);
 
     /**
      * - Runs a search operation on the repository.
      * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
      *
-     *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
+     * @return AcceptedOperation The return value
      */
     AcceptedOperation createSearchOperation(ParametersForCreateSearchOperation parameters);
 
@@ -91,15 +72,15 @@ public interface SearchesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     ODataValueContextOfIListOfEntry getSearchResults(ParametersForGetSearchResults parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntry The return value
      */
@@ -108,8 +89,9 @@ public interface SearchesClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchResults&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetSearchResults parameters);
+    void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
+            ParametersForGetSearchResults parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface SearchesClient {
 
     /**
-     *  - Returns search status.
+     * - Returns search status.
      * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
      * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
      *
@@ -38,7 +38,7 @@ public interface SearchesClient {
     OperationProgress getSearchStatus(ParametersForGetSearchStatus parameters);
 
     /**
-     *  - Cancels a currently running search.
+     * - Cancels a currently running search.
      * - Closes a completed search.
      *
      *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
@@ -47,7 +47,7 @@ public interface SearchesClient {
     ODataValueOfBoolean cancelOrCloseSearch(ParametersForCancelOrCloseSearch parameters);
 
     /**
-     *  - Returns the context hits associated with a search result entry.
+     * - Returns the context hits associated with a search result entry.
      * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -74,7 +74,7 @@ public interface SearchesClient {
     void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback, Integer maxPageSize, ParametersForGetSearchContextHits parameters);
 
     /**
-     *  - Runs a search operation on the repository.
+     * - Runs a search operation on the repository.
      * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
      *
      *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
@@ -83,7 +83,7 @@ public interface SearchesClient {
     AcceptedOperation createSearchOperation(ParametersForCreateSearchOperation parameters);
 
     /**
-     *  - Returns a search result listing if the search is completed.
+     * - Returns a search result listing if the search is completed.
      * - Optional query parameter: groupByOrderType (default false). This query parameter decides whether or not results are returned in groups based on their entry type.
      * - Optional query parameter: refresh (default false). If the search listing should be refreshed to show updated values.
      * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. sort order can be either &quot;asc&quot; or &quot;desc&quot;. Search results expire after 5 minutes, but can be refreshed by retrieving the results again.

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -1,91 +1,89 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface SearchesClient {
 
     /**
-     * - Returns search status.
+     *  - Returns search status.
      * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
      * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
      *
-     * @param repoId      The requested repository ID.
-     * @param searchToken The requested searchToken.
-     * @return OperationProgress The return value
+     *  @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
+     *  @return OperationProgress The return value
      */
-    OperationProgress getSearchStatus(String repoId, String searchToken);
+    OperationProgress getSearchStatus(ParametersForGetSearchStatus parameters);
 
     /**
-     * - Cancels a currently running search.
+     *  - Cancels a currently running search.
      * - Closes a completed search.
      *
-     * @param repoId      The requested repository ID.
-     * @param searchToken The requested searchToken.
-     * @return ODataValueOfBoolean The return value
+     *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
+     *  @return ODataValueOfBoolean The return value
      */
-    ODataValueOfBoolean cancelOrCloseSearch(String repoId, String searchToken);
+    ODataValueOfBoolean cancelOrCloseSearch(ParametersForCancelOrCloseSearch parameters);
 
     /**
-     * - Returns the context hits associated with a search result entry.
+     *  - Returns the context hits associated with a search result entry.
      * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId      The requested repository ID.
-     * @param searchToken The requested searchToken.
-     * @param rowNumber   The search result listing row number to get context hits for.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfContextHit The return value
+     *  @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
+     *  @return ODataValueContextOfIListOfContextHit The return value
      */
-    ODataValueContextOfIListOfContextHit getSearchContextHits(String repoId, String searchToken, Integer rowNumber,
-            String prefer, String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfContextHit getSearchContextHits(ParametersForGetSearchContextHits parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfContextHit The return value
      */
-    ODataValueContextOfIListOfContextHit getSearchContextHitsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfContextHit getSearchContextHitsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchContextHits&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param searchToken The requested searchToken.
-     * @param rowNumber   The search result listing row number to get context hits for.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback,
-            Integer maxPageSize, String repoId, String searchToken, Integer rowNumber, String prefer, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback, Integer maxPageSize, ParametersForGetSearchContextHits parameters);
 
     /**
-     * - Runs a search operation on the repository.
+     *  - Runs a search operation on the repository.
      * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
      *
-     * @param repoId      The requested repository ID.
-     * @param requestBody The Laserfiche search command to run, optionally include fuzzy search settings.
-     * @return AcceptedOperation The return value
+     *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
+     *  @return AcceptedOperation The return value
      */
-    AcceptedOperation createSearchOperation(String repoId, AdvancedSearchRequest requestBody);
+    AcceptedOperation createSearchOperation(ParametersForCreateSearchOperation parameters);
 
     /**
-     * - Returns a search result listing if the search is completed.
+     *  - Returns a search result listing if the search is completed.
      * - Optional query parameter: groupByOrderType (default false). This query parameter decides whether or not results are returned in groups based on their entry type.
      * - Optional query parameter: refresh (default false). If the search listing should be refreshed to show updated values.
      * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. sort order can be either &quot;asc&quot; or &quot;desc&quot;. Search results expire after 5 minutes, but can be refreshed by retrieving the results again.
@@ -93,59 +91,25 @@ public interface SearchesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     * @param repoId           The requested repository ID.
-     * @param searchToken      The requested searchToken.
-     * @param groupByEntryType An optional query parameter used to indicate if the result should be grouped by entry type or not.
-     * @param refresh          If the search listing should be refreshed to show updated values.
-     * @param fields           Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
-     * @param formatFields     Boolean for if field values should be formatted. Only applicable if Fields are specified.
-     * @param prefer           An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture          An optional query parameter used to indicate the locale that should be used for formatting.
-     *                         The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *                         culture will not be used for formatting.
-     * @param select           Limits the properties returned in the result.
-     * @param orderby          Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top              Limits the number of items returned from a collection.
-     * @param skip             Excludes the specified number of items of the queried collection from the result.
-     * @param count            Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfEntry The return value
+     *  @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
+     *  @return ODataValueContextOfIListOfEntry The return value
      */
-    ODataValueContextOfIListOfEntry getSearchResults(String repoId, String searchToken, Boolean groupByEntryType,
-            Boolean refresh, String[] fields, Boolean formatFields, String prefer, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfEntry getSearchResults(ParametersForGetSearchResults parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfEntry The return value
      */
-    ODataValueContextOfIListOfEntry getSearchResultsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfEntry getSearchResultsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getSearchResults&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback         A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
-     * @param maxPageSize      Optionally specify the maximum number of items to retrieve.
-     * @param repoId           The requested repository ID.
-     * @param searchToken      The requested searchToken.
-     * @param groupByEntryType An optional query parameter used to indicate if the result should be grouped by entry type or not.
-     * @param refresh          If the search listing should be refreshed to show updated values.
-     * @param fields           Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
-     * @param formatFields     Boolean for if field values should be formatted. Only applicable if Fields are specified.
-     * @param prefer           An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture          An optional query parameter used to indicate the locale that should be used for formatting.
-     *                         The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *                         culture will not be used for formatting.
-     * @param select           Limits the properties returned in the result.
-     * @param orderby          Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top              Limits the number of items returned from a collection.
-     * @param skip             Excludes the specified number of items of the queried collection from the result.
-     * @param count            Indicates whether the total count of items within a collection are returned in the result.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
-            String repoId, String searchToken, Boolean groupByEntryType, Boolean refresh, String[] fields,
-            Boolean formatFields, String prefer, String culture, String select, String orderby, Integer top,
-            Integer skip, Boolean count);
+    void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetSearchResults parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -1,38 +1,60 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface ServerSessionClient {
 
     /**
-     * - Deprecated.
+     *  - Deprecated.
      * - Invalidates the server session.
      * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
      *
-     * @param repoId The requested repository ID.
-     * @return ODataValueOfBoolean The return value
+     *  @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
+     *  @return ODataValueOfBoolean The return value
      */
-    ODataValueOfBoolean invalidateServerSession(String repoId);
+    ODataValueOfBoolean invalidateServerSession(ParametersForInvalidateServerSession parameters);
 
     /**
-     * - Deprecated. This function is a no-op, always returns 200.
+     *  - Deprecated. This function is a no-op, always returns 200.
      * - Only available in Laserfiche Cloud.
      *
-     * @param repoId The requested repository ID.
-     * @return ODataValueOfBoolean The return value
+     *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
+     *  @return ODataValueOfBoolean The return value
      */
-    ODataValueOfBoolean createServerSession(String repoId);
+    ODataValueOfBoolean createServerSession(ParametersForCreateServerSession parameters);
 
     /**
-     * - Deprecated.
+     *  - Deprecated.
      * - Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.
      * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
      * - Only available in Laserfiche Cloud.
      *
-     * @param repoId The requested repository ID.
-     * @return ODataValueOfDateTime The return value
+     *  @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
+     *  @return ODataValueOfDateTime The return value
      */
-    ODataValueOfDateTime refreshServerSession(String repoId);
+    ODataValueOfDateTime refreshServerSession(ParametersForRefreshServerSession parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface ServerSessionClient {
 
     /**
-     *  - Deprecated.
+     * - Deprecated.
      * - Invalidates the server session.
      * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
@@ -39,7 +39,7 @@ public interface ServerSessionClient {
     ODataValueOfBoolean invalidateServerSession(ParametersForInvalidateServerSession parameters);
 
     /**
-     *  - Deprecated. This function is a no-op, always returns 200.
+     * - Deprecated. This function is a no-op, always returns 200.
      * - Only available in Laserfiche Cloud.
      *
      *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
@@ -48,7 +48,7 @@ public interface ServerSessionClient {
     ODataValueOfBoolean createServerSession(ParametersForCreateServerSession parameters);
 
     /**
-     *  - Deprecated.
+     * - Deprecated.
      * - Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.
      * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
      * - Only available in Laserfiche Cloud.

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -1,29 +1,10 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateServerSession;
+import com.laserfiche.repository.api.clients.params.ParametersForInvalidateServerSession;
+import com.laserfiche.repository.api.clients.params.ParametersForRefreshServerSession;
 
 public interface ServerSessionClient {
 
@@ -33,8 +14,8 @@ public interface ServerSessionClient {
      * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
+     * @return ODataValueOfBoolean The return value
      */
     ODataValueOfBoolean invalidateServerSession(ParametersForInvalidateServerSession parameters);
 
@@ -42,8 +23,8 @@ public interface ServerSessionClient {
      * - Deprecated. This function is a no-op, always returns 200.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
+     * @return ODataValueOfBoolean The return value
      */
     ODataValueOfBoolean createServerSession(ParametersForCreateServerSession parameters);
 
@@ -53,8 +34,8 @@ public interface ServerSessionClient {
      * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
-     *  @return ODataValueOfDateTime The return value
+     * @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
+     * @return ODataValueOfDateTime The return value
      */
     ODataValueOfDateTime refreshServerSession(ParametersForRefreshServerSession parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface SimpleSearchesClient {
 
     /**
-     *  - Runs a &quot;simple&quot; search operation on the repository.
+     * - Runs a &quot;simple&quot; search operation on the repository.
      * - Returns a truncated search result listing.
      * - Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.
      * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,29 +1,7 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateSimpleSearchOperation;
 
 public interface SimpleSearchesClient {
 
@@ -35,8 +13,8 @@ public interface SimpleSearchesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     ODataValueContextOfIListOfEntry createSimpleSearchOperation(ParametersForCreateSimpleSearchOperation parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,30 +1,42 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
-import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface SimpleSearchesClient {
 
     /**
-     * - Runs a &quot;simple&quot; search operation on the repository.
+     *  - Runs a &quot;simple&quot; search operation on the repository.
      * - Returns a truncated search result listing.
      * - Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.
      * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     * @param select       Limits the properties returned in the result.
-     * @param orderby      Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @param repoId       The requested repository ID.
-     * @param fields       Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
-     * @param formatFields Boolean for if field values should be formatted. Only applicable if Fields are specified.
-     * @param requestBody  The Laserfiche search command to run.
-     * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
-     *                     The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *                     culture will not be used for formatting.
-     * @return ODataValueContextOfIListOfEntry The return value
+     *  @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
+     *  @return ODataValueContextOfIListOfEntry The return value
      */
-    ODataValueContextOfIListOfEntry createSimpleSearchOperation(String select, String orderby, Boolean count,
-            String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody, String culture);
+    ODataValueContextOfIListOfEntry createSimpleSearchOperation(ParametersForCreateSimpleSearchOperation parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface TagDefinitionsClient {
 
     /**
-     *  - Returns all tag definitions in the repository.
+     * - Returns all tag definitions in the repository.
      * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -55,7 +55,7 @@ public interface TagDefinitionsClient {
     void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagDefinitions parameters);
 
     /**
-     *  - Returns a single tag definition.
+     * - Returns a single tag definition.
      * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
      * - Allowed OData query options: Select
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -1,70 +1,66 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
-import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface TagDefinitionsClient {
 
     /**
-     * - Returns all tag definitions in the repository.
+     *  - Returns all tag definitions in the repository.
      * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId  The requested repository ID.
-     * @param prefer  An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture An optional query parameter used to indicate the locale that should be used for formatting.
-     *                The value should be a standard language tag.
-     * @param select  Limits the properties returned in the result.
-     * @param orderby Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top     Limits the number of items returned from a collection.
-     * @param skip    Excludes the specified number of items of the queried collection from the result.
-     * @param count   Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfWTagInfo The return value
+     *  @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
+     *  @return ODataValueContextOfIListOfWTagInfo The return value
      */
-    ODataValueContextOfIListOfWTagInfo getTagDefinitions(String repoId, String prefer, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfWTagInfo getTagDefinitions(ParametersForGetTagDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTagInfo The return value
      */
-    ODataValueContextOfIListOfWTagInfo getTagDefinitionsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfWTagInfo getTagDefinitionsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture     An optional query parameter used to indicate the locale that should be used for formatting.
-     *                    The value should be a standard language tag.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize,
-            String repoId, String prefer, String culture, String select, String orderby, Integer top, Integer skip,
-            Boolean count);
+    void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagDefinitions parameters);
 
     /**
-     * - Returns a single tag definition.
+     *  - Returns a single tag definition.
      * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
      * - Allowed OData query options: Select
      *
-     * @param repoId  The requested repository ID.
-     * @param tagId   The requested tag definition ID.
-     * @param culture An optional query parameter used to indicate the locale that should be used for formatting.
-     *                The value should be a standard language tag.
-     * @param select  Limits the properties returned in the result.
-     * @return WTagInfo The return value
+     *  @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
+     *  @return WTagInfo The return value
      */
-    WTagInfo getTagDefinitionById(String repoId, Integer tagId, String culture, String select);
+    WTagInfo getTagDefinitionById(ParametersForGetTagDefinitionById parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -1,29 +1,11 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
+import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitions;
+
 import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
 
 public interface TagDefinitionsClient {
 
@@ -32,15 +14,15 @@ public interface TagDefinitionsClient {
      * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
-     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
+     * @return ODataValueContextOfIListOfWTagInfo The return value
      */
     ODataValueContextOfIListOfWTagInfo getTagDefinitions(ParametersForGetTagDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTagInfo The return value
      */
@@ -49,18 +31,19 @@ public interface TagDefinitionsClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTagDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagDefinitions parameters);
+    void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize,
+            ParametersForGetTagDefinitions parameters);
 
     /**
      * - Returns a single tag definition.
      * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
-     *  @return WTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
+     * @return WTagInfo The return value
      */
     WTagInfo getTagDefinitionById(ParametersForGetTagDefinitionById parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -1,28 +1,49 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.OperationProgress;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface TasksClient {
 
     /**
-     * - Returns the status of an operation.
+     *  - Returns the status of an operation.
      * - Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).
      * - OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
      *
-     * @param repoId         The requested repository ID
-     * @param operationToken The operation token
-     * @return OperationProgress The return value
+     *  @param parameters An object of type ParametersForGetOperationStatusAndProgress which encapsulates the parameters of getOperationStatusAndProgress method.
+     *  @return OperationProgress The return value
      */
-    OperationProgress getOperationStatusAndProgress(String repoId, String operationToken);
+    OperationProgress getOperationStatusAndProgress(ParametersForGetOperationStatusAndProgress parameters);
 
     /**
-     * - Cancels an operation.
+     *  - Cancels an operation.
      * - Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.
      * - Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
      *
-     * @param repoId         The requested repository ID
-     * @param operationToken The operation token
-     * @return Boolean The return value
+     *  @param parameters An object of type ParametersForCancelOperation which encapsulates the parameters of cancelOperation method.
+     *  @return boolean The return value
      */
-    Boolean cancelOperation(String repoId, String operationToken);
+    boolean cancelOperation(ParametersForCancelOperation parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -1,29 +1,8 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.impl.model.OperationProgress;
+import com.laserfiche.repository.api.clients.params.ParametersForCancelOperation;
+import com.laserfiche.repository.api.clients.params.ParametersForGetOperationStatusAndProgress;
 
 public interface TasksClient {
 
@@ -32,8 +11,8 @@ public interface TasksClient {
      * - Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).
      * - OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
      *
-     *  @param parameters An object of type ParametersForGetOperationStatusAndProgress which encapsulates the parameters of getOperationStatusAndProgress method.
-     *  @return OperationProgress The return value
+     * @param parameters An object of type ParametersForGetOperationStatusAndProgress which encapsulates the parameters of getOperationStatusAndProgress method.
+     * @return OperationProgress The return value
      */
     OperationProgress getOperationStatusAndProgress(ParametersForGetOperationStatusAndProgress parameters);
 
@@ -42,8 +21,8 @@ public interface TasksClient {
      * - Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.
      * - Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
      *
-     *  @param parameters An object of type ParametersForCancelOperation which encapsulates the parameters of cancelOperation method.
-     *  @return boolean The return value
+     * @param parameters An object of type ParametersForCancelOperation which encapsulates the parameters of cancelOperation method.
+     * @return boolean The return value
      */
     boolean cancelOperation(ParametersForCancelOperation parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface TasksClient {
 
     /**
-     *  - Returns the status of an operation.
+     * - Returns the status of an operation.
      * - Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).
      * - OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
      *
@@ -38,7 +38,7 @@ public interface TasksClient {
     OperationProgress getOperationStatusAndProgress(ParametersForGetOperationStatusAndProgress parameters);
 
     /**
-     *  - Cancels an operation.
+     * - Cancels an operation.
      * - Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.
      * - Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -1,29 +1,14 @@
 package com.laserfiche.repository.api.clients;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfTemplateFieldInfo;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTemplateInfo;
+import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitionsByTemplateName;
+
 import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
-import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
 
 public interface TemplateDefinitionsClient {
 
@@ -32,15 +17,15 @@ public interface TemplateDefinitionsClient {
      * - Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateDefinitions which encapsulates the parameters of getTemplateDefinitions method.
-     *  @return ODataValueContextOfIListOfWTemplateInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateDefinitions which encapsulates the parameters of getTemplateDefinitions method.
+     * @return ODataValueContextOfIListOfWTemplateInfo The return value
      */
     ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitions(ParametersForGetTemplateDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTemplateInfo The return value
      */
@@ -49,52 +34,58 @@ public interface TemplateDefinitionsClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateDefinitions parameters);
+    void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTemplateDefinitions parameters);
 
     /**
      * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition name, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitionsByTemplateName which encapsulates the parameters of getTemplateFieldDefinitionsByTemplateName method.
-     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateFieldDefinitionsByTemplateName which encapsulates the parameters of getTemplateFieldDefinitionsByTemplateName method.
+     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(
+            ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(String nextLink, int maxPageSize);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(String nextLink,
+            int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitionsByTemplateName&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTemplateFieldDefinitionsByTemplateNameForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
+    void getTemplateFieldDefinitionsByTemplateNameForEach(
+            Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize,
+            ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
 
     /**
      * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitions which encapsulates the parameters of getTemplateFieldDefinitions method.
-     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateFieldDefinitions which encapsulates the parameters of getTemplateFieldDefinitions method.
+     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(ParametersForGetTemplateFieldDefinitions parameters);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(
+            ParametersForGetTemplateFieldDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
@@ -103,18 +94,19 @@ public interface TemplateDefinitionsClient {
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitions parameters);
+    void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTemplateFieldDefinitions parameters);
 
     /**
      * - Returns a single template definition (including field definitions, if relevant).
      * - Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetTemplateDefinitionById which encapsulates the parameters of getTemplateDefinitionById method.
-     *  @return WTemplateInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateDefinitionById which encapsulates the parameters of getTemplateDefinitionById method.
+     * @return WTemplateInfo The return value
      */
     WTemplateInfo getTemplateDefinitionById(ParametersForGetTemplateDefinitionById parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -1,175 +1,120 @@
 package com.laserfiche.repository.api.clients;
 
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfTemplateFieldInfo;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTemplateInfo;
-import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
-
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
 
 public interface TemplateDefinitionsClient {
 
     /**
-     * - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
+     *  - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
      * - Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId       The requested repository ID.
-     * @param templateName An optional query parameter. Can be used to get a single template definition using the template name.
-     * @param prefer       An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
-     *                     The value should be a standard language tag.
-     * @param select       Limits the properties returned in the result.
-     * @param orderby      Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top          Limits the number of items returned from a collection.
-     * @param skip         Excludes the specified number of items of the queried collection from the result.
-     * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfWTemplateInfo The return value
+     *  @param parameters An object of type ParametersForGetTemplateDefinitions which encapsulates the parameters of getTemplateDefinitions method.
+     *  @return ODataValueContextOfIListOfWTemplateInfo The return value
      */
-    ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitions(String repoId, String templateName, String prefer,
-            String culture, String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitions(ParametersForGetTemplateDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfWTemplateInfo The return value
      */
-    ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitionsNextLink(String nextLink, Integer maxPageSize);
+    ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitionsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback     A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
-     * @param maxPageSize  Optionally specify the maximum number of items to retrieve.
-     * @param repoId       The requested repository ID.
-     * @param templateName An optional query parameter. Can be used to get a single template definition using the template name.
-     * @param prefer       An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
-     *                     The value should be a standard language tag.
-     * @param select       Limits the properties returned in the result.
-     * @param orderby      Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top          Limits the number of items returned from a collection.
-     * @param skip         Excludes the specified number of items of the queried collection from the result.
-     * @param count        Indicates whether the total count of items within a collection are returned in the result.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String templateName, String prefer, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateDefinitions parameters);
 
     /**
-     * - Returns the field definitions assigned to a template definition.
+     *  - Returns the field definitions assigned to a template definition.
      * - Provide a template definition name, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId       The requested repository ID.
-     * @param templateName A required query parameter for the requested template name.
-     * @param prefer       An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
-     *                     The value should be a standard language tag.
-     * @param select       Limits the properties returned in the result.
-     * @param orderby      Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top          Limits the number of items returned from a collection.
-     * @param skip         Excludes the specified number of items of the queried collection from the result.
-     * @param count        Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitionsByTemplateName which encapsulates the parameters of getTemplateFieldDefinitionsByTemplateName method.
+     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(String repoId,
-            String templateName, String prefer, String culture, String select, String orderby, Integer top,
-            Integer skip, Boolean count);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(String nextLink,
-            Integer maxPageSize);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitionsByTemplateName&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback     A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
-     * @param maxPageSize  Optionally specify the maximum number of items to retrieve.
-     * @param repoId       The requested repository ID.
-     * @param templateName A required query parameter for the requested template name.
-     * @param prefer       An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture      An optional query parameter used to indicate the locale that should be used for formatting.
-     *                     The value should be a standard language tag.
-     * @param select       Limits the properties returned in the result.
-     * @param orderby      Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top          Limits the number of items returned from a collection.
-     * @param skip         Excludes the specified number of items of the queried collection from the result.
-     * @param count        Indicates whether the total count of items within a collection are returned in the result.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      */
-    void getTemplateFieldDefinitionsByTemplateNameForEach(
-            Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, String repoId,
-            String templateName, String prefer, String culture, String select, String orderby, Integer top,
-            Integer skip, Boolean count);
+    void getTemplateFieldDefinitionsByTemplateNameForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
 
     /**
-     * - Returns the field definitions assigned to a template definition.
+     *  - Returns the field definitions assigned to a template definition.
      * - Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     * @param repoId     The requested repository ID.
-     * @param templateId The requested template definition ID.
-     * @param prefer     An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture    An optional query parameter used to indicate the locale that should be used for formatting.
-     *                   The value should be a standard language tag.
-     * @param select     Limits the properties returned in the result.
-     * @param orderby    Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top        Limits the number of items returned from a collection.
-     * @param skip       Excludes the specified number of items of the queried collection from the result.
-     * @param count      Indicates whether the total count of items within a collection are returned in the result.
-     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitions which encapsulates the parameters of getTemplateFieldDefinitions method.
+     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(String repoId, Integer templateId,
-            String prefer, String culture, String select, String orderby, Integer top, Integer skip, Boolean count);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(ParametersForGetTemplateFieldDefinitions parameters);
 
     /**
      * Returns the next subset of the requested collection, using a nextlink url.
      *
-     * @param nextLink    A url that allows retrieving the next subset of the requested collection.
+     * @param nextLink A url that allows retrieving the next subset of the requested collection.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
      * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
-    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsNextLink(String nextLink,
-            Integer maxPageSize);
+    ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsNextLink(String nextLink, int maxPageSize);
 
     /**
      * Provides the functionality to iteratively (i.e. through paging) call &lt;b&gt;getTemplateFieldDefinitions&lt;/b&gt;, and apply a function on the response of each iteration.
      *
-     * @param callback    A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
+     * @param callback A delegate that will be called each time new data is retrieved. Returns false to stop receiving more data; returns true to be called again if there's more data.
      * @param maxPageSize Optionally specify the maximum number of items to retrieve.
-     * @param repoId      The requested repository ID.
-     * @param templateId  The requested template definition ID.
-     * @param prefer      An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
-     * @param culture     An optional query parameter used to indicate the locale that should be used for formatting.
-     *                    The value should be a standard language tag.
-     * @param select      Limits the properties returned in the result.
-     * @param orderby     Specifies the order in which items are returned. The maximum number of expressions is 5.
-     * @param top         Limits the number of items returned from a collection.
-     * @param skip        Excludes the specified number of items of the queried collection from the result.
-     * @param count       Indicates whether the total count of items within a collection are returned in the result.
      */
-    void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer templateId, String prefer, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count);
+    void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitions parameters);
 
     /**
-     * - Returns a single template definition (including field definitions, if relevant).
+     *  - Returns a single template definition (including field definitions, if relevant).
      * - Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.
      * - Allowed OData query options: Select
      *
-     * @param repoId     The requested repository ID.
-     * @param templateId The requested template definition ID.
-     * @param culture    An optional query parameter used to indicate the locale that should be used for formatting.
-     *                   The value should be a standard language tag.
-     * @param select     Limits the properties returned in the result.
-     * @return WTemplateInfo The return value
+     *  @param parameters An object of type ParametersForGetTemplateDefinitionById which encapsulates the parameters of getTemplateDefinitionById method.
+     *  @return WTemplateInfo The return value
      */
-    WTemplateInfo getTemplateDefinitionById(String repoId, Integer templateId, String culture, String select);
+    WTemplateInfo getTemplateDefinitionById(ParametersForGetTemplateDefinitionById parameters);
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -28,7 +28,7 @@ import com.laserfiche.repository.api.clients.params.*;
 public interface TemplateDefinitionsClient {
 
     /**
-     *  - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
+     * - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
      * - Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -55,7 +55,7 @@ public interface TemplateDefinitionsClient {
     void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateDefinitions parameters);
 
     /**
-     *  - Returns the field definitions assigned to a template definition.
+     * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition name, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -82,7 +82,7 @@ public interface TemplateDefinitionsClient {
     void getTemplateFieldDefinitionsByTemplateNameForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitionsByTemplateName parameters);
 
     /**
-     *  - Returns the field definitions assigned to a template definition.
+     * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -109,7 +109,7 @@ public interface TemplateDefinitionsClient {
     void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitions parameters);
 
     /**
-     *  - Returns a single template definition (including field definitions, if relevant).
+     * - Returns a single template definition (including field definitions, if relevant).
      * - Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.
      * - Allowed OData query options: Select
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -1,23 +1,23 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.MapperFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.laserfiche.repository.api.clients.impl.deserialization.OffsetDateTimeDeserializer;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
 import kong.unirest.Header;
 import kong.unirest.Headers;
-import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
 import org.threeten.bp.OffsetDateTime;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.module.SimpleModule;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import com.laserfiche.repository.api.clients.impl.deserialization.OffsetDateTimeDeserializer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 public class ApiClient {
 
@@ -32,22 +32,31 @@ public class ApiClient {
         this.httpClient = httpClient;
         SimpleModule module = new SimpleModule();
         module.addDeserializer(OffsetDateTime.class, new OffsetDateTimeDeserializer());
-        this.objectMapper = JsonMapper.builder().addModule(module).disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS).disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES).enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS).build();
+        this.objectMapper = JsonMapper
+                .builder()
+                .addModule(module)
+                .disable(MapperFeature.CAN_OVERRIDE_ACCESS_MODIFIERS)
+                .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+                .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS)
+                .build();
     }
 
     protected String mergeMaxSizeIntoPrefer(int maxSize, String prefer) {
         if (maxSize == 0)
             return prefer;
         else
-            return prefer == null ? String.format("maxpagesize=%d", maxSize) : String.format("%s; maxpagesize=%d", prefer, maxSize);
+            return prefer == null ? String.format("maxpagesize=%d", maxSize) : String.format("%s; maxpagesize=%d",
+                    prefer, maxSize);
     }
 
-    protected Map<String, Object> getParametersWithNonDefaultValue(String[] parameterTypes, String[] parameterNames, Object[] parameterValues) {
+    protected Map<String, Object> getParametersWithNonDefaultValue(String[] parameterTypes, String[] parameterNames,
+            Object[] parameterValues) {
         if (parameterTypes == null || parameterNames == null || parameterValues == null) {
             throw new IllegalArgumentException("Input cannot be null.");
         }
         if (parameterTypes.length != parameterNames.length || parameterNames.length != parameterValues.length) {
-            throw new IllegalArgumentException("The arrays for parameter types/names/values should have the same length.");
+            throw new IllegalArgumentException(
+                    "The arrays for parameter types/names/values should have the same length.");
         }
         Map<String, Object> paramKeyValuePairs = new HashMap<>();
         for (int i = 0; i < parameterValues.length; i++) {
@@ -72,11 +81,15 @@ public class ApiClient {
     }
 
     private boolean hasDefaultValue(String type, Object value) {
-        switch(type) {
+        switch (type) {
             case "int":
-                return value.toString().equals("0");
+                return value
+                        .toString()
+                        .equals("0");
             case "boolean":
-                return value.toString().equals("false");
+                return value
+                        .toString()
+                        .equals("false");
         }
         return false;
     }
@@ -92,25 +105,41 @@ public class ApiClient {
     }
 
     protected Map<String, String> getHeadersMap(Headers headers) {
-        return headers.all().stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+        return headers
+                .all()
+                .stream()
+                .collect(Collectors.toMap(Header::getName, Header::getValue));
     }
 
     protected ProblemDetails deserializeToProblemDetails(String jsonString) throws JsonProcessingException {
         ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
         if (problemDetails.get("title") != null)
-            problemDetails.setTitle(problemDetails.get("title").toString());
+            problemDetails.setTitle(problemDetails
+                    .get("title")
+                    .toString());
         if (problemDetails.get("type") != null)
-            problemDetails.setType(problemDetails.get("type").toString());
+            problemDetails.setType(problemDetails
+                    .get("type")
+                    .toString());
         if (problemDetails.get("instance") != null)
-            problemDetails.setInstance(problemDetails.get("instance").toString());
+            problemDetails.setInstance(problemDetails
+                    .get("instance")
+                    .toString());
         if (problemDetails.get("detail") != null)
-            problemDetails.setDetail(problemDetails.get("detail").toString());
-        problemDetails.setStatus((int)Double.parseDouble(problemDetails.get("status").toString()));
+            problemDetails.setDetail(problemDetails
+                    .get("detail")
+                    .toString());
+        problemDetails.setStatus(Integer.parseInt(problemDetails
+                .get("status")
+                .toString()));
         problemDetails.setExtensions((Map<String, Object>) problemDetails.get("extensions"));
         return problemDetails;
     }
 
     protected String decideErrorMessage(ProblemDetails problemDetails, String genericErrorMessage) {
-        return (problemDetails != null && problemDetails.getTitle() != null && problemDetails.getTitle().trim().length() > 0) ? problemDetails.getTitle() : genericErrorMessage;
+        return (problemDetails != null && problemDetails.getTitle() != null && problemDetails
+                .getTitle()
+                .trim()
+                .length() > 0) ? problemDetails.getTitle() : genericErrorMessage;
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,30 +1,21 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.AttributesClient;
+import com.laserfiche.repository.api.clients.impl.model.Attribute;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeKeyValuePairs;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeValueByKey;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.AttributesClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class AttributesClientImpl extends ApiClient implements AttributesClient {
 
@@ -36,14 +27,21 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
      * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
-     *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
-     *  @return Attribute The return value
+     * @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
+     * @return Attribute The return value
      */
     @Override
     public Attribute getTrusteeAttributeValueByKey(ParametersForGetTrusteeAttributeValueByKey parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean" }, new String[] { "everyone" }, new Object[] { parameters.isEveryone() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "attributeKey" }, new Object[] { parameters.getRepoId(), parameters.getAttributeKey() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Attributes/{attributeKey}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"boolean"},
+                new String[]{"everyone"}, new Object[]{parameters.isEveryone()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "attributeKey"},
+                new Object[]{parameters.getRepoId(), parameters.getAttributeKey()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/Attributes/{attributeKey}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -61,18 +59,26 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested attribute key not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested attribute key not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -83,20 +89,35 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
      * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *
-     *  @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
-     *  @return ODataValueContextOfListOfAttribute The return value
+     * @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
+     * @return ODataValueContextOfListOfAttribute The return value
      */
     @Override
-    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(
+            ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
         return doGetTrusteeAttributeKeyValuePairs(baseUrl + "/v1/Repositories/{repoId}/Attributes", parameters);
     }
 
-    private ODataValueContextOfListOfAttribute doGetTrusteeAttributeKeyValuePairs(String url, ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String", "String", "int", "int", "boolean" }, new String[] { "everyone", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isEveryone(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfListOfAttribute doGetTrusteeAttributeKeyValuePairs(String url,
+            ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"boolean", "String", "String", "int", "int", "boolean"},
+                new String[]{"everyone", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.isEveryone(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -114,30 +135,42 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink, int maxPageSize) {
-        return doGetTrusteeAttributeKeyValuePairs(nextLink, new ParametersForGetTrusteeAttributeKeyValuePairs().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink,
+            int maxPageSize) {
+        return doGetTrusteeAttributeKeyValuePairs(nextLink,
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setPrefer(
+                        mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback, Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+    public void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfListOfAttribute response = getTrusteeAttributeKeyValuePairs(parameters);
         while (response != null && callback.apply(response)) {

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -33,7 +33,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
     }
 
     /**
-     *  - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
+     * - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
      * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
      *
      *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
@@ -79,7 +79,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
     }
 
     /**
-     *  - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
+     * - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
      * - Attribute keys can be used with subsequent calls to get specific attribute values.
      * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,19 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.AttributesClient;
-import com.laserfiche.repository.api.clients.impl.model.Attribute;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import kong.unirest.HttpResponse;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.json.JSONObject;
-
 import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.AttributesClient;
 
 public class AttributesClientImpl extends ApiClient implements AttributesClient {
 
@@ -21,16 +32,18 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns the attribute associated with the key. Alternatively, return the attribute associated with the key within &quot;Everyone&quot; group.
+     * - Optional query parameters: everyone (bool, default false). When true, the server only searches for the attribute value with the given key upon the authenticated users attributes. If false, only the authenticated users attributes will be queried.
+     *
+     *  @param parameters An object of type ParametersForGetTrusteeAttributeValueByKey which encapsulates the parameters of getTrusteeAttributeValueByKey method.
+     *  @return Attribute The return value
+     */
     @Override
-    public Attribute getTrusteeAttributeValueByKey(String repoId, String attributeKey, Boolean everyone) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"everyone"}, new Object[]{everyone});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "attributeKey"},
-                new Object[]{repoId, attributeKey});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/Attributes/{attributeKey}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public Attribute getTrusteeAttributeValueByKey(ParametersForGetTrusteeAttributeValueByKey parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean" }, new String[] { "everyone" }, new Object[] { parameters.isEveryone() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "attributeKey" }, new Object[] { parameters.getRepoId(), parameters.getAttributeKey() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Attributes/{attributeKey}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -48,55 +61,42 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested attribute key not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested attribute key not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the attribute key value pairs associated with the authenticated user. Alternatively, return only the attribute key value pairs that are associated with the &quot;Everyone&quot; group.
+     * - Attribute keys can be used with subsequent calls to get specific attribute values.
+     * - Default page size: 100. Allowed OData query options: Select, Count, OrderBy, Skip, Top, SkipToken, Prefer. Optional query parameters: everyone (bool, default false). When true, this route does not return the attributes that are tied to the currently authenticated user, but rather the attributes assigned to the &quot;Everyone&quot; group. Note when this is true, the response does not include both the &quot;Everyone&quot; groups attribute and the currently authenticated user, but only the &quot;Everyone&quot; groups.
+     *
+     *  @param parameters An object of type ParametersForGetTrusteeAttributeKeyValuePairs which encapsulates the parameters of getTrusteeAttributeKeyValuePairs method.
+     *  @return ODataValueContextOfListOfAttribute The return value
+     */
     @Override
-    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(String repoId, Boolean everyone,
-            String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetTrusteeAttributeKeyValuePairs(baseUrl + "/v1/Repositories/{repoId}/Attributes", repoId, everyone,
-                prefer, select, orderby, top, skip, count);
+    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairs(ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+        return doGetTrusteeAttributeKeyValuePairs(baseUrl + "/v1/Repositories/{repoId}/Attributes", parameters);
     }
 
-    private ODataValueContextOfListOfAttribute doGetTrusteeAttributeKeyValuePairs(String url, String repoId,
-            Boolean everyone, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"everyone", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{everyone, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfListOfAttribute doGetTrusteeAttributeKeyValuePairs(String url, ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String", "String", "int", "int", "boolean" }, new String[] { "everyone", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isEveryone(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -114,45 +114,32 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink,
-            Integer maxPageSize) {
-        return doGetTrusteeAttributeKeyValuePairs(nextLink, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null,
-                null, null, null, null);
+    public ODataValueContextOfListOfAttribute getTrusteeAttributeKeyValuePairsNextLink(String nextLink, int maxPageSize) {
+        return doGetTrusteeAttributeKeyValuePairs(nextLink, new ParametersForGetTrusteeAttributeKeyValuePairs().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback,
-            Integer maxPageSize, String repoId, Boolean everyone, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfListOfAttribute response = getTrusteeAttributeKeyValuePairs(repoId, everyone, prefer, select,
-                orderby, top, skip, count);
+    public void getTrusteeAttributeKeyValuePairsForEach(Function<ODataValueContextOfListOfAttribute, Boolean> callback, Integer maxPageSize, ParametersForGetTrusteeAttributeKeyValuePairs parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfListOfAttribute response = getTrusteeAttributeKeyValuePairs(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getTrusteeAttributeKeyValuePairsNextLink(nextLink, maxPageSize);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,30 +1,17 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.AuditReasonsClient;
+import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.params.ParametersForGetAuditReasons;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.AuditReasonsClient;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsClient {
 
@@ -37,13 +24,17 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
      * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *
-     *  @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
-     *  @return AuditReasons The return value
+     * @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
+     * @return AuditReasons The return value
      */
     @Override
     public AuditReasons getAuditReasons(ParametersForGetAuditReasons parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/AuditReasons").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/AuditReasons")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -61,18 +52,26 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -33,7 +33,7 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
     }
 
     /**
-     *  - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
+     * - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
      * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
      * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,16 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.AuditReasonsClient;
-import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
-import java.util.Map;
-import java.util.Optional;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.AuditReasonsClient;
 
 public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsClient {
 
@@ -18,13 +32,18 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns the audit reasons associated with the authenticated user. Inherited audit reasons are included.
+     * - Only includes audit reasons associated with available API functionalities, like delete entry and export document.
+     * - If the authenticated user does not have the appropriate Laserfiche feature right, the audit reasons associated with that feature right will not be included.
+     *
+     *  @param parameters An object of type ParametersForGetAuditReasons which encapsulates the parameters of getAuditReasons method.
+     *  @return AuditReasons The return value
+     */
     @Override
-    public AuditReasons getAuditReasons(String repoId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/AuditReasons")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public AuditReasons getAuditReasons(ParametersForGetAuditReasons parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/AuditReasons").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -42,26 +61,18 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -33,7 +33,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns the fields assigned to an entry.
+     * - Returns the fields assigned to an entry.
      * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -101,7 +101,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Update the field values assigned to an entry.
+     * - Update the field values assigned to an entry.
      * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
      * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
      *
@@ -150,7 +150,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Creates a new document in the specified folder with file (no more than 100 MB).
+     * - Creates a new document in the specified folder with file (no more than 100 MB).
      * - Optionally sets metadata and electronic document component.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
      *
@@ -199,7 +199,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns the links assigned to an entry.
+     * - Returns the links assigned to an entry.
      * - Provide an entry ID, and get a paged listing of links assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -267,7 +267,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Assign links to an entry.
+     * - Assign links to an entry.
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
@@ -315,7 +315,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Assign a template to an entry.
+     * - Assign a template to an entry.
      * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
      * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
      *
@@ -364,7 +364,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Remove the currently assigned template from the specified entry.
+     * - Remove the currently assigned template from the specified entry.
      * - Provide an entry ID to clear template value on.
      * - If the entry does not have a template assigned, no change will be made.
      *
@@ -412,7 +412,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns dynamic field logic values with the current values of the fields in the template.
+     * - Returns dynamic field logic values with the current values of the fields in the template.
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
      *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
@@ -458,7 +458,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns a single entry object using the entry path.
+     * - Returns a single entry object using the entry path.
      * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
      *
      *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
@@ -504,7 +504,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Copy a new child entry in the designated folder async, and potentially return an operationToken.
+     * - Copy a new child entry in the designated folder async, and potentially return an operationToken.
      * - Provide the parent folder ID, and copy an entry as a child of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      * - The status of the operation can be checked via the Tasks/{operationToken} route.
@@ -552,7 +552,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns a single entry object.
+     * - Returns a single entry object.
      * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
      * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
      *
@@ -599,7 +599,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Moves and/or renames an entry.
+     * - Moves and/or renames an entry.
      * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
@@ -650,7 +650,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Begins a task to delete an entry, and returns an operationToken.
+     * - Begins a task to delete an entry, and returns an operationToken.
      * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
      * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
      *
@@ -696,7 +696,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns an entry's edoc resource in a stream format while including an audit reason.
+     * - Returns an entry's edoc resource in a stream format while including an audit reason.
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
@@ -744,7 +744,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns an entry's edoc resource in a stream format.
+     * - Returns an entry's edoc resource in a stream format.
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
@@ -838,7 +838,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
+     * - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
      * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
      * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
      *
@@ -880,7 +880,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
+     * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
      * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
      *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
@@ -928,7 +928,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns the children entries of a folder in the repository.
+     * - Returns the children entries of a folder in the repository.
      * - Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. Sort order can be either value &quot;asc&quot; or &quot;desc&quot;. Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
      * - Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.
@@ -999,7 +999,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Create/copy a new child entry in the designated folder.
+     * - Create/copy a new child entry in the designated folder.
      * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
@@ -1048,7 +1048,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Returns the tags assigned to an entry.
+     * - Returns the tags assigned to an entry.
      * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -1116,7 +1116,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     /**
-     *  - Assign tags to an entry.
+     * - Assign tags to an entry.
      * - Provide an entry ID and a list of tags to assign to that entry.
      * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,19 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.EntriesClient;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import kong.unirest.Header;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
+import java.io.File;
 import java.io.InputStream;
-import java.util.*;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.EntriesClient;
 
 public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
@@ -21,33 +32,25 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns the fields assigned to an entry.
+     * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
+     *  @return ODataValueContextOfIListOfFieldValue The return value
+     */
     @Override
-    public ODataValueContextOfIListOfFieldValue getFieldValues(String repoId, Integer entryId, String prefer,
-            Boolean formatValue, String culture, String select, String orderby, Integer top, Integer skip,
-            Boolean count) {
-        return doGetFieldValues(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields", repoId, entryId, prefer,
-                formatValue, culture, select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfFieldValue getFieldValues(ParametersForGetFieldValues parameters) {
+        return doGetFieldValues(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields", parameters);
     }
 
-    private ODataValueContextOfIListOfFieldValue doGetFieldValues(String url, String repoId, Integer entryId,
-            String prefer, Boolean formatValue, String culture, String select, String orderby, Integer top,
-            Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"formatValue", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{formatValue, culture, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfFieldValue doGetFieldValues(String url, ParametersForGetFieldValues parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "formatValue", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isFormatValue(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -65,63 +68,51 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfFieldValue getFieldValuesNextLink(String nextLink, Integer maxPageSize) {
-        return doGetFieldValues(nextLink, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null, null, null,
-                null, null, null);
+    public ODataValueContextOfIListOfFieldValue getFieldValuesNextLink(String nextLink, int maxPageSize) {
+        return doGetFieldValues(nextLink, new ParametersForGetFieldValues().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer entryId, String prefer, Boolean formatValue, String culture,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfFieldValue response = getFieldValues(repoId, entryId, prefer, formatValue, culture,
-                select, orderby, top, skip, count);
+    public void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize, ParametersForGetFieldValues parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfFieldValue response = getFieldValues(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getFieldValuesNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Update the field values assigned to an entry.
+     * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
+     * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
+     *
+     *  @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
+     *  @return ODataValueOfIListOfFieldValue The return value
+     */
     @Override
-    public ODataValueOfIListOfFieldValue assignFieldValues(String repoId, Integer entryId,
-            Map<String, FieldToUpdate> requestBody, String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"culture"}, new Object[]{culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public ODataValueOfIListOfFieldValue assignFieldValues(ParametersForAssignFieldValues parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "culture" }, new Object[] { parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -139,48 +130,38 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Creates a new document in the specified folder with file (no more than 100 MB).
+     * - Optionally sets metadata and electronic document component.
+     * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
+     *
+     *  @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
+     *  @return CreateEntryResult The return value
+     */
     @Override
-    public CreateEntryResult importDocument(String repoId, Integer parentEntryId, String fileName, Boolean autoRename,
-            String culture, InputStream inputStream, PostEntryWithEdocMetadataRequest requestBody) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
-                new Object[]{autoRename, culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "parentEntryId", "fileName"},
-                new Object[]{repoId, parentEntryId, fileName});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{parentEntryId}/{fileName}")
-                .field("electronicDocument", inputStream, fileName)
-                .field("request", toJson(requestBody))
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public CreateEntryResult importDocument(ParametersForImportDocument parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int", "String" }, new String[] { "repoId", "parentEntryId", "fileName" }, new Object[] { parameters.getRepoId(), parameters.getParentEntryId(), parameters.getFileName() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{parentEntryId}/{fileName}").field("electronicDocument", parameters.getInputStream(), parameters.getFileName()).field("request", toJson(parameters.getRequestBody())).queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
             try {
@@ -198,59 +179,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 500)
-                throw new ApiException(decideErrorMessage(problemDetails, "Document creation is complete failure."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Document creation is complete failure."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the links assigned to an entry.
+     * - Provide an entry ID, and get a paged listing of links assigned to that entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
+     *  @return ODataValueContextOfIListOfWEntryLinkInfo The return value
+     */
     @Override
-    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(String repoId, Integer entryId,
-            String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetLinkValuesFromEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links", repoId, entryId,
-                prefer, select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(ParametersForGetLinkValuesFromEntry parameters) {
+        return doGetLinkValuesFromEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links", parameters);
     }
 
-    private ODataValueContextOfIListOfWEntryLinkInfo doGetLinkValuesFromEntry(String url, String repoId,
-            Integer entryId, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfWEntryLinkInfo doGetLinkValuesFromEntry(String url, ParametersForGetLinkValuesFromEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -268,62 +234,50 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntryNextLink(String nextLink,
-            Integer maxPageSize) {
-        return doGetLinkValuesFromEntry(nextLink, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null,
-                null, null, null);
+    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntryNextLink(String nextLink, int maxPageSize) {
+        return doGetLinkValuesFromEntry(nextLink, new ParametersForGetLinkValuesFromEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer entryId, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfWEntryLinkInfo response = getLinkValuesFromEntry(repoId, entryId, prefer, select,
-                orderby, top, skip, count);
+    public void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfWEntryLinkInfo response = getLinkValuesFromEntry(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getLinkValuesFromEntryNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Assign links to an entry.
+     * - Provide an entry ID and a list of links to assign to that entry.
+     * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
+     *
+     *  @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
+     *  @return ODataValueOfIListOfWEntryLinkInfo The return value
+     */
     @Override
-    public ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(String repoId, Integer entryId,
-            List<PutLinksRequest> requestBody) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links")
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(ParametersForAssignEntryLinks parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -341,47 +295,38 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Assign a template to an entry.
+     * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
+     * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
+     *
+     *  @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
+     *  @return Entry The return value
+     */
     @Override
-    public Entry writeTemplateValueToEntry(String repoId, Integer entryId, PutTemplateRequest requestBody,
-            String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"culture"}, new Object[]{culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public Entry writeTemplateValueToEntry(ParametersForWriteTemplateValueToEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "culture" }, new Object[] { parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -399,42 +344,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Remove the currently assigned template from the specified entry.
+     * - Provide an entry ID to clear template value on.
+     * - If the entry does not have a template assigned, no change will be made.
+     *
+     *  @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
+     *  @return Entry The return value
+     */
     @Override
-    public Entry deleteAssignedTemplate(String repoId, Integer entryId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public Entry deleteAssignedTemplate(ParametersForDeleteAssignedTemplate parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -452,45 +392,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns dynamic field logic values with the current values of the fields in the template.
+     * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
+     *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+     *
+     *  @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
+     *  @return Map&lt;String,String[]&gt; The return value
+     */
     @Override
-    public Map<String, String[]> getDynamicFieldValues(String repoId, Integer entryId,
-            GetDynamicFieldLogicValueRequest requestBody) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields/GetDynamicFieldLogicValue")
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject((new HashMap<String, String[]>()).getClass());
+    public Map<String, String[]> getDynamicFieldValues(ParametersForGetDynamicFieldValues parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields/GetDynamicFieldLogicValue").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject((new HashMap<String, String[]>()).getClass());
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -508,42 +440,35 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns a single entry object using the entry path.
+     * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
+     *
+     *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
+     *  @return FindEntryResult The return value
+     */
     @Override
-    public FindEntryResult getEntryByPath(String repoId, String fullPath, Boolean fallbackToClosestAncestor) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"fullPath", "fallbackToClosestAncestor"},
-                new Object[]{fullPath, fallbackToClosestAncestor});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/Entries/ByPath")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public FindEntryResult getEntryByPath(ParametersForGetEntryByPath parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "boolean" }, new String[] { "fullPath", "fallbackToClosestAncestor" }, new Object[] { parameters.getFullPath(), parameters.isFallbackToClosestAncestor() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/ByPath").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -561,45 +486,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Copy a new child entry in the designated folder async, and potentially return an operationToken.
+     * - Provide the parent folder ID, and copy an entry as a child of the designated folder.
+     * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
+     * - The status of the operation can be checked via the Tasks/{operationToken} route.
+     *
+     *  @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
+     *  @return AcceptedOperation The return value
+     */
     @Override
-    public AcceptedOperation copyEntryAsync(String repoId, Integer entryId, CopyAsyncRequest requestBody,
-            Boolean autoRename, String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
-                new Object[]{autoRename, culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/CopyAsync")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public AcceptedOperation copyEntryAsync(ParametersForCopyEntryAsync parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/CopyAsync").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -617,41 +534,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns a single entry object.
+     * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
+     * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
+     *
+     *  @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
+     *  @return Entry The return value
+     */
     @Override
-    public Entry getEntry(String repoId, Integer entryId, String select) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"$select"}, new Object[]{select});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public Entry getEntry(ParametersForGetEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "$select" }, new Object[] { parameters.getSelect() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -669,45 +581,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Moves and/or renames an entry.
+     * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
+     * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
+     *
+     *  @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
+     *  @return Entry The return value
+     */
     @Override
-    public Entry moveOrRenameEntry(String repoId, Integer entryId, PatchEntryRequest requestBody, Boolean autoRename,
-            String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
-                new Object[]{autoRename, culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .patch(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public Entry moveOrRenameEntry(ParametersForMoveOrRenameEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.patch(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -725,47 +628,39 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Begins a task to delete an entry, and returns an operationToken.
+     * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
+     * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
+     *
+     *  @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
+     *  @return AcceptedOperation The return value
+     */
     @Override
-    public AcceptedOperation deleteEntryInfo(String repoId, Integer entryId, DeleteEntryWithAuditReason requestBody) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public AcceptedOperation deleteEntryInfo(ParametersForDeleteEntryInfo parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -783,177 +678,129 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns an entry's edoc resource in a stream format while including an audit reason.
+     * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
+     * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
+     *
+     *  @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
+     */
     @Override
-    public void exportDocumentWithAuditReason(String repoId, Integer entryId, GetEdocWithAuditReasonRequest requestBody,
-            String range, Consumer<InputStream> inputStreamConsumer) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+    public void exportDocumentWithAuditReason(ParametersForExportDocumentWithAuditReason parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "range" }, new Object[] { parameters.getRange() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         {
-            final RuntimeException[] exception = {null};
-            httpClient
-                    .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason")
-                    .routeParam(pathParameters)
-                    .headers(headerParametersWithStringTypeValue)
-                    .contentType("application/json")
-                    .body(requestBody)
-                    .thenConsume(rawResponse -> {
-                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                            inputStreamConsumer.accept(rawResponse.getContent());
-                        } else {
-                            ProblemDetails problemDetails = null;
-                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
-                            try {
-                                String jsonString = rawResponse.getContentAsString();
-                                problemDetails = deserializeToProblemDetails(jsonString);
-                            } catch (JsonProcessingException | IllegalStateException e) {
-                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
-                                        rawResponse.getContentAsString(), headersMap, null);
-                            }
-                            if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Request entry id not found."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                exception[0] = new RuntimeException(rawResponse.getStatusText());
-                        }
-                    });
+            final RuntimeException[] exception = { null };
+            httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason").routeParam(pathParameters).headers(headerParametersWithStringTypeValue).contentType("application/json").body(parameters.getRequestBody()).thenConsume(rawResponse -> {
+                if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                    parameters.getInputStreamConsumer().accept(rawResponse.getContent());
+                } else {
+                    ProblemDetails problemDetails = null;
+                    Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                    try {
+                        String jsonString = rawResponse.getContentAsString();
+                        problemDetails = deserializeToProblemDetails(jsonString);
+                    } catch (JsonProcessingException | IllegalStateException e) {
+                        exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(), rawResponse.getContentAsString(), headersMap, null);
+                    }
+                    if (rawResponse.getStatus() == 400)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 401)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 403)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 404)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 423)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 429)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else
+                        exception[0] = new RuntimeException(rawResponse.getStatusText());
+                }
+            });
             if (exception[0] != null) {
                 throw exception[0];
             }
         }
     }
 
+    /**
+     *  - Returns an entry's edoc resource in a stream format.
+     * - Provide an entry ID, and get the edoc resource as part of the response content.
+     * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
+     *
+     *  @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
+     */
     @Override
-    public void exportDocument(String repoId, Integer entryId, String range,
-            Consumer<InputStream> inputStreamConsumer) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"range"}, new Object[]{range});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+    public void exportDocument(ParametersForExportDocument parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "range" }, new Object[] { parameters.getRange() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         {
-            final RuntimeException[] exception = {null};
-            httpClient
-                    .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
-                    .routeParam(pathParameters)
-                    .headers(headerParametersWithStringTypeValue)
-                    .thenConsume(rawResponse -> {
-                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                            inputStreamConsumer.accept(rawResponse.getContent());
-                        } else {
-                            ProblemDetails problemDetails = null;
-                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
-                            try {
-                                String jsonString = rawResponse.getContentAsString();
-                                problemDetails = deserializeToProblemDetails(jsonString);
-                            } catch (JsonProcessingException | IllegalStateException e) {
-                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
-                                        rawResponse.getContentAsString(), headersMap, null);
-                            }
-                            if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Request entry id not found."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
-                            else
-                                exception[0] = new RuntimeException(rawResponse.getStatusText());
-                        }
-                    });
+            final RuntimeException[] exception = { null };
+            httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).headers(headerParametersWithStringTypeValue).thenConsume(rawResponse -> {
+                if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                    parameters.getInputStreamConsumer().accept(rawResponse.getContent());
+                } else {
+                    ProblemDetails problemDetails = null;
+                    Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                    try {
+                        String jsonString = rawResponse.getContentAsString();
+                        problemDetails = deserializeToProblemDetails(jsonString);
+                    } catch (JsonProcessingException | IllegalStateException e) {
+                        exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(), rawResponse.getContentAsString(), headersMap, null);
+                    }
+                    if (rawResponse.getStatus() == 400)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 401)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 403)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 404)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 423)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else if (rawResponse.getStatus() == 429)
+                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
+                    else
+                        exception[0] = new RuntimeException(rawResponse.getStatusText());
+                }
+            });
             if (exception[0] != null) {
                 throw exception[0];
             }
         }
     }
 
+    /**
+     * - Delete the edoc associated with the provided entry ID.
+     *
+     * @param parameters An object of type ParametersForDeleteDocument which encapsulates the parameters of deleteDocument method.
+     * @return ODataValueOfBoolean The return value
+     */
     @Override
-    public ODataValueOfBoolean deleteDocument(String repoId, Integer entryId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfBoolean deleteDocument(ParametersForDeleteDocument parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -971,49 +818,40 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns information about the edoc content of an entry, without downloading the edoc in its entirety.
+     * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
+     * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
+     *
+     *  @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
+     *  @return Map&lt;String,String&gt; The return value
+     */
     @Override
-    public Map<String, String> getDocumentContentType(String repoId, Integer entryId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .head(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
-                .routeParam(pathParameters)
-                .asObject(new HashMap<String, String>().getClass());
+    public Map<String, String> getDocumentContentType(ParametersForGetDocumentContentType parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.head(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).asObject(new HashMap<String, String>().getClass());
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
-            return httpResponse
-                    .getHeaders()
-                    .all()
-                    .stream()
-                    .collect(Collectors.toMap(Header::getName, Header::getValue));
+            return httpResponse.getHeaders().all().stream().collect(Collectors.toMap(Header::getName, Header::getValue));
         } else {
             ProblemDetails problemDetails;
             Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
@@ -1022,44 +860,37 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
+     * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
+     *
+     *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
+     *  @return ODataValueOfBoolean The return value
+     */
     @Override
-    public ODataValueOfBoolean deletePages(String repoId, Integer entryId, String pageRange) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"pageRange"}, new Object[]{pageRange});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfBoolean deletePages(ParametersForDeletePages parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "pageRange" }, new Object[] { parameters.getPageRange() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1077,65 +908,47 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the children entries of a folder in the repository.
+     * - Provide an entry ID (must be a folder), and get a paged listing of entries in that folder. Used as a way of navigating through the repository.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. Sort order can be either value &quot;asc&quot; or &quot;desc&quot;. Optional query parameters: groupByOrderType (bool). This query parameter decides if results are returned in groups based on their entry type. Entries returned in the listing are not automatically converted to their subtype (Folder, Shortcut, Document), so clients who want model-specific information should request it via the GET entry by ID route.
+     * - Optionally returns field values for the entries in the folder. Each field name needs to be specified in the request. Maximum limit of 10 field names.
+     * - If field values are requested, only the first value is returned if it is a multi value field.
+     * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
+     *
+     *  @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
+     *  @return ODataValueContextOfIListOfEntry The return value
+     */
     @Override
-    public ODataValueContextOfIListOfEntry getEntryListing(String repoId, Integer entryId, Boolean groupByEntryType,
-            String[] fields, Boolean formatFields, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        return doGetEntryListing(
-                baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children", repoId,
-                entryId, groupByEntryType, fields, formatFields, prefer, culture, select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfEntry getEntryListing(ParametersForGetEntryListing parameters) {
+        return doGetEntryListing(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children", parameters);
     }
 
-    private ODataValueContextOfIListOfEntry doGetEntryListing(String url, String repoId, Integer entryId,
-            Boolean groupByEntryType, String[] fields, Boolean formatFields, String prefer, String culture,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"groupByEntryType", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{groupByEntryType, fields, formatFields, culture, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
-                        "fields") instanceof String ? Arrays.asList(
-                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfEntry doGetEntryListing(String url, ParametersForGetEntryListing parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "groupByEntryType", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isGroupByEntryType(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1153,64 +966,51 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfEntry getEntryListingNextLink(String nextLink, Integer maxPageSize) {
-        return doGetEntryListing(nextLink, null, null, null, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null),
-                null, null, null, null, null, null);
+    public ODataValueContextOfIListOfEntry getEntryListingNextLink(String nextLink, int maxPageSize) {
+        return doGetEntryListing(nextLink, new ParametersForGetEntryListing().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
-            String repoId, Integer entryId, Boolean groupByEntryType, String[] fields, Boolean formatFields,
-            String prefer, String culture, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfEntry response = getEntryListing(repoId, entryId, groupByEntryType, fields,
-                formatFields, prefer, culture, select, orderby, top, skip, count);
+    public void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetEntryListing parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfEntry response = getEntryListing(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getEntryListingNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Create/copy a new child entry in the designated folder.
+     * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
+     * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
+     *
+     *  @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
+     *  @return Entry The return value
+     */
     @Override
-    public Entry createOrCopyEntry(String repoId, Integer entryId, PostEntryChildrenRequest requestBody,
-            Boolean autoRename, String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"autoRename", "culture"},
-                new Object[]{autoRename, culture});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public Entry createOrCopyEntry(ParametersForCreateOrCopyEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -1228,59 +1028,44 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the tags assigned to an entry.
+     * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
+     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     */
     @Override
-    public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(String repoId, Integer entryId, String prefer,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetTagsAssignedToEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags", repoId, entryId,
-                prefer, select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(ParametersForGetTagsAssignedToEntry parameters) {
+        return doGetTagsAssignedToEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags", parameters);
     }
 
-    private ODataValueContextOfIListOfWTagInfo doGetTagsAssignedToEntry(String url, String repoId, Integer entryId,
-            String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfWTagInfo doGetTagsAssignedToEntry(String url, ParametersForGetTagsAssignedToEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1298,60 +1083,50 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntryNextLink(String nextLink, Integer maxPageSize) {
-        return doGetTagsAssignedToEntry(nextLink, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null,
-                null, null, null);
+    public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntryNextLink(String nextLink, int maxPageSize) {
+        return doGetTagsAssignedToEntry(nextLink, new ParametersForGetTagsAssignedToEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, Integer entryId, String prefer, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfWTagInfo response = getTagsAssignedToEntry(repoId, entryId, prefer, select, orderby,
-                top, skip, count);
+    public void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfWTagInfo response = getTagsAssignedToEntry(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getTagsAssignedToEntryNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Assign tags to an entry.
+     * - Provide an entry ID and a list of tags to assign to that entry.
+     * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
+     *
+     *  @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
+     *  @return ODataValueOfIListOfWTagInfo The return value
+     */
     @Override
-    public ODataValueOfIListOfWTagInfo assignTags(String repoId, Integer entryId, PutTagRequest requestBody) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "entryId"},
-                new Object[]{repoId, entryId});
-        HttpResponse<Object> httpResponse = httpClient
-                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags")
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public ODataValueOfIListOfWTagInfo assignTags(ParametersForAssignTags parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
+        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1369,29 +1144,20 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,30 +1,18 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.EntriesClient;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import kong.unirest.Header;
+import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.EntriesClient;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
@@ -37,8 +25,8 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get a paged listing of all fields assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
-     *  @return ODataValueContextOfIListOfFieldValue The return value
+     * @param parameters An object of type ParametersForGetFieldValues which encapsulates the parameters of getFieldValues method.
+     * @return ODataValueContextOfIListOfFieldValue The return value
      */
     @Override
     public ODataValueContextOfIListOfFieldValue getFieldValues(ParametersForGetFieldValues parameters) {
@@ -46,11 +34,24 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     }
 
     private ODataValueContextOfIListOfFieldValue doGetFieldValues(String url, ParametersForGetFieldValues parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "formatValue", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isFormatValue(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"boolean", "String", "String", "String", "int", "int", "boolean"},
+                new String[]{"formatValue", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.isFormatValue(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -68,18 +69,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -87,11 +96,13 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public ODataValueContextOfIListOfFieldValue getFieldValuesNextLink(String nextLink, int maxPageSize) {
-        return doGetFieldValues(nextLink, new ParametersForGetFieldValues().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetFieldValues(nextLink,
+                new ParametersForGetFieldValues().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback, Integer maxPageSize, ParametersForGetFieldValues parameters) {
+    public void getFieldValuesForEach(Function<ODataValueContextOfIListOfFieldValue, Boolean> callback,
+            Integer maxPageSize, ParametersForGetFieldValues parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfFieldValue response = getFieldValues(parameters);
         while (response != null && callback.apply(response)) {
@@ -105,14 +116,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide the new field values to assign to the entry, and remove/reset all previously assigned field values.
      * - This is an overwrite action. The request body must include all desired field values, including any existing field values that should remain assigned to the entry. Field values that are not included in the request will be deleted from the entry. If the field value that is not included is part of a template, it will still be assigned (as required by the template), but its value will be reset.
      *
-     *  @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
-     *  @return ODataValueOfIListOfFieldValue The return value
+     * @param parameters An object of type ParametersForAssignFieldValues which encapsulates the parameters of assignFieldValues method.
+     * @return ODataValueOfIListOfFieldValue The return value
      */
     @Override
     public ODataValueOfIListOfFieldValue assignFieldValues(ParametersForAssignFieldValues parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "culture" }, new Object[] { parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"culture"}, new Object[]{parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -130,20 +149,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -154,14 +182,24 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Optionally sets metadata and electronic document component.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed. With this route, partial success is possible. The response returns multiple operation (entryCreate operation, setEdoc operation, setLinks operation, etc..) objects, which contain information about any errors that may have occurred during the creation. As long as the entryCreate operation succeeds, the entry will be created, even if all other operations fail.
      *
-     *  @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
-     *  @return CreateEntryResult The return value
+     * @param parameters An object of type ParametersForImportDocument which encapsulates the parameters of importDocument method.
+     * @return CreateEntryResult The return value
      */
     @Override
     public CreateEntryResult importDocument(ParametersForImportDocument parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int", "String" }, new String[] { "repoId", "parentEntryId", "fileName" }, new Object[] { parameters.getRepoId(), parameters.getParentEntryId(), parameters.getFileName() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{parentEntryId}/{fileName}").field("electronicDocument", parameters.getInputStream(), parameters.getFileName()).field("request", toJson(parameters.getRequestBody())).queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"boolean", "String"},
+                new String[]{"autoRename", "culture"},
+                new Object[]{parameters.isAutoRename(), parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int", "String"},
+                new String[]{"repoId", "parentEntryId", "fileName"},
+                new Object[]{parameters.getRepoId(), parameters.getParentEntryId(), parameters.getFileName()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{parentEntryId}/{fileName}")
+                .field("electronicDocument", parameters.getInputStream(), parameters.getFileName())
+                .field("request", toJson(parameters.getRequestBody()))
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
             try {
@@ -179,20 +217,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 500)
-                throw new ApiException(decideErrorMessage(problemDetails, "Document creation is complete failure."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Document creation is complete failure."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -203,20 +250,35 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get a paged listing of links assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
-     *  @return ODataValueContextOfIListOfWEntryLinkInfo The return value
+     * @param parameters An object of type ParametersForGetLinkValuesFromEntry which encapsulates the parameters of getLinkValuesFromEntry method.
+     * @return ODataValueContextOfIListOfWEntryLinkInfo The return value
      */
     @Override
-    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(ParametersForGetLinkValuesFromEntry parameters) {
+    public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntry(
+            ParametersForGetLinkValuesFromEntry parameters) {
         return doGetLinkValuesFromEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links", parameters);
     }
 
-    private ODataValueContextOfIListOfWEntryLinkInfo doGetLinkValuesFromEntry(String url, ParametersForGetLinkValuesFromEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfWEntryLinkInfo doGetLinkValuesFromEntry(String url,
+            ParametersForGetLinkValuesFromEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "int", "int", "boolean"},
+                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -234,18 +296,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -253,11 +323,13 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public ODataValueContextOfIListOfWEntryLinkInfo getLinkValuesFromEntryNextLink(String nextLink, int maxPageSize) {
-        return doGetLinkValuesFromEntry(nextLink, new ParametersForGetLinkValuesFromEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetLinkValuesFromEntry(nextLink,
+                new ParametersForGetLinkValuesFromEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters) {
+    public void getLinkValuesFromEntryForEach(Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetLinkValuesFromEntry parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfWEntryLinkInfo response = getLinkValuesFromEntry(parameters);
         while (response != null && callback.apply(response)) {
@@ -271,13 +343,19 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID and a list of links to assign to that entry.
      * - This is an overwrite action. The request must include all links to assign to the entry, including existing links that should remain assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
-     *  @return ODataValueOfIListOfWEntryLinkInfo The return value
+     * @param parameters An object of type ParametersForAssignEntryLinks which encapsulates the parameters of assignEntryLinks method.
+     * @return ODataValueOfIListOfWEntryLinkInfo The return value
      */
     @Override
     public ODataValueOfIListOfWEntryLinkInfo assignEntryLinks(ParametersForAssignEntryLinks parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/links")
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -295,20 +373,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -319,14 +406,22 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, template name, and a list of template fields to assign to that entry.
      * - Only template values will be modified. Any existing independent fields on the entry will not be modified, nor will they be added if included in the request. The only modification to fields will only occur on templated fields. If the previously assigned template includes common template fields as the newly assigned template, the common field values will not be modified.
      *
-     *  @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForWriteTemplateValueToEntry which encapsulates the parameters of writeTemplateValueToEntry method.
+     * @return Entry The return value
      */
     @Override
     public Entry writeTemplateValueToEntry(ParametersForWriteTemplateValueToEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "culture" }, new Object[] { parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"culture"}, new Object[]{parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -344,20 +439,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -368,13 +472,17 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID to clear template value on.
      * - If the entry does not have a template assigned, no change will be made.
      *
-     *  @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForDeleteAssignedTemplate which encapsulates the parameters of deleteAssignedTemplate method.
+     * @return Entry The return value
      */
     @Override
     public Entry deleteAssignedTemplate(ParametersForDeleteAssignedTemplate parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/template")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -392,20 +500,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -414,15 +531,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
     /**
      * - Returns dynamic field logic values with the current values of the fields in the template.
      * - Provide an entry ID and field values in the JSON body to get dynamic field logic values.
-     *  Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
+     * Independent and non-dynamic fields in the request body will be ignored, and only related dynamic field logic values for the assigned template will be returned.
      *
-     *  @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
-     *  @return Map&lt;String,String[]&gt; The return value
+     * @param parameters An object of type ParametersForGetDynamicFieldValues which encapsulates the parameters of getDynamicFieldValues method.
+     * @return Map&lt;String,String[]&gt; The return value
      */
     @Override
     public Map<String, String[]> getDynamicFieldValues(ParametersForGetDynamicFieldValues parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields/GetDynamicFieldLogicValue").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject((new HashMap<String, String[]>()).getClass());
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/fields/GetDynamicFieldLogicValue")
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject((new HashMap<String, String[]>()).getClass());
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -440,18 +563,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -461,14 +592,21 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Returns a single entry object using the entry path.
      * - Optional query parameter: fallbackToClosestAncestor. Use the fallbackToClosestAncestor query parameter to return the closest existing ancestor if the initial entry path is not found.
      *
-     *  @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
-     *  @return FindEntryResult The return value
+     * @param parameters An object of type ParametersForGetEntryByPath which encapsulates the parameters of getEntryByPath method.
+     * @return FindEntryResult The return value
      */
     @Override
     public FindEntryResult getEntryByPath(ParametersForGetEntryByPath parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "boolean" }, new String[] { "fullPath", "fallbackToClosestAncestor" }, new Object[] { parameters.getFullPath(), parameters.isFallbackToClosestAncestor() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/ByPath").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String", "boolean"},
+                new String[]{"fullPath", "fallbackToClosestAncestor"},
+                new Object[]{parameters.getFullPath(), parameters.isFallbackToClosestAncestor()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/Entries/ByPath")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -486,18 +624,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -509,14 +655,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      * - The status of the operation can be checked via the Tasks/{operationToken} route.
      *
-     *  @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForCopyEntryAsync which encapsulates the parameters of copyEntryAsync method.
+     * @return AcceptedOperation The return value
      */
     @Override
     public AcceptedOperation copyEntryAsync(ParametersForCopyEntryAsync parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/CopyAsync").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"boolean", "String"},
+                new String[]{"autoRename", "culture"},
+                new Object[]{parameters.isAutoRename(), parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/CopyAsync")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -534,18 +689,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -556,14 +719,20 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get the entry associated with that ID. Useful when detailed information about the entry is required, such as metadata, path information, etc.
      * - Allowed OData query options: Select. If the entry is a subtype (Folder, Document, or Shortcut), the entry will automatically be converted to include those model-specific properties.
      *
-     *  @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForGetEntry which encapsulates the parameters of getEntry method.
+     * @return Entry The return value
      */
     @Override
     public Entry getEntry(ParametersForGetEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "$select" }, new Object[] { parameters.getSelect() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"$select"}, new Object[]{parameters.getSelect()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -581,18 +750,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -603,14 +780,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Move and/or rename an entry by passing in the new parent folder ID or name in the JSON body.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     *  @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForMoveOrRenameEntry which encapsulates the parameters of moveOrRenameEntry method.
+     * @return Entry The return value
      */
     @Override
     public Entry moveOrRenameEntry(ParametersForMoveOrRenameEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.patch(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"boolean", "String"},
+                new String[]{"autoRename", "culture"},
+                new Object[]{parameters.isAutoRename(), parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .patch(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -628,22 +814,32 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -654,13 +850,19 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and queue a delete task to remove it from the repository (includes nested objects if the entry is a Folder type). The entry will not be deleted immediately.
      * - Optionally include an audit reason ID and comment in the JSON body. This route returns an operationToken, and will run as an asynchronous operation. Check the progress via the Tasks/{operationToken} route.
      *
-     *  @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForDeleteEntryInfo which encapsulates the parameters of deleteEntryInfo method.
+     * @return AcceptedOperation The return value
      */
     @Override
     public AcceptedOperation deleteEntryInfo(ParametersForDeleteEntryInfo parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}")
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -678,18 +880,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -700,43 +910,74 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID and audit reason/comment in the request body, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc. This route is identical to the GET edoc route, but allows clients to include an audit reason when downloading the edoc.
      *
-     *  @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
+     * @param parameters An object of type ParametersForExportDocumentWithAuditReason which encapsulates the parameters of exportDocumentWithAuditReason method.
      */
     @Override
     public void exportDocumentWithAuditReason(ParametersForExportDocumentWithAuditReason parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "range" }, new Object[] { parameters.getRange() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"range"}, new Object[]{parameters.getRange()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         {
-            final RuntimeException[] exception = { null };
-            httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason").routeParam(pathParameters).headers(headerParametersWithStringTypeValue).contentType("application/json").body(parameters.getRequestBody()).thenConsume(rawResponse -> {
-                if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                    parameters.getInputStreamConsumer().accept(rawResponse.getContent());
-                } else {
-                    ProblemDetails problemDetails = null;
-                    Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
-                    try {
-                        String jsonString = rawResponse.getContentAsString();
-                        problemDetails = deserializeToProblemDetails(jsonString);
-                    } catch (JsonProcessingException | IllegalStateException e) {
-                        exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(), rawResponse.getContentAsString(), headersMap, null);
-                    }
-                    if (rawResponse.getStatus() == 400)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 401)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 403)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 404)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 423)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 429)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else
-                        exception[0] = new RuntimeException(rawResponse.getStatusText());
-                }
-            });
+            final RuntimeException[] exception = {null};
+            httpClient
+                    .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/GetEdocWithAuditReason")
+                    .routeParam(pathParameters)
+                    .headers(headerParametersWithStringTypeValue)
+                    .contentType("application/json")
+                    .body(parameters.getRequestBody())
+                    .thenConsume(rawResponse -> {
+                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                            parameters
+                                    .getInputStreamConsumer()
+                                    .accept(rawResponse.getContent());
+                        } else {
+                            ProblemDetails problemDetails = null;
+                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                            try {
+                                String jsonString = rawResponse.getContentAsString();
+                                problemDetails = deserializeToProblemDetails(jsonString);
+                            } catch (JsonProcessingException | IllegalStateException e) {
+                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
+                                        rawResponse.getContentAsString(), headersMap, null);
+                            }
+                            if (rawResponse.getStatus() == 400)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 401)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 403)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 404)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Request entry id not found."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 423)
+                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 429)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                exception[0] = new RuntimeException(rawResponse.getStatusText());
+                        }
+                    });
             if (exception[0] != null) {
                 throw exception[0];
             }
@@ -748,43 +989,72 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get the edoc resource as part of the response content.
      * - Optional header: Range. Use the Range header (single range with byte unit) to retrieve partial content of the edoc, rather than the entire edoc.
      *
-     *  @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
+     * @param parameters An object of type ParametersForExportDocument which encapsulates the parameters of exportDocument method.
      */
     @Override
     public void exportDocument(ParametersForExportDocument parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "range" }, new Object[] { parameters.getRange() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"range"}, new Object[]{parameters.getRange()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
         {
-            final RuntimeException[] exception = { null };
-            httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).headers(headerParametersWithStringTypeValue).thenConsume(rawResponse -> {
-                if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
-                    parameters.getInputStreamConsumer().accept(rawResponse.getContent());
-                } else {
-                    ProblemDetails problemDetails = null;
-                    Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
-                    try {
-                        String jsonString = rawResponse.getContentAsString();
-                        problemDetails = deserializeToProblemDetails(jsonString);
-                    } catch (JsonProcessingException | IllegalStateException e) {
-                        exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(), rawResponse.getContentAsString(), headersMap, null);
-                    }
-                    if (rawResponse.getStatus() == 400)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 401)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 403)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 404)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 423)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else if (rawResponse.getStatus() == 429)
-                        exception[0] = new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), rawResponse.getStatus(), rawResponse.getStatusText(), headersMap, problemDetails);
-                    else
-                        exception[0] = new RuntimeException(rawResponse.getStatusText());
-                }
-            });
+            final RuntimeException[] exception = {null};
+            httpClient
+                    .get(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
+                    .routeParam(pathParameters)
+                    .headers(headerParametersWithStringTypeValue)
+                    .thenConsume(rawResponse -> {
+                        if (rawResponse.getStatus() == 200 || rawResponse.getStatus() == 206) {
+                            parameters
+                                    .getInputStreamConsumer()
+                                    .accept(rawResponse.getContent());
+                        } else {
+                            ProblemDetails problemDetails = null;
+                            Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
+                            try {
+                                String jsonString = rawResponse.getContentAsString();
+                                problemDetails = deserializeToProblemDetails(jsonString);
+                            } catch (JsonProcessingException | IllegalStateException e) {
+                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
+                                        rawResponse.getContentAsString(), headersMap, null);
+                            }
+                            if (rawResponse.getStatus() == 400)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 401)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 403)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 404)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Request entry id not found."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 423)
+                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else if (rawResponse.getStatus() == 429)
+                                exception[0] = new ApiException(
+                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
+                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
+                                        problemDetails);
+                            else
+                                exception[0] = new RuntimeException(rawResponse.getStatusText());
+                        }
+                    });
             if (exception[0] != null) {
                 throw exception[0];
             }
@@ -799,8 +1069,12 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      */
     @Override
     public ODataValueOfBoolean deleteDocument(ParametersForDeleteDocument parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -818,20 +1092,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -842,16 +1125,24 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get back the Content-Type and Content-Length in the response headers.
      * - This route does not provide a way to download the actual edoc. Instead, it just gives metadata information about the edoc associated with the entry.
      *
-     *  @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
-     *  @return Map&lt;String,String&gt; The return value
+     * @param parameters An object of type ParametersForGetDocumentContentType which encapsulates the parameters of getDocumentContentType method.
+     * @return Map&lt;String,String&gt; The return value
      */
     @Override
     public Map<String, String> getDocumentContentType(ParametersForGetDocumentContentType parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.head(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc").routeParam(pathParameters).asObject(new HashMap<String, String>().getClass());
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .head(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/edoc")
+                .routeParam(pathParameters)
+                .asObject(new HashMap<String, String>().getClass());
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
-            return httpResponse.getHeaders().all().stream().collect(Collectors.toMap(Header::getName, Header::getValue));
+            return httpResponse
+                    .getHeaders()
+                    .all()
+                    .stream()
+                    .collect(Collectors.toMap(Header::getName, Header::getValue));
         } else {
             ProblemDetails problemDetails;
             Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
@@ -860,20 +1151,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -883,14 +1183,20 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Delete the pages associated with the provided entry ID. If no pageRange is specified, all pages will be deleted.
      * - Optional parameter: pageRange (default empty). The value should be a comma-seperated string which contains non-overlapping single values, or page ranges. Ex: &quot;1,2,3&quot;, &quot;1-3,5&quot;, &quot;2-7,10-12.&quot;
      *
-     *  @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForDeletePages which encapsulates the parameters of deletePages method.
+     * @return ODataValueOfBoolean The return value
      */
     @Override
     public ODataValueOfBoolean deletePages(ParametersForDeletePages parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "pageRange" }, new Object[] { parameters.getPageRange() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"pageRange"}, new Object[]{parameters.getPageRange()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Document/pages")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -908,20 +1214,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -935,20 +1250,38 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForGetEntryListing which encapsulates the parameters of getEntryListing method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     @Override
     public ODataValueContextOfIListOfEntry getEntryListing(ParametersForGetEntryListing parameters) {
-        return doGetEntryListing(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children", parameters);
+        return doGetEntryListing(
+                baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children",
+                parameters);
     }
 
     private ODataValueContextOfIListOfEntry doGetEntryListing(String url, ParametersForGetEntryListing parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "groupByEntryType", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isGroupByEntryType(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean"},
+                new String[]{"groupByEntryType", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.isGroupByEntryType(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
+                        "fields") instanceof String ? Arrays.asList(
+                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -966,18 +1299,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -985,11 +1326,13 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public ODataValueContextOfIListOfEntry getEntryListingNextLink(String nextLink, int maxPageSize) {
-        return doGetEntryListing(nextLink, new ParametersForGetEntryListing().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetEntryListing(nextLink,
+                new ParametersForGetEntryListing().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetEntryListing parameters) {
+    public void getEntryListingForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize,
+            ParametersForGetEntryListing parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfEntry response = getEntryListing(parameters);
         while (response != null && callback.apply(response)) {
@@ -1003,14 +1346,23 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide the parent folder ID, and based on the request body, copy or create a folder/shortcut as a child entry of the designated folder.
      * - Optional parameter: autoRename (default false). If an entry already exists with the given name, the entry will be automatically renamed.
      *
-     *  @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
-     *  @return Entry The return value
+     * @param parameters An object of type ParametersForCreateOrCopyEntry which encapsulates the parameters of createOrCopyEntry method.
+     * @return Entry The return value
      */
     @Override
     public Entry createOrCopyEntry(ParametersForCreateOrCopyEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "String" }, new String[] { "autoRename", "culture" }, new Object[] { parameters.isAutoRename(), parameters.getCulture() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children").queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"boolean", "String"},
+                new String[]{"autoRename", "culture"},
+                new Object[]{parameters.isAutoRename(), parameters.getCulture()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/Laserfiche.Repository.Folder/children")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -1028,20 +1380,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -1052,20 +1413,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID, and get a paged listing of tags assigned to that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
-     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagsAssignedToEntry which encapsulates the parameters of getTagsAssignedToEntry method.
+     * @return ODataValueContextOfIListOfWTagInfo The return value
      */
     @Override
     public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntry(ParametersForGetTagsAssignedToEntry parameters) {
         return doGetTagsAssignedToEntry(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags", parameters);
     }
 
-    private ODataValueContextOfIListOfWTagInfo doGetTagsAssignedToEntry(String url, ParametersForGetTagsAssignedToEntry parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfWTagInfo doGetTagsAssignedToEntry(String url,
+            ParametersForGetTagsAssignedToEntry parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "int", "int", "boolean"},
+                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1083,18 +1458,26 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -1102,11 +1485,13 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
 
     @Override
     public ODataValueContextOfIListOfWTagInfo getTagsAssignedToEntryNextLink(String nextLink, int maxPageSize) {
-        return doGetTagsAssignedToEntry(nextLink, new ParametersForGetTagsAssignedToEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetTagsAssignedToEntry(nextLink,
+                new ParametersForGetTagsAssignedToEntry().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters) {
+    public void getTagsAssignedToEntryForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTagsAssignedToEntry parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfWTagInfo response = getTagsAssignedToEntry(parameters);
         while (response != null && callback.apply(response)) {
@@ -1120,13 +1505,19 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
      * - Provide an entry ID and a list of tags to assign to that entry.
      * - This is an overwrite action. The request must include all tags to assign to the entry, including existing tags that should remain assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
-     *  @return ODataValueOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForAssignTags which encapsulates the parameters of assignTags method.
+     * @return ODataValueOfIListOfWTagInfo The return value
      */
     @Override
     public ODataValueOfIListOfWTagInfo assignTags(ParametersForAssignTags parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "entryId" }, new Object[] { parameters.getRepoId(), parameters.getEntryId() });
-        HttpResponse<Object> httpResponse = httpClient.put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "entryId"}, new Object[]{parameters.getRepoId(), parameters.getEntryId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .put(baseUrl + "/v1/Repositories/{repoId}/Entries/{entryId}/tags")
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -1144,20 +1535,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -33,7 +33,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
     }
 
     /**
-     *  - Returns a single field definition associated with the specified ID.
+     * - Returns a single field definition associated with the specified ID.
      * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
      * - Allowed OData query options: Select
      *
@@ -80,7 +80,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
     }
 
     /**
-     *  - Returns a paged listing of field definitions available in the specified repository.
+     * - Returns a paged listing of field definitions available in the specified repository.
      * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,30 +1,21 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitions;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefinitionsClient {
 
@@ -37,14 +28,21 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
      * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
-     *  @return WFieldInfo The return value
+     * @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
+     * @return WFieldInfo The return value
      */
     @Override
     public WFieldInfo getFieldDefinitionById(ParametersForGetFieldDefinitionById parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "culture", "$select" }, new Object[] { parameters.getCulture(), parameters.getSelect() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "fieldDefinitionId" }, new Object[] { parameters.getRepoId(), parameters.getFieldDefinitionId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions/{fieldDefinitionId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"culture", "$select"}, new Object[]{parameters.getCulture(), parameters.getSelect()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "fieldDefinitionId"},
+                new Object[]{parameters.getRepoId(), parameters.getFieldDefinitionId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions/{fieldDefinitionId}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -62,18 +60,26 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested field definition id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested field definition id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -84,20 +90,34 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
      * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
-     *  @return ODataValueContextOfIListOfWFieldInfo The return value
+     * @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
+     * @return ODataValueContextOfIListOfWFieldInfo The return value
      */
     @Override
     public ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(ParametersForGetFieldDefinitions parameters) {
         return doGetFieldDefinitions(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfWFieldInfo doGetFieldDefinitions(String url, ParametersForGetFieldDefinitions parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "int", "int", "boolean" }, new String[] { "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfWFieldInfo doGetFieldDefinitions(String url,
+            ParametersForGetFieldDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "String", "int", "int", "boolean"},
+                new String[]{"culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -115,18 +135,26 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -134,11 +162,13 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
 
     @Override
     public ODataValueContextOfIListOfWFieldInfo getFieldDefinitionsNextLink(String nextLink, int maxPageSize) {
-        return doGetFieldDefinitions(nextLink, new ParametersForGetFieldDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetFieldDefinitions(nextLink,
+                new ParametersForGetFieldDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetFieldDefinitions parameters) {
+    public void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetFieldDefinitions parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfWFieldInfo response = getFieldDefinitions(parameters);
         while (response != null && callback.apply(response)) {

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,19 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
-import kong.unirest.HttpResponse;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.json.JSONObject;
-
 import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
 
 public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefinitionsClient {
 
@@ -21,17 +32,19 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns a single field definition associated with the specified ID.
+     * - Useful when a route provides a minimal amount of details and more information about the specific field definition is needed.
+     * - Allowed OData query options: Select
+     *
+     *  @param parameters An object of type ParametersForGetFieldDefinitionById which encapsulates the parameters of getFieldDefinitionById method.
+     *  @return WFieldInfo The return value
+     */
     @Override
-    public WFieldInfo getFieldDefinitionById(String repoId, Integer fieldDefinitionId, String culture, String select) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"culture", "$select"},
-                new Object[]{culture, select});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "fieldDefinitionId"},
-                new Object[]{repoId, fieldDefinitionId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions/{fieldDefinitionId}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public WFieldInfo getFieldDefinitionById(ParametersForGetFieldDefinitionById parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "culture", "$select" }, new Object[] { parameters.getCulture(), parameters.getSelect() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "fieldDefinitionId" }, new Object[] { parameters.getRepoId(), parameters.getFieldDefinitionId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions/{fieldDefinitionId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -49,55 +62,42 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested field definition id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested field definition id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns a paged listing of field definitions available in the specified repository.
+     * - Useful when trying to find a list of all field definitions available, rather than only those assigned to a specific entry/template.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetFieldDefinitions which encapsulates the parameters of getFieldDefinitions method.
+     *  @return ODataValueContextOfIListOfWFieldInfo The return value
+     */
     @Override
-    public ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(String repoId, String prefer, String culture,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetFieldDefinitions(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions", repoId, prefer, culture,
-                select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfWFieldInfo getFieldDefinitions(ParametersForGetFieldDefinitions parameters) {
+        return doGetFieldDefinitions(baseUrl + "/v1/Repositories/{repoId}/FieldDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfWFieldInfo doGetFieldDefinitions(String url, String repoId, String prefer,
-            String culture, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"culture", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{culture, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfWFieldInfo doGetFieldDefinitions(String url, ParametersForGetFieldDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "int", "int", "boolean" }, new String[] { "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -115,44 +115,32 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfWFieldInfo getFieldDefinitionsNextLink(String nextLink, Integer maxPageSize) {
-        return doGetFieldDefinitions(nextLink, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null, null, null,
-                null, null);
+    public ODataValueContextOfIListOfWFieldInfo getFieldDefinitionsNextLink(String nextLink, int maxPageSize) {
+        return doGetFieldDefinitions(nextLink, new ParametersForGetFieldDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfWFieldInfo response = getFieldDefinitions(repoId, prefer, culture, select, orderby,
-                top, skip, count);
+    public void getFieldDefinitionsForEach(Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetFieldDefinitions parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfWFieldInfo response = getFieldDefinitions(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getFieldDefinitionsNextLink(nextLink, maxPageSize);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -33,7 +33,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
     }
 
     /**
-     *  - Returns a single link definition associated with the specified ID.
+     * - Returns a single link definition associated with the specified ID.
      * - Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.
      * - Allowed OData query options: Select
      *
@@ -80,7 +80,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
     }
 
     /**
-     *  - Returns the link definitions in the repository.
+     * - Returns the link definitions in the repository.
      * - Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -1,19 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.LinkDefinitionsClient;
-import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import kong.unirest.HttpResponse;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.json.JSONObject;
-
 import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.LinkDefinitionsClient;
 
 public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefinitionsClient {
 
@@ -21,16 +32,19 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns a single link definition associated with the specified ID.
+     * - Provide a link type ID and get the associated link definition. Useful when a route provides a minimal amount of details and more information about the specific link definition is needed.
+     * - Allowed OData query options: Select
+     *
+     *  @param parameters An object of type ParametersForGetLinkDefinitionById which encapsulates the parameters of getLinkDefinitionById method.
+     *  @return EntryLinkTypeInfo The return value
+     */
     @Override
-    public EntryLinkTypeInfo getLinkDefinitionById(String repoId, Integer linkTypeId, String select) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"$select"}, new Object[]{select});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "linkTypeId"},
-                new Object[]{repoId, linkTypeId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/LinkDefinitions/{linkTypeId}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public EntryLinkTypeInfo getLinkDefinitionById(ParametersForGetLinkDefinitionById parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "$select" }, new Object[] { parameters.getSelect() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "linkTypeId" }, new Object[] { parameters.getRepoId(), parameters.getLinkTypeId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/LinkDefinitions/{linkTypeId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -48,56 +62,42 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(
-                        decideErrorMessage(problemDetails, "Requested link type definition ID not found"),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Requested link type definition ID not found"), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the link definitions in the repository.
+     * - Provide a repository ID and get a paged listing of link definitions available in the repository. Useful when trying to display all link definitions available, not only links assigned to a specific entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetLinkDefinitions which encapsulates the parameters of getLinkDefinitions method.
+     *  @return ODataValueContextOfIListOfEntryLinkTypeInfo The return value
+     */
     @Override
-    public ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitions(String repoId, String prefer, String select,
-            String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetLinkDefinitions(baseUrl + "/v1/Repositories/{repoId}/LinkDefinitions", repoId, prefer, select,
-                orderby, top, skip, count);
+    public ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitions(ParametersForGetLinkDefinitions parameters) {
+        return doGetLinkDefinitions(baseUrl + "/v1/Repositories/{repoId}/LinkDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfEntryLinkTypeInfo doGetLinkDefinitions(String url, String repoId, String prefer,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfEntryLinkTypeInfo doGetLinkDefinitions(String url, ParametersForGetLinkDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -115,45 +115,32 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitionsNextLink(String nextLink,
-            Integer maxPageSize) {
-        return doGetLinkDefinitions(nextLink, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null, null, null,
-                null);
+    public ODataValueContextOfIListOfEntryLinkTypeInfo getLinkDefinitionsNextLink(String nextLink, int maxPageSize) {
+        return doGetLinkDefinitions(nextLink, new ParametersForGetLinkDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String prefer, String select, String orderby, Integer top, Integer skip,
-            Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfEntryLinkTypeInfo response = getLinkDefinitions(repoId, prefer, select, orderby, top,
-                skip, count);
+    public void getLinkDefinitionsForEach(Function<ODataValueContextOfIListOfEntryLinkTypeInfo, Boolean> callback, Integer maxPageSize, ParametersForGetLinkDefinitions parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfEntryLinkTypeInfo response = getLinkDefinitions(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getLinkDefinitionsNextLink(nextLink, maxPageSize);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,30 +1,18 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.RepositoriesClient;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.RepositoriesClient;
+
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
 
 public class RepositoriesClientImpl extends ApiClient implements RepositoriesClient {
 
@@ -39,7 +27,9 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
      */
     @Override
     public RepositoryInfo[] getRepositoryList() {
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories").asObject(Object.class);
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories")
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -57,16 +47,23 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,18 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.RepositoriesClient;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
-import java.util.ArrayList;
-import java.util.Map;
-import java.util.Optional;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.RepositoriesClient;
 
 public class RepositoriesClientImpl extends ApiClient implements RepositoriesClient {
 
@@ -20,11 +32,14 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
         super(baseUrl, httpClient);
     }
 
+    /**
+     * - Returns the repository resource list that current user has access to.
+     *
+     * @return RepositoryInfo[] The return value
+     */
     @Override
     public RepositoryInfo[] getRepositoryList() {
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories")
-                .asObject(Object.class);
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories").asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -42,23 +57,16 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,30 +1,17 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.SearchesClient;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.SearchesClient;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class SearchesClientImpl extends ApiClient implements SearchesClient {
 
@@ -37,13 +24,18 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
      * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
      * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
      *
-     *  @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
-     *  @return OperationProgress The return value
+     * @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
+     * @return OperationProgress The return value
      */
     @Override
     public OperationProgress getSearchStatus(ParametersForGetSearchStatus parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "searchToken"},
+                new Object[]{parameters.getRepoId(), parameters.getSearchToken()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
             try {
@@ -61,18 +53,26 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -82,13 +82,18 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
      * - Cancels a currently running search.
      * - Closes a completed search.
      *
-     *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
+     * @return ODataValueOfBoolean The return value
      */
     @Override
     public ODataValueOfBoolean cancelOrCloseSearch(ParametersForCancelOrCloseSearch parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "searchToken"},
+                new Object[]{parameters.getRepoId(), parameters.getSearchToken()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -106,18 +111,26 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -128,20 +141,37 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
      * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
-     *  @return ODataValueContextOfIListOfContextHit The return value
+     * @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
+     * @return ODataValueContextOfIListOfContextHit The return value
      */
     @Override
     public ODataValueContextOfIListOfContextHit getSearchContextHits(ParametersForGetSearchContextHits parameters) {
-        return doGetSearchContextHits(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results/{rowNumber}/ContextHits", parameters);
+        return doGetSearchContextHits(
+                baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results/{rowNumber}/ContextHits",
+                parameters);
     }
 
-    private ODataValueContextOfIListOfContextHit doGetSearchContextHits(String url, ParametersForGetSearchContextHits parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int" }, new String[] { "repoId", "searchToken", "rowNumber" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken(), parameters.getRowNumber() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfContextHit doGetSearchContextHits(String url,
+            ParametersForGetSearchContextHits parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "int", "int", "boolean"},
+                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String", "int"},
+                new String[]{"repoId", "searchToken", "rowNumber"},
+                new Object[]{parameters.getRepoId(), parameters.getSearchToken(), parameters.getRowNumber()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -159,18 +189,26 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -178,11 +216,13 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
 
     @Override
     public ODataValueContextOfIListOfContextHit getSearchContextHitsNextLink(String nextLink, int maxPageSize) {
-        return doGetSearchContextHits(nextLink, new ParametersForGetSearchContextHits().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetSearchContextHits(nextLink,
+                new ParametersForGetSearchContextHits().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback, Integer maxPageSize, ParametersForGetSearchContextHits parameters) {
+    public void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback,
+            Integer maxPageSize, ParametersForGetSearchContextHits parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfContextHit response = getSearchContextHits(parameters);
         while (response != null && callback.apply(response)) {
@@ -195,13 +235,19 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
      * - Runs a search operation on the repository.
      * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
      *
-     *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
-     *  @return AcceptedOperation The return value
+     * @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
+     * @return AcceptedOperation The return value
      */
     @Override
     public AcceptedOperation createSearchOperation(ParametersForCreateSearchOperation parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Searches").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/Searches")
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -219,18 +265,26 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -245,8 +299,8 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     @Override
     public ODataValueContextOfIListOfEntry getSearchResults(ParametersForGetSearchResults parameters) {
@@ -254,11 +308,28 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     private ODataValueContextOfIListOfEntry doGetSearchResults(String url, ParametersForGetSearchResults parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "groupByEntryType", "refresh", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isGroupByEntryType(), parameters.isRefresh(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"boolean", "boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean"},
+                new String[]{"groupByEntryType", "refresh", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.isGroupByEntryType(), parameters.isRefresh(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "searchToken"},
+                new Object[]{parameters.getRepoId(), parameters.getSearchToken()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
+                        "fields") instanceof String ? Arrays.asList(
+                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -276,18 +347,26 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -295,11 +374,13 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
 
     @Override
     public ODataValueContextOfIListOfEntry getSearchResultsNextLink(String nextLink, int maxPageSize) {
-        return doGetSearchResults(nextLink, new ParametersForGetSearchResults().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetSearchResults(nextLink,
+                new ParametersForGetSearchResults().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetSearchResults parameters) {
+    public void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback,
+            Integer maxPageSize, ParametersForGetSearchResults parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfEntry response = getSearchResults(parameters);
         while (response != null && callback.apply(response)) {

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -33,7 +33,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     /**
-     *  - Returns search status.
+     * - Returns search status.
      * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
      * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
      *
@@ -79,7 +79,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     /**
-     *  - Cancels a currently running search.
+     * - Cancels a currently running search.
      * - Closes a completed search.
      *
      *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
@@ -124,7 +124,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     /**
-     *  - Returns the context hits associated with a search result entry.
+     * - Returns the context hits associated with a search result entry.
      * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -192,7 +192,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     /**
-     *  - Runs a search operation on the repository.
+     * - Runs a search operation on the repository.
      * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
      *
      *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
@@ -237,7 +237,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
     }
 
     /**
-     *  - Returns a search result listing if the search is completed.
+     * - Returns a search result listing if the search is completed.
      * - Optional query parameter: groupByOrderType (default false). This query parameter decides whether or not results are returned in groups based on their entry type.
      * - Optional query parameter: refresh (default false). If the search listing should be refreshed to show updated values.
      * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. sort order can be either &quot;asc&quot; or &quot;desc&quot;. Search results expire after 5 minutes, but can be refreshed by retrieving the results again.

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,16 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.SearchesClient;
-import com.laserfiche.repository.api.clients.impl.model.*;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.SearchesClient;
 
 public class SearchesClientImpl extends ApiClient implements SearchesClient {
 
@@ -18,14 +32,18 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns search status.
+     * - Provide a token (returned in the create search asynchronous route), and get the search status, progress, and any errors that may have occurred. When the search is completed, the Location header can be inspected as a link to the search results.
+     * - OperationStatus can be one of the following : NotStarted, InProgress, Completed, Failed, or Canceled.
+     *
+     *  @param parameters An object of type ParametersForGetSearchStatus which encapsulates the parameters of getSearchStatus method.
+     *  @return OperationProgress The return value
+     */
     @Override
-    public OperationProgress getSearchStatus(String repoId, String searchToken) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "searchToken"},
-                new Object[]{repoId, searchToken});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public OperationProgress getSearchStatus(ParametersForGetSearchStatus parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
             try {
@@ -43,39 +61,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Cancels a currently running search.
+     * - Closes a completed search.
+     *
+     *  @param parameters An object of type ParametersForCancelOrCloseSearch which encapsulates the parameters of cancelOrCloseSearch method.
+     *  @return ODataValueOfBoolean The return value
+     */
     @Override
-    public ODataValueOfBoolean cancelOrCloseSearch(String repoId, String searchToken) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "searchToken"},
-                new Object[]{repoId, searchToken});
-        HttpResponse<Object> httpResponse = httpClient
-                .delete(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfBoolean cancelOrCloseSearch(ParametersForCancelOrCloseSearch parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
+        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -93,57 +106,42 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns the context hits associated with a search result entry.
+     * - Given a searchToken, and rowNumber associated with a search entry in the listing, return the context hits for that entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetSearchContextHits which encapsulates the parameters of getSearchContextHits method.
+     *  @return ODataValueContextOfIListOfContextHit The return value
+     */
     @Override
-    public ODataValueContextOfIListOfContextHit getSearchContextHits(String repoId, String searchToken,
-            Integer rowNumber, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetSearchContextHits(
-                baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results/{rowNumber}/ContextHits", repoId,
-                searchToken, rowNumber, prefer, select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfContextHit getSearchContextHits(ParametersForGetSearchContextHits parameters) {
+        return doGetSearchContextHits(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results/{rowNumber}/ContextHits", parameters);
     }
 
-    private ODataValueContextOfIListOfContextHit doGetSearchContextHits(String url, String repoId, String searchToken,
-            Integer rowNumber, String prefer, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "searchToken", "rowNumber"},
-                new Object[]{repoId, searchToken, rowNumber});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfContextHit doGetSearchContextHits(String url, ParametersForGetSearchContextHits parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int", "int", "boolean" }, new String[] { "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "int" }, new String[] { "repoId", "searchToken", "rowNumber" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken(), parameters.getRowNumber() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -161,59 +159,49 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfContextHit getSearchContextHitsNextLink(String nextLink, Integer maxPageSize) {
-        return doGetSearchContextHits(nextLink, null, null, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null,
-                null, null, null);
+    public ODataValueContextOfIListOfContextHit getSearchContextHitsNextLink(String nextLink, int maxPageSize) {
+        return doGetSearchContextHits(nextLink, new ParametersForGetSearchContextHits().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback,
-            Integer maxPageSize, String repoId, String searchToken, Integer rowNumber, String prefer, String select,
-            String orderby, Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfContextHit response = getSearchContextHits(repoId, searchToken, rowNumber, prefer,
-                select, orderby, top, skip, count);
+    public void getSearchContextHitsForEach(Function<ODataValueContextOfIListOfContextHit, Boolean> callback, Integer maxPageSize, ParametersForGetSearchContextHits parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfContextHit response = getSearchContextHits(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getSearchContextHitsNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Runs a search operation on the repository.
+     * - Optional body parameters: FuzzyType: (default none), which can be used to determine what is considered a match by number of letters or percentage. FuzzyFactor: integer value that determines the degree to which a search will be considered a match (integer value for NumberOfLetters, or int value representing a percentage). The status for search operations must be checked via the Search specific status checking route.
+     *
+     *  @param parameters An object of type ParametersForCreateSearchOperation which encapsulates the parameters of createSearchOperation method.
+     *  @return AcceptedOperation The return value
+     */
     @Override
-    public AcceptedOperation createSearchOperation(String repoId, AdvancedSearchRequest requestBody) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/Searches")
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public AcceptedOperation createSearchOperation(ParametersForCreateSearchOperation parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/Searches").routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 201) {
             try {
@@ -231,62 +219,46 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Returns a search result listing if the search is completed.
+     * - Optional query parameter: groupByOrderType (default false). This query parameter decides whether or not results are returned in groups based on their entry type.
+     * - Optional query parameter: refresh (default false). If the search listing should be refreshed to show updated values.
+     * - Default page size: 150. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer. OData $OrderBy syntax should follow: &quot;PropertyName direction,PropertyName2 direction&quot;. sort order can be either &quot;asc&quot; or &quot;desc&quot;. Search results expire after 5 minutes, but can be refreshed by retrieving the results again.
+     * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.
+     * - If field values are requested, only the first value is returned if it is a multi value field.
+     * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
+     *
+     *  @param parameters An object of type ParametersForGetSearchResults which encapsulates the parameters of getSearchResults method.
+     *  @return ODataValueContextOfIListOfEntry The return value
+     */
     @Override
-    public ODataValueContextOfIListOfEntry getSearchResults(String repoId, String searchToken, Boolean groupByEntryType,
-            Boolean refresh, String[] fields, Boolean formatFields, String prefer, String culture, String select,
-            String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetSearchResults(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results", repoId,
-                searchToken, groupByEntryType, refresh, fields, formatFields, prefer, culture, select, orderby, top,
-                skip, count);
+    public ODataValueContextOfIListOfEntry getSearchResults(ParametersForGetSearchResults parameters) {
+        return doGetSearchResults(baseUrl + "/v1/Repositories/{repoId}/Searches/{searchToken}/Results", parameters);
     }
 
-    private ODataValueContextOfIListOfEntry doGetSearchResults(String url, String repoId, String searchToken,
-            Boolean groupByEntryType, Boolean refresh, String[] fields, Boolean formatFields, String prefer,
-            String culture, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"groupByEntryType", "refresh", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{groupByEntryType, refresh, fields, formatFields, culture, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "searchToken"},
-                new Object[]{repoId, searchToken});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
-                        "fields") instanceof String ? Arrays.asList(
-                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfEntry doGetSearchResults(String url, ParametersForGetSearchResults parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "boolean", "boolean", "String[]", "boolean", "String", "String", "String", "int", "int", "boolean" }, new String[] { "groupByEntryType", "refresh", "fields", "formatFields", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.isGroupByEntryType(), parameters.isRefresh(), parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "searchToken" }, new Object[] { parameters.getRepoId(), parameters.getSearchToken() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -304,45 +276,32 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfEntry getSearchResultsNextLink(String nextLink, Integer maxPageSize) {
-        return doGetSearchResults(nextLink, null, null, null, null, null, null,
-                mergeMaxSizeIntoPrefer(maxPageSize, null), null, null, null, null, null, null);
+    public ODataValueContextOfIListOfEntry getSearchResultsNextLink(String nextLink, int maxPageSize) {
+        return doGetSearchResults(nextLink, new ParametersForGetSearchResults().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback,
-            Integer maxPageSize, String repoId, String searchToken, Boolean groupByEntryType, Boolean refresh,
-            String[] fields, Boolean formatFields, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfEntry response = getSearchResults(repoId, searchToken, groupByEntryType, refresh,
-                fields, formatFields, prefer, culture, select, orderby, top, skip, count);
+    public void getSearchResultsForEach(Function<ODataValueContextOfIListOfEntry, Boolean> callback, Integer maxPageSize, ParametersForGetSearchResults parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfEntry response = getSearchResults(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getSearchResultsNextLink(nextLink, maxPageSize);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -1,17 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.ServerSessionClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
-import java.util.Map;
-import java.util.Optional;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.ServerSessionClient;
 
 public class ServerSessionClientImpl extends ApiClient implements ServerSessionClient {
 
@@ -19,13 +32,19 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Deprecated.
+     * - Invalidates the server session.
+     * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
+     * - Only available in Laserfiche Cloud.
+     *
+     *  @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
+     *  @return ODataValueOfBoolean The return value
+     */
     @Override
-    public ODataValueOfBoolean invalidateServerSession(String repoId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Invalidate")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfBoolean invalidateServerSession(ParametersForInvalidateServerSession parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Invalidate").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -43,38 +62,34 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Deprecated. This function is a no-op, always returns 200.
+     * - Only available in Laserfiche Cloud.
+     *
+     *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
+     *  @return ODataValueOfBoolean The return value
+     */
     @Override
-    public ODataValueOfBoolean createServerSession(String repoId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Create")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfBoolean createServerSession(ParametersForCreateServerSession parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Create").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -92,29 +107,30 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
+    /**
+     *  - Deprecated.
+     * - Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.
+     * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
+     * - Only available in Laserfiche Cloud.
+     *
+     *  @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
+     *  @return ODataValueOfDateTime The return value
+     */
     @Override
-    public ODataValueOfDateTime refreshServerSession(String repoId) {
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Refresh")
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public ODataValueOfDateTime refreshServerSession(ParametersForRefreshServerSession parameters) {
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Refresh").routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -132,26 +148,18 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -1,30 +1,20 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.ServerSessionClient;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfBoolean;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueOfDateTime;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateServerSession;
+import com.laserfiche.repository.api.clients.params.ParametersForInvalidateServerSession;
+import com.laserfiche.repository.api.clients.params.ParametersForRefreshServerSession;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.ServerSessionClient;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class ServerSessionClientImpl extends ApiClient implements ServerSessionClient {
 
@@ -38,13 +28,17 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
      * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForInvalidateServerSession which encapsulates the parameters of invalidateServerSession method.
+     * @return ODataValueOfBoolean The return value
      */
     @Override
     public ODataValueOfBoolean invalidateServerSession(ParametersForInvalidateServerSession parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Invalidate").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Invalidate")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -62,18 +56,26 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -83,13 +85,17 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
      * - Deprecated. This function is a no-op, always returns 200.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
-     *  @return ODataValueOfBoolean The return value
+     * @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
+     * @return ODataValueOfBoolean The return value
      */
     @Override
     public ODataValueOfBoolean createServerSession(ParametersForCreateServerSession parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Create").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Create")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -107,12 +113,17 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -124,13 +135,17 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
      * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
      * - Only available in Laserfiche Cloud.
      *
-     *  @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
-     *  @return ODataValueOfDateTime The return value
+     * @param parameters An object of type ParametersForRefreshServerSession which encapsulates the parameters of refreshServerSession method.
+     * @return ODataValueOfDateTime The return value
      */
     @Override
     public ODataValueOfDateTime refreshServerSession(ParametersForRefreshServerSession parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Refresh").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/ServerSession/Refresh")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -148,18 +163,26 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -33,7 +33,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
     }
 
     /**
-     *  - Deprecated.
+     * - Deprecated.
      * - Invalidates the server session.
      * - Acts as a &quot;logout&quot; operation, and invalidates the session associated with the provided access token. This method should be used when the client wants to clean up the current session.
      * - Only available in Laserfiche Cloud.
@@ -80,7 +80,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
     }
 
     /**
-     *  - Deprecated. This function is a no-op, always returns 200.
+     * - Deprecated. This function is a no-op, always returns 200.
      * - Only available in Laserfiche Cloud.
      *
      *  @param parameters An object of type ParametersForCreateServerSession which encapsulates the parameters of createServerSession method.
@@ -119,7 +119,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
     }
 
     /**
-     *  - Deprecated.
+     * - Deprecated.
      * - Refreshes the session associated with the access token. This is only necessary if you want to keep the same session alive, otherwise a new session will be automatically created when the session expires.
      * - When a client application wants to keep a session alive that has been idle for an hour, this route can be used to refresh the expiration timer associated with the access token.
      * - Only available in Laserfiche Cloud.

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,30 +1,16 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.SimpleSearchesClient;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateSimpleSearchOperation;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.SimpleSearchesClient;
+
+import java.util.*;
 
 public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearchesClient {
 
@@ -40,14 +26,28 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
      * - If field values are requested, only the first value is returned if it is a multi value field.
      * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
      *
-     *  @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
-     *  @return ODataValueContextOfIListOfEntry The return value
+     * @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
+     * @return ODataValueContextOfIListOfEntry The return value
      */
     @Override
-    public ODataValueContextOfIListOfEntry createSimpleSearchOperation(ParametersForCreateSimpleSearchOperation parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String[]", "boolean", "String", "String", "String", "boolean" }, new String[] { "fields", "formatFields", "culture", "$select", "$orderby", "$count" }, new Object[] { parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/SimpleSearches").queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
+    public ODataValueContextOfIListOfEntry createSimpleSearchOperation(
+            ParametersForCreateSimpleSearchOperation parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String[]", "boolean", "String", "String", "String", "boolean"},
+                new String[]{"fields", "formatFields", "culture", "$select", "$orderby", "$count"},
+                new Object[]{parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .post(baseUrl + "/v1/Repositories/{repoId}/SimpleSearches")
+                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
+                        "fields") instanceof String ? Arrays.asList(
+                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .contentType("application/json")
+                .body(parameters.getRequestBody())
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
             try {
@@ -65,18 +65,26 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,16 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.SimpleSearchesClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntry;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-
-import java.util.*;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.SimpleSearchesClient;
 
 public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearchesClient {
 
@@ -18,23 +32,22 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Runs a &quot;simple&quot; search operation on the repository.
+     * - Returns a truncated search result listing.
+     * - Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.
+     * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.
+     * - If field values are requested, only the first value is returned if it is a multi value field.
+     * - Null or Empty field values should not be used to determine if a field is assigned to the entry.
+     *
+     *  @param parameters An object of type ParametersForCreateSimpleSearchOperation which encapsulates the parameters of createSimpleSearchOperation method.
+     *  @return ODataValueContextOfIListOfEntry The return value
+     */
     @Override
-    public ODataValueContextOfIListOfEntry createSimpleSearchOperation(String select, String orderby, Boolean count,
-            String repoId, String[] fields, Boolean formatFields, SimpleSearchRequest requestBody, String culture) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"fields", "formatFields", "culture", "$select", "$orderby", "$count"},
-                new Object[]{fields, formatFields, culture, select, orderby, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        HttpResponse<Object> httpResponse = httpClient
-                .post(baseUrl + "/v1/Repositories/{repoId}/SimpleSearches")
-                .queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get(
-                        "fields") instanceof String ? Arrays.asList(
-                        queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList())
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .contentType("application/json")
-                .body(requestBody)
-                .asObject(Object.class);
+    public ODataValueContextOfIListOfEntry createSimpleSearchOperation(ParametersForCreateSimpleSearchOperation parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String[]", "boolean", "String", "String", "String", "boolean" }, new String[] { "fields", "formatFields", "culture", "$select", "$orderby", "$count" }, new Object[] { parameters.getFields(), parameters.isFormatFields(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        HttpResponse<Object> httpResponse = httpClient.post(baseUrl + "/v1/Repositories/{repoId}/SimpleSearches").queryString("fields", (queryParameters.get("fields") != null) ? (queryParameters.get("fields") instanceof String ? Arrays.asList(queryParameters.remove("fields")) : (List) queryParameters.remove("fields")) : new ArrayList()).queryString(queryParameters).routeParam(pathParameters).contentType("application/json").body(parameters.getRequestBody()).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
             try {
@@ -52,26 +65,18 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -33,7 +33,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
     }
 
     /**
-     *  - Runs a &quot;simple&quot; search operation on the repository.
+     * - Runs a &quot;simple&quot; search operation on the repository.
      * - Returns a truncated search result listing.
      * - Search result listing may be truncated, depending on number of results. Additionally, searches may time out if they take too long. Use the other search route to run full searches.
      * - Optionally returns field values for the entries in the search result listing. Each field name needs to be specified in the request. Maximum limit of 10 field names.

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,30 +1,21 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.TagDefinitionsClient;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitions;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.TagDefinitionsClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class TagDefinitionsClientImpl extends ApiClient implements TagDefinitionsClient {
 
@@ -37,20 +28,34 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
      * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
-     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
+     * @return ODataValueContextOfIListOfWTagInfo The return value
      */
     @Override
     public ODataValueContextOfIListOfWTagInfo getTagDefinitions(ParametersForGetTagDefinitions parameters) {
         return doGetTagDefinitions(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfWTagInfo doGetTagDefinitions(String url, ParametersForGetTagDefinitions parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "int", "int", "boolean" }, new String[] { "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfWTagInfo doGetTagDefinitions(String url,
+            ParametersForGetTagDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "String", "int", "int", "boolean"},
+                new String[]{"culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -68,18 +73,26 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
+                        httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -87,11 +100,13 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
 
     @Override
     public ODataValueContextOfIListOfWTagInfo getTagDefinitionsNextLink(String nextLink, int maxPageSize) {
-        return doGetTagDefinitions(nextLink, new ParametersForGetTagDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetTagDefinitions(nextLink,
+                new ParametersForGetTagDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagDefinitions parameters) {
+    public void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTagDefinitions parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfWTagInfo response = getTagDefinitions(parameters);
         while (response != null && callback.apply(response)) {
@@ -105,14 +120,20 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
      * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
-     *  @return WTagInfo The return value
+     * @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
+     * @return WTagInfo The return value
      */
     @Override
     public WTagInfo getTagDefinitionById(ParametersForGetTagDefinitionById parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "culture", "$select" }, new Object[] { parameters.getCulture(), parameters.getSelect() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "tagId" }, new Object[] { parameters.getRepoId(), parameters.getTagId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions/{tagId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"culture", "$select"}, new Object[]{parameters.getCulture(), parameters.getSelect()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "tagId"}, new Object[]{parameters.getRepoId(), parameters.getTagId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions/{tagId}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -130,18 +151,26 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request tag definition id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request tag definition id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -33,7 +33,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
     }
 
     /**
-     *  - Returns all tag definitions in the repository.
+     * - Returns all tag definitions in the repository.
      * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -101,7 +101,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
     }
 
     /**
-     *  - Returns a single tag definition.
+     * - Returns a single tag definition.
      * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
      * - Allowed OData query options: Select
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,19 +1,30 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.TagDefinitionsClient;
-import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
-import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
-import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
-import kong.unirest.HttpResponse;
-import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
-import kong.unirest.json.JSONObject;
-
 import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import kong.unirest.Header;
+import kong.unirest.UnirestInstance;
+import kong.unirest.UnirestParsingException;
+import kong.unirest.ObjectMapper;
+import kong.unirest.json.JSONArray;
+import kong.unirest.json.JSONObject;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.ExecutionException;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.TagDefinitionsClient;
 
 public class TagDefinitionsClientImpl extends ApiClient implements TagDefinitionsClient {
 
@@ -21,30 +32,25 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
         super(baseUrl, httpClient);
     }
 
+    /**
+     *  - Returns all tag definitions in the repository.
+     * - Provide a repository ID and get a paged listing of tag definitions available in the repository. Useful when trying to display all tag definitions available, not only tags assigned to a specific entry.
+     * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
+     *
+     *  @param parameters An object of type ParametersForGetTagDefinitions which encapsulates the parameters of getTagDefinitions method.
+     *  @return ODataValueContextOfIListOfWTagInfo The return value
+     */
     @Override
-    public ODataValueContextOfIListOfWTagInfo getTagDefinitions(String repoId, String prefer, String culture,
-            String select, String orderby, Integer top, Integer skip, Boolean count) {
-        return doGetTagDefinitions(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions", repoId, prefer, culture,
-                select, orderby, top, skip, count);
+    public ODataValueContextOfIListOfWTagInfo getTagDefinitions(ParametersForGetTagDefinitions parameters) {
+        return doGetTagDefinitions(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfWTagInfo doGetTagDefinitions(String url, String repoId, String prefer,
-            String culture, String select, String orderby, Integer top, Integer skip, Boolean count) {
-        Map<String, Object> queryParameters = getNonNullParameters(
-                new String[]{"culture", "$select", "$orderby", "$top", "$skip", "$count"},
-                new Object[]{culture, select, orderby, top, skip, count});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId"}, new Object[]{repoId});
-        Map<String, Object> headerParameters = getNonNullParameters(new String[]{"prefer"}, new Object[]{prefer});
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters
-                .entrySet()
-                .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient
-                .get(url)
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .headers(headerParametersWithStringTypeValue)
-                .asObject(Object.class);
+    private ODataValueContextOfIListOfWTagInfo doGetTagDefinitions(String url, ParametersForGetTagDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "int", "int", "boolean" }, new String[] { "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -62,61 +68,51 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfWTagInfo getTagDefinitionsNextLink(String nextLink, Integer maxPageSize) {
-        return doGetTagDefinitions(nextLink, null, mergeMaxSizeIntoPrefer(maxPageSize, null), null, null, null, null,
-                null, null);
+    public ODataValueContextOfIListOfWTagInfo getTagDefinitionsNextLink(String nextLink, int maxPageSize) {
+        return doGetTagDefinitions(nextLink, new ParametersForGetTagDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback,
-            Integer maxPageSize, String repoId, String prefer, String culture, String select, String orderby,
-            Integer top, Integer skip, Boolean count) {
-        prefer = mergeMaxSizeIntoPrefer(maxPageSize, prefer);
-        ODataValueContextOfIListOfWTagInfo response = getTagDefinitions(repoId, prefer, culture, select, orderby, top,
-                skip, count);
+    public void getTagDefinitionsForEach(Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTagDefinitions parameters) {
+        parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
+        ODataValueContextOfIListOfWTagInfo response = getTagDefinitions(parameters);
         while (response != null && callback.apply(response)) {
             String nextLink = response.getOdataNextLink();
             response = getTagDefinitionsNextLink(nextLink, maxPageSize);
         }
     }
 
+    /**
+     *  - Returns a single tag definition.
+     * - Provide a tag definition ID, and get the single tag definition associated with that ID. Useful when another route provides a minimal amount of details, and more information about the specific tag is needed.
+     * - Allowed OData query options: Select
+     *
+     *  @param parameters An object of type ParametersForGetTagDefinitionById which encapsulates the parameters of getTagDefinitionById method.
+     *  @return WTagInfo The return value
+     */
     @Override
-    public WTagInfo getTagDefinitionById(String repoId, Integer tagId, String culture, String select) {
-        Map<String, Object> queryParameters = getNonNullParameters(new String[]{"culture", "$select"},
-                new Object[]{culture, select});
-        Map<String, Object> pathParameters = getNonNullParameters(new String[]{"repoId", "tagId"},
-                new Object[]{repoId, tagId});
-        HttpResponse<Object> httpResponse = httpClient
-                .get(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions/{tagId}")
-                .queryString(queryParameters)
-                .routeParam(pathParameters)
-                .asObject(Object.class);
+    public WTagInfo getTagDefinitionById(ParametersForGetTagDefinitionById parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "culture", "$select" }, new Object[] { parameters.getCulture(), parameters.getSelect() });
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "tagId" }, new Object[] { parameters.getRepoId(), parameters.getTagId() });
+        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/TagDefinitions/{tagId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -134,26 +130,18 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request tag definition id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request tag definition id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -1,30 +1,18 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.TasksClient;
+import com.laserfiche.repository.api.clients.impl.model.OperationProgress;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.params.ParametersForCancelOperation;
+import com.laserfiche.repository.api.clients.params.ParametersForGetOperationStatusAndProgress;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.TasksClient;
+
+import java.util.Map;
+import java.util.Optional;
 
 public class TasksClientImpl extends ApiClient implements TasksClient {
 
@@ -37,13 +25,18 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
      * - Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).
      * - OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
      *
-     *  @param parameters An object of type ParametersForGetOperationStatusAndProgress which encapsulates the parameters of getOperationStatusAndProgress method.
-     *  @return OperationProgress The return value
+     * @param parameters An object of type ParametersForGetOperationStatusAndProgress which encapsulates the parameters of getOperationStatusAndProgress method.
+     * @return OperationProgress The return value
      */
     @Override
     public OperationProgress getOperationStatusAndProgress(ParametersForGetOperationStatusAndProgress parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "operationToken" }, new Object[] { parameters.getRepoId(), parameters.getOperationToken() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "operationToken"},
+                new Object[]{parameters.getRepoId(), parameters.getOperationToken()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
             try {
@@ -61,18 +54,26 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -83,13 +84,18 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
      * - Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.
      * - Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
      *
-     *  @param parameters An object of type ParametersForCancelOperation which encapsulates the parameters of cancelOperation method.
-     *  @return boolean The return value
+     * @param parameters An object of type ParametersForCancelOperation which encapsulates the parameters of cancelOperation method.
+     * @return boolean The return value
      */
     @Override
     public boolean cancelOperation(ParametersForCancelOperation parameters) {
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "repoId", "operationToken" }, new Object[] { parameters.getRepoId(), parameters.getOperationToken() });
-        HttpResponse<Object> httpResponse = httpClient.delete(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}").routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"repoId", "operationToken"},
+                new Object[]{parameters.getRepoId(), parameters.getOperationToken()});
+        HttpResponse<Object> httpResponse = httpClient
+                .delete(baseUrl + "/v1/Repositories/{repoId}/Tasks/{operationToken}")
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 204) {
             return true;
@@ -101,18 +107,26 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -33,7 +33,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
     }
 
     /**
-     *  - Returns the status of an operation.
+     * - Returns the status of an operation.
      * - Provide an operationToken (returned in other asynchronous routes) to get the operation status, progress, and any errors that may have occurred. When the operation is completed, the Location header can be inspected as a link to the modified resources (if relevant).
      * - OperationStatus can be one of the following values: NotStarted, InProgress, Completed, or Failed.
      *
@@ -79,7 +79,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
     }
 
     /**
-     *  - Cancels an operation.
+     * - Cancels an operation.
      * - Provide an operationToken to cancel the operation, if possible. Should be used if an operation was created in error, or is no longer necessary.
      * - Rollbacks must be done manually. For example, if a copy operation is started and is halfway complete when canceled, the client application is responsible for cleaning up the files that were successfully copied before the operation was canceled.
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -33,7 +33,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
     }
 
     /**
-     *  - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
+     * - Returns all template definitions (including field definitions) in the repository. If a template name query parameter is given, then a single template definition is returned.
      * - Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -101,7 +101,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
     }
 
     /**
-     *  - Returns the field definitions assigned to a template definition.
+     * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition name, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -169,7 +169,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
     }
 
     /**
-     *  - Returns the field definitions assigned to a template definition.
+     * - Returns the field definitions assigned to a template definition.
      * - Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
@@ -237,7 +237,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
     }
 
     /**
-     *  - Returns a single template definition (including field definitions, if relevant).
+     * - Returns a single template definition (including field definitions, if relevant).
      * - Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.
      * - Allowed OData query options: Select
      *

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -1,30 +1,24 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Optional;
-import java.util.function.Function;
-import java.util.function.Consumer;
-import java.util.stream.Collectors;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.laserfiche.repository.api.clients.TemplateDefinitionsClient;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfTemplateFieldInfo;
+import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTemplateInfo;
+import com.laserfiche.repository.api.clients.impl.model.ProblemDetails;
+import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitionsByTemplateName;
 import kong.unirest.HttpResponse;
-import kong.unirest.Unirest;
-import kong.unirest.Header;
 import kong.unirest.UnirestInstance;
 import kong.unirest.UnirestParsingException;
-import kong.unirest.ObjectMapper;
-import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
-import java.io.File;
-import java.io.InputStream;
-import java.nio.file.StandardCopyOption;
-import java.util.concurrent.ExecutionException;
-import com.laserfiche.repository.api.clients.impl.model.*;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.laserfiche.repository.api.clients.params.*;
-import com.laserfiche.repository.api.clients.TemplateDefinitionsClient;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 public class TemplateDefinitionsClientImpl extends ApiClient implements TemplateDefinitionsClient {
 
@@ -37,20 +31,35 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
      * - Provide a repository ID, and get a paged listing of template definitions available in the repository. Useful when trying to find a list of all template definitions available, rather than a specific one.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateDefinitions which encapsulates the parameters of getTemplateDefinitions method.
-     *  @return ODataValueContextOfIListOfWTemplateInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateDefinitions which encapsulates the parameters of getTemplateDefinitions method.
+     * @return ODataValueContextOfIListOfWTemplateInfo The return value
      */
     @Override
-    public ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitions(ParametersForGetTemplateDefinitions parameters) {
+    public ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitions(
+            ParametersForGetTemplateDefinitions parameters) {
         return doGetTemplateDefinitions(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions", parameters);
     }
 
-    private ODataValueContextOfIListOfWTemplateInfo doGetTemplateDefinitions(String url, ParametersForGetTemplateDefinitions parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "String", "int", "int", "boolean" }, new String[] { "templateName", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getTemplateName(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfWTemplateInfo doGetTemplateDefinitions(String url,
+            ParametersForGetTemplateDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "String", "String", "int", "int", "boolean"},
+                new String[]{"templateName", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getTemplateName(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -68,18 +77,26 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
@@ -87,11 +104,13 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
 
     @Override
     public ODataValueContextOfIListOfWTemplateInfo getTemplateDefinitionsNextLink(String nextLink, int maxPageSize) {
-        return doGetTemplateDefinitions(nextLink, new ParametersForGetTemplateDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+        return doGetTemplateDefinitions(nextLink,
+                new ParametersForGetTemplateDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateDefinitions parameters) {
+    public void getTemplateDefinitionsForEach(Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback,
+            Integer maxPageSize, ParametersForGetTemplateDefinitions parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfWTemplateInfo response = getTemplateDefinitions(parameters);
         while (response != null && callback.apply(response)) {
@@ -105,20 +124,36 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
      * - Provide a template definition name, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitionsByTemplateName which encapsulates the parameters of getTemplateFieldDefinitionsByTemplateName method.
-     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateFieldDefinitionsByTemplateName which encapsulates the parameters of getTemplateFieldDefinitionsByTemplateName method.
+     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
     @Override
-    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
-        return doGetTemplateFieldDefinitionsByTemplateName(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/Fields", parameters);
+    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateName(
+            ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
+        return doGetTemplateFieldDefinitionsByTemplateName(
+                baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/Fields", parameters);
     }
 
-    private ODataValueContextOfIListOfTemplateFieldInfo doGetTemplateFieldDefinitionsByTemplateName(String url, ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "String", "int", "int", "boolean" }, new String[] { "templateName", "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getTemplateName(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "repoId" }, new Object[] { parameters.getRepoId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfTemplateFieldInfo doGetTemplateFieldDefinitionsByTemplateName(String url,
+            ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "String", "String", "int", "int", "boolean"},
+                new String[]{"templateName", "culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getTemplateName(), parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"repoId"}, new Object[]{parameters.getRepoId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -136,30 +171,43 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(String nextLink, int maxPageSize) {
-        return doGetTemplateFieldDefinitionsByTemplateName(nextLink, new ParametersForGetTemplateFieldDefinitionsByTemplateName().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsByTemplateNameNextLink(
+            String nextLink, int maxPageSize) {
+        return doGetTemplateFieldDefinitionsByTemplateName(nextLink,
+                new ParametersForGetTemplateFieldDefinitionsByTemplateName().setPrefer(
+                        mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTemplateFieldDefinitionsByTemplateNameForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
+    public void getTemplateFieldDefinitionsByTemplateNameForEach(
+            Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize,
+            ParametersForGetTemplateFieldDefinitionsByTemplateName parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfTemplateFieldInfo response = getTemplateFieldDefinitionsByTemplateName(parameters);
         while (response != null && callback.apply(response)) {
@@ -173,20 +221,36 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
      * - Provide a template definition ID, and get a paged listing of the field definitions assigned to that template.
      * - Default page size: 100. Allowed OData query options: Select | Count | OrderBy | Skip | Top | SkipToken | Prefer.
      *
-     *  @param parameters An object of type ParametersForGetTemplateFieldDefinitions which encapsulates the parameters of getTemplateFieldDefinitions method.
-     *  @return ODataValueContextOfIListOfTemplateFieldInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateFieldDefinitions which encapsulates the parameters of getTemplateFieldDefinitions method.
+     * @return ODataValueContextOfIListOfTemplateFieldInfo The return value
      */
     @Override
-    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(ParametersForGetTemplateFieldDefinitions parameters) {
-        return doGetTemplateFieldDefinitions(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}/Fields", parameters);
+    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitions(
+            ParametersForGetTemplateFieldDefinitions parameters) {
+        return doGetTemplateFieldDefinitions(
+                baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}/Fields", parameters);
     }
 
-    private ODataValueContextOfIListOfTemplateFieldInfo doGetTemplateFieldDefinitions(String url, ParametersForGetTemplateFieldDefinitions parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String", "String", "int", "int", "boolean" }, new String[] { "culture", "$select", "$orderby", "$top", "$skip", "$count" }, new Object[] { parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "templateId" }, new Object[] { parameters.getRepoId(), parameters.getTemplateId() });
-        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[] { "String" }, new String[] { "prefer" }, new Object[] { parameters.getPrefer() });
-        Map<String, String> headerParametersWithStringTypeValue = headerParameters.entrySet().stream().collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
-        HttpResponse<Object> httpResponse = httpClient.get(url).queryString(queryParameters).routeParam(pathParameters).headers(headerParametersWithStringTypeValue).asObject(Object.class);
+    private ODataValueContextOfIListOfTemplateFieldInfo doGetTemplateFieldDefinitions(String url,
+            ParametersForGetTemplateFieldDefinitions parameters) {
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(
+                new String[]{"String", "String", "String", "int", "int", "boolean"},
+                new String[]{"culture", "$select", "$orderby", "$top", "$skip", "$count"},
+                new Object[]{parameters.getCulture(), parameters.getSelect(), parameters.getOrderby(), parameters.getTop(), parameters.getSkip(), parameters.isCount()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "templateId"}, new Object[]{parameters.getRepoId(), parameters.getTemplateId()});
+        Map<String, Object> headerParameters = getParametersWithNonDefaultValue(new String[]{"String"},
+                new String[]{"prefer"}, new Object[]{parameters.getPrefer()});
+        Map<String, String> headerParametersWithStringTypeValue = headerParameters
+                .entrySet()
+                .stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, e -> (String) e.getValue()));
+        HttpResponse<Object> httpResponse = httpClient
+                .get(url)
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .headers(headerParametersWithStringTypeValue)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -204,30 +268,42 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }
     }
 
     @Override
-    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsNextLink(String nextLink, int maxPageSize) {
-        return doGetTemplateFieldDefinitions(nextLink, new ParametersForGetTemplateFieldDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
+    public ODataValueContextOfIListOfTemplateFieldInfo getTemplateFieldDefinitionsNextLink(String nextLink,
+            int maxPageSize) {
+        return doGetTemplateFieldDefinitions(nextLink,
+                new ParametersForGetTemplateFieldDefinitions().setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, null)));
     }
 
     @Override
-    public void getTemplateFieldDefinitionsForEach(Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize, ParametersForGetTemplateFieldDefinitions parameters) {
+    public void getTemplateFieldDefinitionsForEach(
+            Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback, Integer maxPageSize,
+            ParametersForGetTemplateFieldDefinitions parameters) {
         parameters.setPrefer(mergeMaxSizeIntoPrefer(maxPageSize, parameters.getPrefer()));
         ODataValueContextOfIListOfTemplateFieldInfo response = getTemplateFieldDefinitions(parameters);
         while (response != null && callback.apply(response)) {
@@ -241,14 +317,20 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
      * - Provide a template definition ID, and get the single template definition associated with that ID. Useful when a route provides a minimal amount of details, and more information about the specific template is needed.
      * - Allowed OData query options: Select
      *
-     *  @param parameters An object of type ParametersForGetTemplateDefinitionById which encapsulates the parameters of getTemplateDefinitionById method.
-     *  @return WTemplateInfo The return value
+     * @param parameters An object of type ParametersForGetTemplateDefinitionById which encapsulates the parameters of getTemplateDefinitionById method.
+     * @return WTemplateInfo The return value
      */
     @Override
     public WTemplateInfo getTemplateDefinitionById(ParametersForGetTemplateDefinitionById parameters) {
-        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[] { "String", "String" }, new String[] { "culture", "$select" }, new Object[] { parameters.getCulture(), parameters.getSelect() });
-        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[] { "String", "int" }, new String[] { "repoId", "templateId" }, new Object[] { parameters.getRepoId(), parameters.getTemplateId() });
-        HttpResponse<Object> httpResponse = httpClient.get(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}").queryString(queryParameters).routeParam(pathParameters).asObject(Object.class);
+        Map<String, Object> queryParameters = getParametersWithNonDefaultValue(new String[]{"String", "String"},
+                new String[]{"culture", "$select"}, new Object[]{parameters.getCulture(), parameters.getSelect()});
+        Map<String, Object> pathParameters = getParametersWithNonDefaultValue(new String[]{"String", "int"},
+                new String[]{"repoId", "templateId"}, new Object[]{parameters.getRepoId(), parameters.getTemplateId()});
+        HttpResponse<Object> httpResponse = httpClient
+                .get(baseUrl + "/v1/Repositories/{repoId}/TemplateDefinitions/{templateId}")
+                .queryString(queryParameters)
+                .routeParam(pathParameters)
+                .asObject(Object.class);
         Object body = httpResponse.getBody();
         if (httpResponse.getStatus() == 200) {
             try {
@@ -266,18 +348,26 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 problemDetails = deserializeToProblemDetails(jsonString);
             } catch (JsonProcessingException | IllegalStateException e) {
                 Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(), (parsingException.isPresent() ? parsingException.get().getOriginalBody() : null), headersMap, null);
+                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+                        (parsingException.isPresent() ? parsingException
+                                .get()
+                                .getOriginalBody() : null), headersMap, null);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."), httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
             else
                 throw new RuntimeException(httpResponse.getStatusText());
         }

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
@@ -1,24 +1,22 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
+import com.laserfiche.repository.api.clients.impl.model.PutLinksRequest;
+
 import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 
 public class ParametersForAssignEntryLinks {
 
     /**
      * The request repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
-    List<PutLinksRequest> requestBody;
+    private List<PutLinksRequest> requestBody;
 
     public ParametersForAssignEntryLinks setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
@@ -1,0 +1,49 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForAssignEntryLinks {
+
+    /**
+     * The request repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    List<PutLinksRequest> requestBody;
+
+    public ParametersForAssignEntryLinks setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForAssignEntryLinks setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForAssignEntryLinks setRequestBody(List<PutLinksRequest> requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public List<PutLinksRequest> getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
@@ -1,30 +1,28 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
+import com.laserfiche.repository.api.clients.impl.model.FieldToUpdate;
+
 import java.util.Map;
-import java.util.function.Consumer;
 
 public class ParametersForAssignFieldValues {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The entry ID of the entry that will have its fields updated.
      */
-    int entryId;
+    private int entryId;
 
-    Map<String, FieldToUpdate> requestBody;
+    private Map<String, FieldToUpdate> requestBody;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     * The value should be a standard language tag. This may be used when setting field values with tokens.
      */
-    String culture;
+    private String culture;
 
     public ParametersForAssignFieldValues setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
@@ -1,0 +1,64 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForAssignFieldValues {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The entry ID of the entry that will have its fields updated.
+     */
+    int entryId;
+
+    Map<String, FieldToUpdate> requestBody;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     */
+    String culture;
+
+    public ParametersForAssignFieldValues setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForAssignFieldValues setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForAssignFieldValues setRequestBody(Map<String, FieldToUpdate> requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public Map<String, FieldToUpdate> getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForAssignFieldValues setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
@@ -1,0 +1,49 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForAssignTags {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    PutTagRequest requestBody;
+
+    public ParametersForAssignTags setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForAssignTags setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForAssignTags setRequestBody(PutTagRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public PutTagRequest getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
@@ -1,24 +1,20 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.PutTagRequest;
 
 public class ParametersForAssignTags {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
-    PutTagRequest requestBody;
+    private PutTagRequest requestBody;
 
     public ParametersForAssignTags setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForCancelOperation {
 
     /**
      * The requested repository ID
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The operation token
      */
-    String operationToken;
+    private String operationToken;
 
     public ParametersForCancelOperation setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCancelOperation {
+
+    /**
+     * The requested repository ID
+     */
+    String repoId;
+
+    /**
+     * The operation token
+     */
+    String operationToken;
+
+    public ParametersForCancelOperation setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCancelOperation setOperationToken(String operationToken) {
+        this.operationToken = operationToken;
+        return this;
+    }
+
+    public String getOperationToken() {
+        return this.operationToken;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForCancelOrCloseSearch {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested searchToken.
      */
-    String searchToken;
+    private String searchToken;
 
     public ParametersForCancelOrCloseSearch setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCancelOrCloseSearch {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested searchToken.
+     */
+    String searchToken;
+
+    public ParametersForCancelOrCloseSearch setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCancelOrCloseSearch setSearchToken(String searchToken) {
+        this.searchToken = searchToken;
+        return this;
+    }
+
+    public String getSearchToken() {
+        return this.searchToken;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
@@ -1,0 +1,79 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCopyEntryAsync {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The folder ID that the entry will be created in.
+     */
+    int entryId;
+
+    CopyAsyncRequest requestBody;
+
+    /**
+     * An optional query parameter used to indicate if the new entry should be automatically
+     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     */
+    boolean autoRename;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    public ParametersForCopyEntryAsync setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCopyEntryAsync setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForCopyEntryAsync setRequestBody(CopyAsyncRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public CopyAsyncRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForCopyEntryAsync setAutoRename(boolean autoRename) {
+        this.autoRename = autoRename;
+        return this;
+    }
+
+    public boolean isAutoRename() {
+        return this.autoRename;
+    }
+
+    public ParametersForCopyEntryAsync setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
@@ -1,36 +1,32 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.CopyAsyncRequest;
 
 public class ParametersForCopyEntryAsync {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The folder ID that the entry will be created in.
      */
-    int entryId;
+    private int entryId;
 
-    CopyAsyncRequest requestBody;
+    private CopyAsyncRequest requestBody;
 
     /**
      * An optional query parameter used to indicate if the new entry should be automatically
-     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     * renamed if an entry already exists with the given name in the folder. The default value is false.
      */
-    boolean autoRename;
+    private boolean autoRename;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     public ParametersForCopyEntryAsync setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
@@ -1,36 +1,32 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.PostEntryChildrenRequest;
 
 public class ParametersForCreateOrCopyEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The folder ID that the entry will be created in.
      */
-    int entryId;
+    private int entryId;
 
-    PostEntryChildrenRequest requestBody;
+    private PostEntryChildrenRequest requestBody;
 
     /**
      * An optional query parameter used to indicate if the new entry should be automatically
-     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     * renamed if an entry already exists with the given name in the folder. The default value is false.
      */
-    boolean autoRename;
+    private boolean autoRename;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     public ParametersForCreateOrCopyEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
@@ -1,0 +1,79 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCreateOrCopyEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The folder ID that the entry will be created in.
+     */
+    int entryId;
+
+    PostEntryChildrenRequest requestBody;
+
+    /**
+     * An optional query parameter used to indicate if the new entry should be automatically
+     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     */
+    boolean autoRename;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    public ParametersForCreateOrCopyEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCreateOrCopyEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForCreateOrCopyEntry setRequestBody(PostEntryChildrenRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public PostEntryChildrenRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForCreateOrCopyEntry setAutoRename(boolean autoRename) {
+        this.autoRename = autoRename;
+        return this;
+    }
+
+    public boolean isAutoRename() {
+        return this.autoRename;
+    }
+
+    public ParametersForCreateOrCopyEntry setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
@@ -1,0 +1,35 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCreateSearchOperation {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    AdvancedSearchRequest requestBody;
+
+    public ParametersForCreateSearchOperation setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCreateSearchOperation setRequestBody(AdvancedSearchRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public AdvancedSearchRequest getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
@@ -1,19 +1,15 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.AdvancedSearchRequest;
 
 public class ParametersForCreateSearchOperation {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
-    AdvancedSearchRequest requestBody;
+    private AdvancedSearchRequest requestBody;
 
     public ParametersForCreateSearchOperation setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
@@ -1,17 +1,11 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForCreateServerSession {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     public ParametersForCreateServerSession setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
@@ -1,0 +1,24 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCreateServerSession {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    public ParametersForCreateServerSession setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
@@ -1,51 +1,47 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
 
 public class ParametersForCreateSimpleSearchOperation {
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
      */
-    String[] fields;
+    private String[] fields;
 
     /**
      * Boolean for if field values should be formatted. Only applicable if Fields are specified.
      */
-    boolean formatFields;
+    private boolean formatFields;
 
-    SimpleSearchRequest requestBody;
+    private SimpleSearchRequest requestBody;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *            culture will not be used for formatting.
+     * The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     * culture will not be used for formatting.
      */
-    String culture;
+    private String culture;
 
     public ParametersForCreateSimpleSearchOperation setSelect(String select) {
         this.select = select;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
@@ -1,0 +1,121 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForCreateSimpleSearchOperation {
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
+     */
+    String[] fields;
+
+    /**
+     * Boolean for if field values should be formatted. Only applicable if Fields are specified.
+     */
+    boolean formatFields;
+
+    SimpleSearchRequest requestBody;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     *            culture will not be used for formatting.
+     */
+    String culture;
+
+    public ParametersForCreateSimpleSearchOperation setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setFields(String[] fields) {
+        this.fields = fields;
+        return this;
+    }
+
+    public String[] getFields() {
+        return this.fields;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setFormatFields(boolean formatFields) {
+        this.formatFields = formatFields;
+        return this;
+    }
+
+    public boolean isFormatFields() {
+        return this.formatFields;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setRequestBody(SimpleSearchRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public SimpleSearchRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForCreateSimpleSearchOperation setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForDeleteAssignedTemplate {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The ID of the entry that will have its template removed.
+     */
+    int entryId;
+
+    public ParametersForDeleteAssignedTemplate setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForDeleteAssignedTemplate setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForDeleteAssignedTemplate {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The ID of the entry that will have its template removed.
      */
-    int entryId;
+    private int entryId;
 
     public ParametersForDeleteAssignedTemplate setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForDeleteDocument {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested document ID.
      */
-    int entryId;
+    private int entryId;
 
     public ParametersForDeleteDocument setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForDeleteDocument {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested document ID.
+     */
+    int entryId;
+
+    public ParametersForDeleteDocument setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForDeleteDocument setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
@@ -1,24 +1,20 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.DeleteEntryWithAuditReason;
 
 public class ParametersForDeleteEntryInfo {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
-    DeleteEntryWithAuditReason requestBody;
+    private DeleteEntryWithAuditReason requestBody;
 
     public ParametersForDeleteEntryInfo setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
@@ -1,0 +1,49 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForDeleteEntryInfo {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    DeleteEntryWithAuditReason requestBody;
+
+    public ParametersForDeleteEntryInfo setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForDeleteEntryInfo setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForDeleteEntryInfo setRequestBody(DeleteEntryWithAuditReason requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public DeleteEntryWithAuditReason getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
@@ -1,27 +1,21 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForDeletePages {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested document ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * The pages to be deleted.
      */
-    String pageRange;
+    private String pageRange;
 
     public ParametersForDeletePages setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
@@ -1,0 +1,52 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForDeletePages {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested document ID.
+     */
+    int entryId;
+
+    /**
+     * The pages to be deleted.
+     */
+    String pageRange;
+
+    public ParametersForDeletePages setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForDeletePages setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForDeletePages setPageRange(String pageRange) {
+        this.pageRange = pageRange;
+        return this;
+    }
+
+    public String getPageRange() {
+        return this.pageRange;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
@@ -1,9 +1,6 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 public class ParametersForExportDocument {
@@ -11,20 +8,20 @@ public class ParametersForExportDocument {
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested document ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * An optional header used to retrieve partial content of the edoc. Only supports single
-     *            range with byte unit.
+     * range with byte unit.
      */
-    String range;
+    private String range;
 
-    Consumer<InputStream> inputStreamConsumer;
+    private Consumer<InputStream> inputStreamConsumer;
 
     public ParametersForExportDocument setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
@@ -1,0 +1,64 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForExportDocument {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested document ID.
+     */
+    int entryId;
+
+    /**
+     * An optional header used to retrieve partial content of the edoc. Only supports single
+     *            range with byte unit.
+     */
+    String range;
+
+    Consumer<InputStream> inputStreamConsumer;
+
+    public ParametersForExportDocument setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForExportDocument setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForExportDocument setRange(String range) {
+        this.range = range;
+        return this;
+    }
+
+    public String getRange() {
+        return this.range;
+    }
+
+    public ParametersForExportDocument setInputStreamConsumer(Consumer<InputStream> inputStreamConsumer) {
+        this.inputStreamConsumer = inputStreamConsumer;
+        return this;
+    }
+
+    public Consumer<InputStream> getInputStreamConsumer() {
+        return this.inputStreamConsumer;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
@@ -1,0 +1,75 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForExportDocumentWithAuditReason {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested document ID.
+     */
+    int entryId;
+
+    GetEdocWithAuditReasonRequest requestBody;
+
+    /**
+     * An optional header used to retrieve partial content of the edoc. Only supports single
+     *            range with byte unit.
+     */
+    String range;
+
+    Consumer<InputStream> inputStreamConsumer;
+
+    public ParametersForExportDocumentWithAuditReason setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForExportDocumentWithAuditReason setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForExportDocumentWithAuditReason setRequestBody(GetEdocWithAuditReasonRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public GetEdocWithAuditReasonRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForExportDocumentWithAuditReason setRange(String range) {
+        this.range = range;
+        return this;
+    }
+
+    public String getRange() {
+        return this.range;
+    }
+
+    public ParametersForExportDocumentWithAuditReason setInputStreamConsumer(Consumer<InputStream> inputStreamConsumer) {
+        this.inputStreamConsumer = inputStreamConsumer;
+        return this;
+    }
+
+    public Consumer<InputStream> getInputStreamConsumer() {
+        return this.inputStreamConsumer;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
@@ -1,9 +1,8 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.impl.model.GetEdocWithAuditReasonRequest;
+
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
 import java.util.function.Consumer;
 
 public class ParametersForExportDocumentWithAuditReason {
@@ -11,22 +10,22 @@ public class ParametersForExportDocumentWithAuditReason {
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested document ID.
      */
-    int entryId;
+    private int entryId;
 
-    GetEdocWithAuditReasonRequest requestBody;
+    private GetEdocWithAuditReasonRequest requestBody;
 
     /**
      * An optional header used to retrieve partial content of the edoc. Only supports single
-     *            range with byte unit.
+     * range with byte unit.
      */
-    String range;
+    private String range;
 
-    Consumer<InputStream> inputStreamConsumer;
+    private Consumer<InputStream> inputStreamConsumer;
 
     public ParametersForExportDocumentWithAuditReason setRepoId(String repoId) {
         this.repoId = repoId;
@@ -64,7 +63,8 @@ public class ParametersForExportDocumentWithAuditReason {
         return this.range;
     }
 
-    public ParametersForExportDocumentWithAuditReason setInputStreamConsumer(Consumer<InputStream> inputStreamConsumer) {
+    public ParametersForExportDocumentWithAuditReason setInputStreamConsumer(
+            Consumer<InputStream> inputStreamConsumer) {
         this.inputStreamConsumer = inputStreamConsumer;
         return this;
     }

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
@@ -1,0 +1,24 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetAuditReasons {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    public ParametersForGetAuditReasons setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
@@ -1,17 +1,11 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetAuditReasons {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     public ParametersForGetAuditReasons setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetDocumentContentType {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested document ID.
      */
-    int entryId;
+    private int entryId;
 
     public ParametersForGetDocumentContentType setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetDocumentContentType {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested document ID.
+     */
+    int entryId;
+
+    public ParametersForGetDocumentContentType setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetDocumentContentType setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
@@ -1,0 +1,49 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetDynamicFieldValues {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    GetDynamicFieldLogicValueRequest requestBody;
+
+    public ParametersForGetDynamicFieldValues setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetDynamicFieldValues setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetDynamicFieldValues setRequestBody(GetDynamicFieldLogicValueRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public GetDynamicFieldLogicValueRequest getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
@@ -1,24 +1,20 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.GetDynamicFieldLogicValueRequest;
 
 public class ParametersForGetDynamicFieldValues {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
-    GetDynamicFieldLogicValueRequest requestBody;
+    private GetDynamicFieldLogicValueRequest requestBody;
 
     public ParametersForGetDynamicFieldValues setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
@@ -1,0 +1,52 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    public ParametersForGetEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetEntry setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
@@ -1,27 +1,21 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     public ParametersForGetEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
@@ -1,0 +1,52 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetEntryByPath {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry path.
+     */
+    String fullPath;
+
+    /**
+     * An optional query parameter used to indicate whether or not the closest ancestor in the path should be returned if the initial entry path is not found. The default value is false.
+     */
+    boolean fallbackToClosestAncestor;
+
+    public ParametersForGetEntryByPath setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetEntryByPath setFullPath(String fullPath) {
+        this.fullPath = fullPath;
+        return this;
+    }
+
+    public String getFullPath() {
+        return this.fullPath;
+    }
+
+    public ParametersForGetEntryByPath setFallbackToClosestAncestor(boolean fallbackToClosestAncestor) {
+        this.fallbackToClosestAncestor = fallbackToClosestAncestor;
+        return this;
+    }
+
+    public boolean isFallbackToClosestAncestor() {
+        return this.fallbackToClosestAncestor;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
@@ -1,27 +1,21 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetEntryByPath {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry path.
      */
-    String fullPath;
+    private String fullPath;
 
     /**
      * An optional query parameter used to indicate whether or not the closest ancestor in the path should be returned if the initial entry path is not found. The default value is false.
      */
-    boolean fallbackToClosestAncestor;
+    private boolean fallbackToClosestAncestor;
 
     public ParametersForGetEntryByPath setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
@@ -1,0 +1,180 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetEntryListing {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The folder ID.
+     */
+    int entryId;
+
+    /**
+     * An optional query parameter used to indicate if the result should be grouped by entry type or not.
+     */
+    boolean groupByEntryType;
+
+    /**
+     * Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
+     */
+    String[] fields;
+
+    /**
+     * Boolean for if field values should be formatted. Only applicable if Fields are specified.
+     */
+    boolean formatFields;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     *            culture will not be used for formatting.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetEntryListing setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetEntryListing setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetEntryListing setGroupByEntryType(boolean groupByEntryType) {
+        this.groupByEntryType = groupByEntryType;
+        return this;
+    }
+
+    public boolean isGroupByEntryType() {
+        return this.groupByEntryType;
+    }
+
+    public ParametersForGetEntryListing setFields(String[] fields) {
+        this.fields = fields;
+        return this;
+    }
+
+    public String[] getFields() {
+        return this.fields;
+    }
+
+    public ParametersForGetEntryListing setFormatFields(boolean formatFields) {
+        this.formatFields = formatFields;
+        return this;
+    }
+
+    public boolean isFormatFields() {
+        return this.formatFields;
+    }
+
+    public ParametersForGetEntryListing setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetEntryListing setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetEntryListing setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetEntryListing setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetEntryListing setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetEntryListing setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetEntryListing setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
@@ -1,74 +1,68 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetEntryListing {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The folder ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * An optional query parameter used to indicate if the result should be grouped by entry type or not.
      */
-    boolean groupByEntryType;
+    private boolean groupByEntryType;
 
     /**
      * Optional array of field names. Field values corresponding to the given field names will be returned for each entry.
      */
-    String[] fields;
+    private String[] fields;
 
     /**
      * Boolean for if field values should be formatted. Only applicable if Fields are specified.
      */
-    boolean formatFields;
+    private boolean formatFields;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *            culture will not be used for formatting.
+     * The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     * culture will not be used for formatting.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetEntryListing setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
@@ -1,0 +1,67 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetFieldDefinitionById {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested field definition ID.
+     */
+    int fieldDefinitionId;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    public ParametersForGetFieldDefinitionById setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetFieldDefinitionById setFieldDefinitionId(int fieldDefinitionId) {
+        this.fieldDefinitionId = fieldDefinitionId;
+        return this;
+    }
+
+    public int getFieldDefinitionId() {
+        return this.fieldDefinitionId;
+    }
+
+    public ParametersForGetFieldDefinitionById setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetFieldDefinitionById setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
@@ -1,33 +1,27 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetFieldDefinitionById {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested field definition ID.
      */
-    int fieldDefinitionId;
+    private int fieldDefinitionId;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     public ParametersForGetFieldDefinitionById setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
@@ -1,53 +1,47 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetFieldDefinitions {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetFieldDefinitions setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
@@ -1,0 +1,123 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetFieldDefinitions {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetFieldDefinitions setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetFieldDefinitions setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetFieldDefinitions setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetFieldDefinitions setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetFieldDefinitions setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetFieldDefinitions setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetFieldDefinitions setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetFieldDefinitions setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
@@ -1,0 +1,153 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetFieldValues {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate if the field values should be formatted.
+     *            The default value is false.
+     */
+    boolean formatValue;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag. The formatValue query parameter must be set to true, otherwise
+     *            culture will not be used for formatting.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetFieldValues setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetFieldValues setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetFieldValues setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetFieldValues setFormatValue(boolean formatValue) {
+        this.formatValue = formatValue;
+        return this;
+    }
+
+    public boolean isFormatValue() {
+        return this.formatValue;
+    }
+
+    public ParametersForGetFieldValues setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetFieldValues setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetFieldValues setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetFieldValues setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetFieldValues setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetFieldValues setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
@@ -1,65 +1,59 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetFieldValues {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate if the field values should be formatted.
-     *            The default value is false.
+     * The default value is false.
      */
-    boolean formatValue;
+    private boolean formatValue;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag. The formatValue query parameter must be set to true, otherwise
-     *            culture will not be used for formatting.
+     * The value should be a standard language tag. The formatValue query parameter must be set to true, otherwise
+     * culture will not be used for formatting.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetFieldValues setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
@@ -1,0 +1,52 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetLinkDefinitionById {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested link type ID.
+     */
+    int linkTypeId;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    public ParametersForGetLinkDefinitionById setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetLinkDefinitionById setLinkTypeId(int linkTypeId) {
+        this.linkTypeId = linkTypeId;
+        return this;
+    }
+
+    public int getLinkTypeId() {
+        return this.linkTypeId;
+    }
+
+    public ParametersForGetLinkDefinitionById setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
@@ -1,27 +1,21 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetLinkDefinitionById {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested link type ID.
      */
-    int linkTypeId;
+    private int linkTypeId;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     public ParametersForGetLinkDefinitionById setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
@@ -1,47 +1,41 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetLinkDefinitions {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetLinkDefinitions setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
@@ -1,0 +1,108 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetLinkDefinitions {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetLinkDefinitions setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetLinkDefinitions setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetLinkDefinitions setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetLinkDefinitions setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetLinkDefinitions setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetLinkDefinitions setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetLinkDefinitions setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
@@ -1,52 +1,46 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetLinkValuesFromEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetLinkValuesFromEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
@@ -1,0 +1,122 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetLinkValuesFromEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    /**
+     * An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetLinkValuesFromEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetLinkValuesFromEntry setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetOperationStatusAndProgress {
 
     /**
      * The requested repository ID
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The operation token
      */
-    String operationToken;
+    private String operationToken;
 
     public ParametersForGetOperationStatusAndProgress setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetOperationStatusAndProgress {
+
+    /**
+     * The requested repository ID
+     */
+    String repoId;
+
+    /**
+     * The operation token
+     */
+    String operationToken;
+
+    public ParametersForGetOperationStatusAndProgress setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetOperationStatusAndProgress setOperationToken(String operationToken) {
+        this.operationToken = operationToken;
+        return this;
+    }
+
+    public String getOperationToken() {
+        return this.operationToken;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
@@ -1,57 +1,51 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetSearchContextHits {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested searchToken.
      */
-    String searchToken;
+    private String searchToken;
 
     /**
      * The search result listing row number to get context hits for.
      */
-    int rowNumber;
+    private int rowNumber;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetSearchContextHits setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
@@ -1,0 +1,136 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetSearchContextHits {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested searchToken.
+     */
+    String searchToken;
+
+    /**
+     * The search result listing row number to get context hits for.
+     */
+    int rowNumber;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetSearchContextHits setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetSearchContextHits setSearchToken(String searchToken) {
+        this.searchToken = searchToken;
+        return this;
+    }
+
+    public String getSearchToken() {
+        return this.searchToken;
+    }
+
+    public ParametersForGetSearchContextHits setRowNumber(int rowNumber) {
+        this.rowNumber = rowNumber;
+        return this;
+    }
+
+    public int getRowNumber() {
+        return this.rowNumber;
+    }
+
+    public ParametersForGetSearchContextHits setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetSearchContextHits setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetSearchContextHits setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetSearchContextHits setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetSearchContextHits setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetSearchContextHits setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
@@ -1,0 +1,194 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetSearchResults {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested searchToken.
+     */
+    String searchToken;
+
+    /**
+     * An optional query parameter used to indicate if the result should be grouped by entry type or not.
+     */
+    boolean groupByEntryType;
+
+    /**
+     * If the search listing should be refreshed to show updated values.
+     */
+    boolean refresh;
+
+    /**
+     * Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
+     */
+    String[] fields;
+
+    /**
+     * Boolean for if field values should be formatted. Only applicable if Fields are specified.
+     */
+    boolean formatFields;
+
+    /**
+     * An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     *            culture will not be used for formatting.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetSearchResults setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetSearchResults setSearchToken(String searchToken) {
+        this.searchToken = searchToken;
+        return this;
+    }
+
+    public String getSearchToken() {
+        return this.searchToken;
+    }
+
+    public ParametersForGetSearchResults setGroupByEntryType(boolean groupByEntryType) {
+        this.groupByEntryType = groupByEntryType;
+        return this;
+    }
+
+    public boolean isGroupByEntryType() {
+        return this.groupByEntryType;
+    }
+
+    public ParametersForGetSearchResults setRefresh(boolean refresh) {
+        this.refresh = refresh;
+        return this;
+    }
+
+    public boolean isRefresh() {
+        return this.refresh;
+    }
+
+    public ParametersForGetSearchResults setFields(String[] fields) {
+        this.fields = fields;
+        return this;
+    }
+
+    public String[] getFields() {
+        return this.fields;
+    }
+
+    public ParametersForGetSearchResults setFormatFields(boolean formatFields) {
+        this.formatFields = formatFields;
+        return this;
+    }
+
+    public boolean isFormatFields() {
+        return this.formatFields;
+    }
+
+    public ParametersForGetSearchResults setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetSearchResults setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetSearchResults setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetSearchResults setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetSearchResults setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetSearchResults setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetSearchResults setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
@@ -1,79 +1,73 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetSearchResults {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested searchToken.
      */
-    String searchToken;
+    private String searchToken;
 
     /**
      * An optional query parameter used to indicate if the result should be grouped by entry type or not.
      */
-    boolean groupByEntryType;
+    private boolean groupByEntryType;
 
     /**
      * If the search listing should be refreshed to show updated values.
      */
-    boolean refresh;
+    private boolean refresh;
 
     /**
      * Optional array of field names. Field values corresponding to the given field names will be returned for each search result.
      */
-    String[] fields;
+    private String[] fields;
 
     /**
      * Boolean for if field values should be formatted. Only applicable if Fields are specified.
      */
-    boolean formatFields;
+    private boolean formatFields;
 
     /**
      * An optional odata header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
-     *            culture will not be used for formatting.
+     * The value should be a standard language tag. The formatFields query parameter must be set to true, otherwise
+     * culture will not be used for formatting.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetSearchResults setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
@@ -1,0 +1,38 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetSearchStatus {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested searchToken.
+     */
+    String searchToken;
+
+    public ParametersForGetSearchStatus setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetSearchStatus setSearchToken(String searchToken) {
+        this.searchToken = searchToken;
+        return this;
+    }
+
+    public String getSearchToken() {
+        return this.searchToken;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
@@ -1,22 +1,16 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetSearchStatus {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested searchToken.
      */
-    String searchToken;
+    private String searchToken;
 
     public ParametersForGetSearchStatus setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
@@ -1,0 +1,67 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTagDefinitionById {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested tag definition ID.
+     */
+    int tagId;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    public ParametersForGetTagDefinitionById setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTagDefinitionById setTagId(int tagId) {
+        this.tagId = tagId;
+        return this;
+    }
+
+    public int getTagId() {
+        return this.tagId;
+    }
+
+    public ParametersForGetTagDefinitionById setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTagDefinitionById setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
@@ -1,33 +1,27 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTagDefinitionById {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested tag definition ID.
      */
-    int tagId;
+    private int tagId;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     public ParametersForGetTagDefinitionById setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
@@ -1,53 +1,47 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTagDefinitions {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTagDefinitions setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
@@ -1,0 +1,123 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTagDefinitions {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTagDefinitions setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTagDefinitions setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTagDefinitions setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTagDefinitions setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTagDefinitions setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTagDefinitions setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTagDefinitions setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTagDefinitions setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
@@ -1,0 +1,122 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTagsAssignedToEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTagsAssignedToEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTagsAssignedToEntry setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
@@ -1,52 +1,46 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTagsAssignedToEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTagsAssignedToEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
@@ -1,33 +1,27 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTemplateDefinitionById {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested template definition ID.
      */
-    int templateId;
+    private int templateId;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     public ParametersForGetTemplateDefinitionById setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
@@ -1,0 +1,67 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTemplateDefinitionById {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested template definition ID.
+     */
+    int templateId;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    public ParametersForGetTemplateDefinitionById setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTemplateDefinitionById setTemplateId(int templateId) {
+        this.templateId = templateId;
+        return this;
+    }
+
+    public int getTemplateId() {
+        return this.templateId;
+    }
+
+    public ParametersForGetTemplateDefinitionById setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTemplateDefinitionById setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
@@ -1,58 +1,52 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTemplateDefinitions {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * An optional query parameter. Can be used to get a single template definition using the template name.
      */
-    String templateName;
+    private String templateName;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTemplateDefinitions setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
@@ -1,0 +1,137 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTemplateDefinitions {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * An optional query parameter. Can be used to get a single template definition using the template name.
+     */
+    String templateName;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTemplateDefinitions setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTemplateDefinitions setTemplateName(String templateName) {
+        this.templateName = templateName;
+        return this;
+    }
+
+    public String getTemplateName() {
+        return this.templateName;
+    }
+
+    public ParametersForGetTemplateDefinitions setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTemplateDefinitions setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTemplateDefinitions setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTemplateDefinitions setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTemplateDefinitions setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTemplateDefinitions setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTemplateDefinitions setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
@@ -1,58 +1,52 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTemplateFieldDefinitions {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested template definition ID.
      */
-    int templateId;
+    private int templateId;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTemplateFieldDefinitions setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
@@ -1,0 +1,137 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTemplateFieldDefinitions {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested template definition ID.
+     */
+    int templateId;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTemplateFieldDefinitions setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setTemplateId(int templateId) {
+        this.templateId = templateId;
+        return this;
+    }
+
+    public int getTemplateId() {
+        return this.templateId;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTemplateFieldDefinitions setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
@@ -1,58 +1,52 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTemplateFieldDefinitionsByTemplateName {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * A required query parameter for the requested template name.
      */
-    String templateName;
+    private String templateName;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * An optional query parameter used to indicate the locale that should be used for formatting.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTemplateFieldDefinitionsByTemplateName setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
@@ -1,0 +1,137 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTemplateFieldDefinitionsByTemplateName {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * A required query parameter for the requested template name.
+     */
+    String templateName;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used for formatting.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setTemplateName(String templateName) {
+        this.templateName = templateName;
+        return this;
+    }
+
+    public String getTemplateName() {
+        return this.templateName;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTemplateFieldDefinitionsByTemplateName setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
@@ -1,0 +1,122 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTrusteeAttributeKeyValuePairs {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * Boolean value that indicates whether to return attributes key value pairs associated with everyone or the currently authenticated user.
+     */
+    boolean everyone;
+
+    /**
+     * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
+     */
+    String prefer;
+
+    /**
+     * Limits the properties returned in the result.
+     */
+    String select;
+
+    /**
+     * Specifies the order in which items are returned. The maximum number of expressions is 5.
+     */
+    String orderby;
+
+    /**
+     * Limits the number of items returned from a collection.
+     */
+    int top;
+
+    /**
+     * Excludes the specified number of items of the queried collection from the result.
+     */
+    int skip;
+
+    /**
+     * Indicates whether the total count of items within a collection are returned in the result.
+     */
+    boolean count;
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setEveryone(boolean everyone) {
+        this.everyone = everyone;
+        return this;
+    }
+
+    public boolean isEveryone() {
+        return this.everyone;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setPrefer(String prefer) {
+        this.prefer = prefer;
+        return this;
+    }
+
+    public String getPrefer() {
+        return this.prefer;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    public String getSelect() {
+        return this.select;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setOrderby(String orderby) {
+        this.orderby = orderby;
+        return this;
+    }
+
+    public String getOrderby() {
+        return this.orderby;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setTop(int top) {
+        this.top = top;
+        return this;
+    }
+
+    public int getTop() {
+        return this.top;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setSkip(int skip) {
+        this.skip = skip;
+        return this;
+    }
+
+    public int getSkip() {
+        return this.skip;
+    }
+
+    public ParametersForGetTrusteeAttributeKeyValuePairs setCount(boolean count) {
+        this.count = count;
+        return this;
+    }
+
+    public boolean isCount() {
+        return this.count;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
@@ -1,52 +1,46 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTrusteeAttributeKeyValuePairs {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * Boolean value that indicates whether to return attributes key value pairs associated with everyone or the currently authenticated user.
      */
-    boolean everyone;
+    private boolean everyone;
 
     /**
      * An optional OData header. Can be used to set the maximum page size using odata.maxpagesize.
      */
-    String prefer;
+    private String prefer;
 
     /**
      * Limits the properties returned in the result.
      */
-    String select;
+    private String select;
 
     /**
      * Specifies the order in which items are returned. The maximum number of expressions is 5.
      */
-    String orderby;
+    private String orderby;
 
     /**
      * Limits the number of items returned from a collection.
      */
-    int top;
+    private int top;
 
     /**
      * Excludes the specified number of items of the queried collection from the result.
      */
-    int skip;
+    private int skip;
 
     /**
      * Indicates whether the total count of items within a collection are returned in the result.
      */
-    boolean count;
+    private boolean count;
 
     public ParametersForGetTrusteeAttributeKeyValuePairs setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
@@ -1,0 +1,52 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForGetTrusteeAttributeValueByKey {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested attribute key.
+     */
+    String attributeKey;
+
+    /**
+     * Boolean value that indicates whether to return attributes associated with everyone or the currently authenticated user.
+     */
+    boolean everyone;
+
+    public ParametersForGetTrusteeAttributeValueByKey setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForGetTrusteeAttributeValueByKey setAttributeKey(String attributeKey) {
+        this.attributeKey = attributeKey;
+        return this;
+    }
+
+    public String getAttributeKey() {
+        return this.attributeKey;
+    }
+
+    public ParametersForGetTrusteeAttributeValueByKey setEveryone(boolean everyone) {
+        this.everyone = everyone;
+        return this;
+    }
+
+    public boolean isEveryone() {
+        return this.everyone;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
@@ -1,27 +1,21 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForGetTrusteeAttributeValueByKey {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested attribute key.
      */
-    String attributeKey;
+    private String attributeKey;
 
     /**
      * Boolean value that indicates whether to return attributes associated with everyone or the currently authenticated user.
      */
-    boolean everyone;
+    private boolean everyone;
 
     public ParametersForGetTrusteeAttributeValueByKey setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
@@ -1,43 +1,41 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.impl.model.PostEntryWithEdocMetadataRequest;
+
 import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
 
 public class ParametersForImportDocument {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The entry ID of the folder that the document will be created in.
      */
-    int parentEntryId;
+    private int parentEntryId;
 
     /**
      * The created document's file name.
      */
-    String fileName;
+    private String fileName;
 
     /**
      * An optional query parameter used to indicate if the new document should be automatically
-     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     * renamed if an entry already exists with the given name in the folder. The default value is false.
      */
-    boolean autoRename;
+    private boolean autoRename;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     * The value should be a standard language tag. This may be used when setting field values with tokens.
      */
-    String culture;
+    private String culture;
 
-    InputStream inputStream;
+    private InputStream inputStream;
 
-    PostEntryWithEdocMetadataRequest requestBody;
+    private PostEntryWithEdocMetadataRequest requestBody;
 
     public ParametersForImportDocument setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
@@ -1,0 +1,104 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForImportDocument {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The entry ID of the folder that the document will be created in.
+     */
+    int parentEntryId;
+
+    /**
+     * The created document's file name.
+     */
+    String fileName;
+
+    /**
+     * An optional query parameter used to indicate if the new document should be automatically
+     *            renamed if an entry already exists with the given name in the folder. The default value is false.
+     */
+    boolean autoRename;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     */
+    String culture;
+
+    InputStream inputStream;
+
+    PostEntryWithEdocMetadataRequest requestBody;
+
+    public ParametersForImportDocument setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForImportDocument setParentEntryId(int parentEntryId) {
+        this.parentEntryId = parentEntryId;
+        return this;
+    }
+
+    public int getParentEntryId() {
+        return this.parentEntryId;
+    }
+
+    public ParametersForImportDocument setFileName(String fileName) {
+        this.fileName = fileName;
+        return this;
+    }
+
+    public String getFileName() {
+        return this.fileName;
+    }
+
+    public ParametersForImportDocument setAutoRename(boolean autoRename) {
+        this.autoRename = autoRename;
+        return this;
+    }
+
+    public boolean isAutoRename() {
+        return this.autoRename;
+    }
+
+    public ParametersForImportDocument setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+
+    public ParametersForImportDocument setInputStream(InputStream inputStream) {
+        this.inputStream = inputStream;
+        return this;
+    }
+
+    public InputStream getInputStream() {
+        return this.inputStream;
+    }
+
+    public ParametersForImportDocument setRequestBody(PostEntryWithEdocMetadataRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public PostEntryWithEdocMetadataRequest getRequestBody() {
+        return this.requestBody;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
@@ -1,0 +1,24 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForInvalidateServerSession {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    public ParametersForInvalidateServerSession setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
@@ -1,17 +1,11 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForInvalidateServerSession {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     public ParametersForInvalidateServerSession setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
@@ -1,36 +1,32 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.PatchEntryRequest;
 
 public class ParametersForMoveOrRenameEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The requested entry ID.
      */
-    int entryId;
+    private int entryId;
 
-    PatchEntryRequest requestBody;
+    private PatchEntryRequest requestBody;
 
     /**
      * An optional query parameter used to indicate if the entry should be automatically
-     *            renamed if another entry already exists with the same name in the folder. The default value is false.
+     * renamed if another entry already exists with the same name in the folder. The default value is false.
      */
-    boolean autoRename;
+    private boolean autoRename;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag.
+     * The value should be a standard language tag.
      */
-    String culture;
+    private String culture;
 
     public ParametersForMoveOrRenameEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
@@ -1,0 +1,79 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForMoveOrRenameEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The requested entry ID.
+     */
+    int entryId;
+
+    PatchEntryRequest requestBody;
+
+    /**
+     * An optional query parameter used to indicate if the entry should be automatically
+     *            renamed if another entry already exists with the same name in the folder. The default value is false.
+     */
+    boolean autoRename;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag.
+     */
+    String culture;
+
+    public ParametersForMoveOrRenameEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForMoveOrRenameEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForMoveOrRenameEntry setRequestBody(PatchEntryRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public PatchEntryRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForMoveOrRenameEntry setAutoRename(boolean autoRename) {
+        this.autoRename = autoRename;
+        return this;
+    }
+
+    public boolean isAutoRename() {
+        return this.autoRename;
+    }
+
+    public ParametersForMoveOrRenameEntry setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
@@ -1,0 +1,24 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForRefreshServerSession {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    public ParametersForRefreshServerSession setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
@@ -1,17 +1,11 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-
 public class ParametersForRefreshServerSession {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     public ParametersForRefreshServerSession setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
@@ -1,30 +1,26 @@
 package com.laserfiche.repository.api.clients.params;
 
-import com.laserfiche.repository.api.clients.impl.model.*;
-import java.io.InputStream;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
+import com.laserfiche.repository.api.clients.impl.model.PutTemplateRequest;
 
 public class ParametersForWriteTemplateValueToEntry {
 
     /**
      * The requested repository ID.
      */
-    String repoId;
+    private String repoId;
 
     /**
      * The ID of entry that will have its template updated.
      */
-    int entryId;
+    private int entryId;
 
-    PutTemplateRequest requestBody;
+    private PutTemplateRequest requestBody;
 
     /**
      * An optional query parameter used to indicate the locale that should be used.
-     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     * The value should be a standard language tag. This may be used when setting field values with tokens.
      */
-    String culture;
+    private String culture;
 
     public ParametersForWriteTemplateValueToEntry setRepoId(String repoId) {
         this.repoId = repoId;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
@@ -1,0 +1,64 @@
+package com.laserfiche.repository.api.clients.params;
+
+import com.laserfiche.repository.api.clients.impl.model.*;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+public class ParametersForWriteTemplateValueToEntry {
+
+    /**
+     * The requested repository ID.
+     */
+    String repoId;
+
+    /**
+     * The ID of entry that will have its template updated.
+     */
+    int entryId;
+
+    PutTemplateRequest requestBody;
+
+    /**
+     * An optional query parameter used to indicate the locale that should be used.
+     *            The value should be a standard language tag. This may be used when setting field values with tokens.
+     */
+    String culture;
+
+    public ParametersForWriteTemplateValueToEntry setRepoId(String repoId) {
+        this.repoId = repoId;
+        return this;
+    }
+
+    public String getRepoId() {
+        return this.repoId;
+    }
+
+    public ParametersForWriteTemplateValueToEntry setEntryId(int entryId) {
+        this.entryId = entryId;
+        return this;
+    }
+
+    public int getEntryId() {
+        return this.entryId;
+    }
+
+    public ParametersForWriteTemplateValueToEntry setRequestBody(PutTemplateRequest requestBody) {
+        this.requestBody = requestBody;
+        return this;
+    }
+
+    public PutTemplateRequest getRequestBody() {
+        return this.requestBody;
+    }
+
+    public ParametersForWriteTemplateValueToEntry setCulture(String culture) {
+        this.culture = culture;
+        return this;
+    }
+
+    public String getCulture() {
+        return this.culture;
+    }
+}

--- a/src/test/java/integration/AttributesApiTest.java
+++ b/src/test/java/integration/AttributesApiTest.java
@@ -8,7 +8,6 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttri
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -25,7 +24,8 @@ class AttributesApiTest extends BaseTest {
     @Test
     void getTrusteeAttributeKeyValuePairs_ReturnAttributes() {
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
-                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                new ParametersForGetTrusteeAttributeKeyValuePairs()
+                        .setRepoId(repoId)
                         .setEveryone(true));
 
         assertNotNull(attributeList);
@@ -34,16 +34,19 @@ class AttributesApiTest extends BaseTest {
     @Test
     void getAttributeValueByKey_ReturnAttribute() {
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
-                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                new ParametersForGetTrusteeAttributeKeyValuePairs()
+                        .setRepoId(repoId)
                         .setEveryone(true));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
-                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                new ParametersForGetTrusteeAttributeValueByKey()
+                        .setRepoId(repoId)
                         .setAttributeKey(attributeList
-                .getValue()
-                .get(0)
-                .getKey()).setEveryone(true));
+                                .getValue()
+                                .get(0)
+                                .getKey())
+                        .setEveryone(true));
         assertNotNull(attribute);
     }
 
@@ -51,16 +54,20 @@ class AttributesApiTest extends BaseTest {
     void getAttributeValueByKey_NextLink() throws InterruptedException {
         int maxPageSize = 5;
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
-                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
-                        .setEveryone(true).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                new ParametersForGetTrusteeAttributeKeyValuePairs()
+                        .setRepoId(repoId)
+                        .setEveryone(true)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
-                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                new ParametersForGetTrusteeAttributeValueByKey()
+                        .setRepoId(repoId)
                         .setAttributeKey(attributeList
-                        .getValue()
-                        .get(0)
-                        .getKey()).setEveryone(true));
+                                .getValue()
+                                .get(0)
+                                .getKey())
+                        .setEveryone(true));
         assertNotNull(attribute);
 
         String nextLink = attributeList.getOdataNextLink();
@@ -85,16 +92,20 @@ class AttributesApiTest extends BaseTest {
     void getAttributeValueByKey_ForEach() throws InterruptedException {
         int maxPageSize = 90;
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
-                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
-                        .setEveryone(true).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                new ParametersForGetTrusteeAttributeKeyValuePairs()
+                        .setRepoId(repoId)
+                        .setEveryone(true)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
-                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                new ParametersForGetTrusteeAttributeValueByKey()
+                        .setRepoId(repoId)
                         .setAttributeKey(attributeList
-                        .getValue()
-                        .get(0)
-                        .getKey()).setEveryone(true));
+                                .getValue()
+                                .get(0)
+                                .getKey())
+                        .setEveryone(true));
         assertNotNull(attribute);
 
         TimeUnit.SECONDS.sleep(10);
@@ -113,6 +124,8 @@ class AttributesApiTest extends BaseTest {
             }
         };
         client.getTrusteeAttributeKeyValuePairsForEach(callback, maxPageSize,
-                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId).setEveryone(true));
+                new ParametersForGetTrusteeAttributeKeyValuePairs()
+                        .setRepoId(repoId)
+                        .setEveryone(true));
     }
 }

--- a/src/test/java/integration/AttributesApiTest.java
+++ b/src/test/java/integration/AttributesApiTest.java
@@ -3,6 +3,8 @@ package integration;
 import com.laserfiche.repository.api.clients.AttributesClient;
 import com.laserfiche.repository.api.clients.impl.model.Attribute;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfListOfAttribute;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeKeyValuePairs;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeValueByKey;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,37 +24,43 @@ class AttributesApiTest extends BaseTest {
 
     @Test
     void getTrusteeAttributeKeyValuePairs_ReturnAttributes() {
-        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(repoId,
-                true, null, null, null, null, null, false);
+        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                        .setEveryone(true));
 
         assertNotNull(attributeList);
     }
 
     @Test
     void getAttributeValueByKey_ReturnAttribute() {
-        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(repoId,
-                true, null, null, null, null, null, false);
+        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                        .setEveryone(true));
         assertNotNull(attributeList);
 
-        Attribute attribute = client.getTrusteeAttributeValueByKey(repoId, attributeList
+        Attribute attribute = client.getTrusteeAttributeValueByKey(
+                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                        .setAttributeKey(attributeList
                 .getValue()
                 .get(0)
-                .getKey(), true);
+                .getKey()).setEveryone(true));
         assertNotNull(attribute);
     }
 
     @Test
     void getAttributeValueByKey_NextLink() throws InterruptedException {
         int maxPageSize = 5;
-        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(repoId,
-                true, String.format("maxpagesize=%d", maxPageSize), null, null, null, null, false);
+        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                        .setEveryone(true).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
-        Attribute attribute = client.getTrusteeAttributeValueByKey(repoId,
-                attributeList
+        Attribute attribute = client.getTrusteeAttributeValueByKey(
+                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                        .setAttributeKey(attributeList
                         .getValue()
                         .get(0)
-                        .getKey(), true);
+                        .getKey()).setEveryone(true));
         assertNotNull(attribute);
 
         String nextLink = attributeList.getOdataNextLink();
@@ -76,15 +84,17 @@ class AttributesApiTest extends BaseTest {
     @Test
     void getAttributeValueByKey_ForEach() throws InterruptedException {
         int maxPageSize = 90;
-        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(repoId,
-                true, String.format("maxpagesize=%d", maxPageSize), null, null, null, null, false);
+        ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId)
+                        .setEveryone(true).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
-        Attribute attribute = client.getTrusteeAttributeValueByKey(repoId,
-                attributeList
+        Attribute attribute = client.getTrusteeAttributeValueByKey(
+                new ParametersForGetTrusteeAttributeValueByKey().setRepoId(repoId)
+                        .setAttributeKey(attributeList
                         .getValue()
                         .get(0)
-                        .getKey(), true);
+                        .getKey()).setEveryone(true));
         assertNotNull(attribute);
 
         TimeUnit.SECONDS.sleep(10);
@@ -102,7 +112,7 @@ class AttributesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTrusteeAttributeKeyValuePairsForEach(callback, maxPageSize, repoId, true, null, null, null, null,
-                null, null);
+        client.getTrusteeAttributeKeyValuePairsForEach(callback, maxPageSize,
+                new ParametersForGetTrusteeAttributeKeyValuePairs().setRepoId(repoId).setEveryone(true));
     }
 }

--- a/src/test/java/integration/AuditReasonsApiTest.java
+++ b/src/test/java/integration/AuditReasonsApiTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.laserfiche.repository.api.clients.AuditReasonsClient;
 import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
+import com.laserfiche.repository.api.clients.params.ParametersForGetAuditReasons;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -10,7 +11,7 @@ class AuditReasonsApiTest extends BaseTest {
     @Test
     void getAuditReasons_ReturnAuditReasons() {
         AuditReasonsClient client = repositoryApiClient.getAuditReasonsClient();
-        AuditReasons reasons = client.getAuditReasons(repoId);
+        AuditReasons reasons = client.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repoId));
 
         assertNotNull(reasons);
     }

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -109,7 +109,10 @@ public class BaseTest {
 
         return client
                 .getEntriesClient()
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId).setEntryId(parentEntryId).setRequestBody(request)
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
                         .setAutoRename(autoRename));
     }
 

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -7,6 +7,7 @@ import com.laserfiche.repository.api.clients.impl.model.Entry;
 import com.laserfiche.repository.api.clients.impl.model.PostEntryChildrenEntryType;
 import com.laserfiche.repository.api.clients.impl.model.PostEntryChildrenRequest;
 import com.laserfiche.repository.api.clients.impl.model.TemplateFieldInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateOrCopyEntry;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -108,7 +109,8 @@ public class BaseTest {
 
         return client
                 .getEntriesClient()
-                .createOrCopyEntry(repoId, parentEntryId, request, autoRename, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId).setEntryId(parentEntryId).setRequestBody(request)
+                        .setAutoRename(autoRename));
     }
 
     public static Boolean allFalse(List<TemplateFieldInfo> arr) {

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -4,6 +4,7 @@ import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -36,7 +37,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
                 Integer num = createdEntry.getId();
                 repositoryApiClient
                         .getEntriesClient()
-                        .deleteEntryInfo(repoId, num, body);
+                        .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(num).setRequestBody(body));
             }
         }
         createdEntries.clear();
@@ -52,7 +53,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry createdEntry = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
 
         assertNotNull(createdEntry);
         createdEntries.add(createdEntry);
@@ -74,7 +76,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId).setEntryId(parentEntryId)
+                        .setRequestBody(request).setAutoRename(true));
 
         assertNotNull(targetEntry);
         createdEntries.add(targetEntry);
@@ -89,7 +92,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setTargetId(targetEntry.getId());
 
         Entry shortCut = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
 
         assertNotNull(shortCut);
         createdEntries.add(shortCut);
@@ -112,7 +116,9 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(repoId, testFolder.getId(), request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                                                                       .setEntryId(testFolder.getId())
+                                                                       .setRequestBody(request).setAutoRename(true));
 
         assertNotNull(targetEntry);
         createdEntries.add(targetEntry);
@@ -124,8 +130,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         copyAsyncRequest.setName("RepositoryApiClientIntegrationTest Java CopiedEntry");
         copyAsyncRequest.setSourceId(targetEntry.getId());
 
-        AcceptedOperation copyEntryResponse = client.copyEntryAsync(repoId, testFolder.getId(),
-                copyAsyncRequest, true, null);
+        AcceptedOperation copyEntryResponse = client.copyEntryAsync(new ParametersForCopyEntryAsync().setRepoId(repoId)
+                        .setEntryId(testFolder.getId()).setRequestBody(copyAsyncRequest).setAutoRename(true));
         String opToken = copyEntryResponse
                 .getToken();
 
@@ -133,13 +139,14 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         OperationProgress getOperationStatusAndProgressResponse = repositoryApiClient
                 .getTasksClient()
-                .getOperationStatusAndProgress(repoId, opToken);
+                .getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress().setRepoId(repoId).setOperationToken(opToken));
 
         assertEquals(getOperationStatusAndProgressResponse.getStatus(), OperationStatus.COMPLETED);
 
         DeleteEntryWithAuditReason deleteEntryWithAuditReason = new DeleteEntryWithAuditReason();
         AcceptedOperation deleteEntryResponse = client
-                .deleteEntryInfo(repoId, testFolder.getId(), deleteEntryWithAuditReason);
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(testFolder.getId())
+                        .setRequestBody(deleteEntryWithAuditReason));
         assertNotNull(deleteEntryResponse);
     }
 
@@ -153,7 +160,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
 
         assertNotNull(targetEntry);
 
@@ -170,7 +178,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setTargetId(targetEntry.getId());
 
         Entry createOrCopyEntryResponse = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
 
         assertNotNull(createOrCopyEntryResponse);
 
@@ -184,7 +193,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setSourceId(createOrCopyEntryResponse.getId());
 
         Entry newEntryResponse = client
-                .createOrCopyEntry(repoId, parentEntryId, request, true, null);
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
+                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
 
         createdEntries.add(newEntryResponse);
 
@@ -209,7 +219,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName("RepositoryApiClientIntegrationTest Java MovedFolder");
 
         Entry movedEntry = client
-                .moveOrRenameEntry(repoId, childFolder.getId(), request, true, null);
+                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry().setRepoId(repoId)
+                        .setEntryId(childFolder.getId()).setRequestBody(request).setAutoRename(true));
 
         assertNotNull(movedEntry);
         assertEquals(movedEntry.getId(), childFolder.getId());
@@ -235,7 +246,8 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         String invalidRepoId = String.format("%s-%s", repoId, repoId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .moveOrRenameEntry(invalidRepoId, childFolder.getId(), request, true, null));
+                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry().setRepoId(invalidRepoId)
+                        .setEntryId(childFolder.getId()).setRequestBody(request).setAutoRename(true)));
 
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -12,11 +12,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CreateCopyEntryApiTest extends BaseTest {
     List<Entry> createdEntries = new ArrayList<>();
@@ -37,7 +36,10 @@ public class CreateCopyEntryApiTest extends BaseTest {
                 Integer num = createdEntry.getId();
                 repositoryApiClient
                         .getEntriesClient()
-                        .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(num).setRequestBody(body));
+                        .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                                .setRepoId(repoId)
+                                .setEntryId(num)
+                                .setRequestBody(body));
             }
         }
         createdEntries.clear();
@@ -53,8 +55,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry createdEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(createdEntry);
         createdEntries.add(createdEntry);
@@ -76,8 +81,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId).setEntryId(parentEntryId)
-                        .setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(targetEntry);
         createdEntries.add(targetEntry);
@@ -92,8 +100,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setTargetId(targetEntry.getId());
 
         Entry shortCut = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(shortCut);
         createdEntries.add(shortCut);
@@ -116,9 +127,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                                                                       .setEntryId(testFolder.getId())
-                                                                       .setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(testFolder.getId())
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(targetEntry);
         createdEntries.add(targetEntry);
@@ -130,8 +143,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         copyAsyncRequest.setName("RepositoryApiClientIntegrationTest Java CopiedEntry");
         copyAsyncRequest.setSourceId(targetEntry.getId());
 
-        AcceptedOperation copyEntryResponse = client.copyEntryAsync(new ParametersForCopyEntryAsync().setRepoId(repoId)
-                        .setEntryId(testFolder.getId()).setRequestBody(copyAsyncRequest).setAutoRename(true));
+        AcceptedOperation copyEntryResponse = client.copyEntryAsync(new ParametersForCopyEntryAsync()
+                .setRepoId(repoId)
+                .setEntryId(testFolder.getId())
+                .setRequestBody(copyAsyncRequest)
+                .setAutoRename(true));
         String opToken = copyEntryResponse
                 .getToken();
 
@@ -139,13 +155,17 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         OperationProgress getOperationStatusAndProgressResponse = repositoryApiClient
                 .getTasksClient()
-                .getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress().setRepoId(repoId).setOperationToken(opToken));
+                .getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress()
+                        .setRepoId(repoId)
+                        .setOperationToken(opToken));
 
         assertEquals(getOperationStatusAndProgressResponse.getStatus(), OperationStatus.COMPLETED);
 
         DeleteEntryWithAuditReason deleteEntryWithAuditReason = new DeleteEntryWithAuditReason();
         AcceptedOperation deleteEntryResponse = client
-                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(testFolder.getId())
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                        .setRepoId(repoId)
+                        .setEntryId(testFolder.getId())
                         .setRequestBody(deleteEntryWithAuditReason));
         assertNotNull(deleteEntryResponse);
     }
@@ -160,8 +180,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName(newEntryName);
 
         Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(targetEntry);
 
@@ -178,8 +201,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setTargetId(targetEntry.getId());
 
         Entry createOrCopyEntryResponse = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(createOrCopyEntryResponse);
 
@@ -193,8 +219,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setSourceId(createOrCopyEntryResponse.getId());
 
         Entry newEntryResponse = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry().setRepoId(repoId)
-                        .setEntryId(parentEntryId).setRequestBody(request).setAutoRename(true));
+                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(parentEntryId)
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         createdEntries.add(newEntryResponse);
 
@@ -219,8 +248,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setName("RepositoryApiClientIntegrationTest Java MovedFolder");
 
         Entry movedEntry = client
-                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry().setRepoId(repoId)
-                        .setEntryId(childFolder.getId()).setRequestBody(request).setAutoRename(true));
+                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(childFolder.getId())
+                        .setRequestBody(request)
+                        .setAutoRename(true));
 
         assertNotNull(movedEntry);
         assertEquals(movedEntry.getId(), childFolder.getId());
@@ -246,8 +278,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         String invalidRepoId = String.format("%s-%s", repoId, repoId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry().setRepoId(invalidRepoId)
-                        .setEntryId(childFolder.getId()).setRequestBody(request).setAutoRename(true)));
+                .moveOrRenameEntry(new ParametersForMoveOrRenameEntry()
+                        .setRepoId(invalidRepoId)
+                        .setEntryId(childFolder.getId())
+                        .setRequestBody(request)
+                        .setAutoRename(true)));
 
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -33,7 +33,9 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getEntry_ReturnRootFolder() {
-        Entry entry = client.getEntry(new ParametersForGetEntry().setRepoId(repoId).setEntryId(1));
+        Entry entry = client.getEntry(new ParametersForGetEntry()
+                .setRepoId(repoId)
+                .setEntryId(1));
 
         assertNotNull(entry);
         assertTrue(entry instanceof Folder); // We know the root folder is of type Folder.
@@ -41,7 +43,10 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getEntry_ReturnEntryWhenTypeInfoMissing() {
-        Entry entry = client.getEntry(new ParametersForGetEntry().setRepoId(repoId).setEntryId(1).setSelect("name"));
+        Entry entry = client.getEntry(new ParametersForGetEntry()
+                .setRepoId(repoId)
+                .setEntryId(1)
+                .setSelect("name"));
 
         assertNotNull(entry);
         assertFalse(entry instanceof Folder
@@ -53,7 +58,10 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getEntryListing_ReturnEntries() {
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1).setPrefer("maxpagesize=5"));
+                .getEntryListing(new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setPrefer("maxpagesize=5"));
 
         assertNotNull(entries);
 
@@ -76,7 +84,9 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfEntry entryList = client
-                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1).
+                .getEntryListing(new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1).
                         setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(entryList);
@@ -115,14 +125,18 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getEntryListingForEach( callback, maxPageSize,
-                new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1));
+        client.getEntryListingForEach(callback, maxPageSize,
+                new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1));
     }
 
     @Test
     void getFieldValues_ReturnFields() {
         ODataValueContextOfIListOfFieldValue fieldValueList = client
-                .getFieldValues(new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1));
+                .getFieldValues(new ParametersForGetFieldValues()
+                        .setRepoId(repoId)
+                        .setEntryId(1));
 
         assertNotNull(fieldValueList);
     }
@@ -130,7 +144,9 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getLinkValuesFromEntry_ReturnLinks() {
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
-                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1));
+                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(1));
 
         assertNotNull(linkInfoList);
     }
@@ -139,8 +155,10 @@ class EntriesApiTest extends BaseTest {
     void getFieldValues_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfFieldValue fieldValueList = client
-                .getFieldValues(new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1)
-                                                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                .getFieldValues(new ParametersForGetFieldValues()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(fieldValueList);
 
@@ -179,7 +197,9 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getFieldValuesForEach(callback, maxPageSize, new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1));
+        client.getFieldValuesForEach(callback, maxPageSize, new ParametersForGetFieldValues()
+                .setRepoId(repoId)
+                .setEntryId(1));
     }
 
 
@@ -187,8 +207,10 @@ class EntriesApiTest extends BaseTest {
     void getLinkValuesFromEntry_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
-                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1)
-                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(linkInfoList);
 
@@ -232,7 +254,9 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getLinkValuesFromEntryForEach(callback, maxPageSize, new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1));
+        client.getLinkValuesFromEntryForEach(callback, maxPageSize, new ParametersForGetLinkValuesFromEntry()
+                .setRepoId(repoId)
+                .setEntryId(1));
     }
 
     @Test
@@ -240,8 +264,10 @@ class EntriesApiTest extends BaseTest {
         Entry entryToDelete = createEntry(createEntryClient,
                 "RepositoryApiClientIntegrationTest Java DeleteFolder", 1, true);
 
-        AcceptedOperation deleteEntryResponse = client.deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId)
-                        .setEntryId(entryToDelete.getId()).setRequestBody(new DeleteEntryWithAuditReason()));
+        AcceptedOperation deleteEntryResponse = client.deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                .setRepoId(repoId)
+                .setEntryId(entryToDelete.getId())
+                .setRequestBody(new DeleteEntryWithAuditReason()));
 
         String token = deleteEntryResponse
                 .getToken();
@@ -253,8 +279,10 @@ class EntriesApiTest extends BaseTest {
     void getTagsAssignedToEntry_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry().setRepoId(repoId)
-                                .setEntryId(1).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(tagInfoList);
 
@@ -298,13 +326,17 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTagsAssignedToEntryForEach(callback, maxPageSize, new ParametersForGetTagsAssignedToEntry().setRepoId(repoId).setEntryId(1));
+        client.getTagsAssignedToEntryForEach(callback, maxPageSize, new ParametersForGetTagsAssignedToEntry()
+                .setRepoId(repoId)
+                .setEntryId(1));
     }
 
     @Test
     void getTagsAssignedToEntry_ReturnTags() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry().setRepoId(repoId).setEntryId(1));
+                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(1));
 
         assertNotNull(tagInfoList);
     }
@@ -325,7 +357,10 @@ class EntriesApiTest extends BaseTest {
                 .getId());
 
         Map<String, String[]> dynamicFieldValueResponse = client
-                .getDynamicFieldValues(new ParametersForGetDynamicFieldValues().setRepoId(repoId).setEntryId(1).setRequestBody(request));
+                .getDynamicFieldValues(new ParametersForGetDynamicFieldValues()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setRequestBody(request));
         assertNotNull(dynamicFieldValueResponse);
     }
 
@@ -333,7 +368,9 @@ class EntriesApiTest extends BaseTest {
     void getEntryByFullPath_ReturnRootFolder() {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
-                .getEntryByPath(new ParametersForGetEntryByPath().setRepoId(repoId).setFullPath(rootPath));
+                .getEntryByPath(new ParametersForGetEntryByPath()
+                        .setRepoId(repoId)
+                        .setFullPath(rootPath));
 
         assertNotNull(entry);
         assertEquals(1, entry
@@ -353,7 +390,10 @@ class EntriesApiTest extends BaseTest {
     void getEntryByFullPath_ReturnAncestorRootFolder() {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
-                .getEntryByPath(new ParametersForGetEntryByPath().setRepoId(repoId).setFullPath(nonExistingPath).setFallbackToClosestAncestor(true));
+                .getEntryByPath(new ParametersForGetEntryByPath()
+                        .setRepoId(repoId)
+                        .setFullPath(nonExistingPath)
+                        .setFallbackToClosestAncestor(true));
 
         assertNotNull(entry);
         assertEquals(1, entry
@@ -372,8 +412,10 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getDocumentContentType_ReturnsExpectedHeaders() {
         ODataValueContextOfIListOfEntry entryList = client
-                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId)
-                        .setEntryId(1).setPrefer("maxpagesize=100"));
+                .getEntryListing(new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setPrefer("maxpagesize=100"));
         assertNotNull(entryList);
 
         Optional<Entry> optionalEntry = entryList
@@ -385,7 +427,9 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(entry);
 
         Map<String, String> headers = client
-                .getDocumentContentType(new ParametersForGetDocumentContentType().setRepoId(repoId).setEntryId(entry.getId()));
+                .getDocumentContentType(new ParametersForGetDocumentContentType()
+                        .setRepoId(repoId)
+                        .setEntryId(entry.getId()));
         assertNotNull(headers.get("Content-Type"));
         assertNotNull(headers.get("Content-Length"));
     }
@@ -394,8 +438,10 @@ class EntriesApiTest extends BaseTest {
     void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() {
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> {
             client
-                    .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId)
-                                    .setEntryId(-1).setPrefer("maxpagesize=100"));
+                    .getEntryListing(new ParametersForGetEntryListing()
+                            .setRepoId(repoId)
+                            .setEntryId(-1)
+                            .setPrefer("maxpagesize=100"));
         });
         assertNotNull(apiException);
         ProblemDetails problemDetails = apiException.getProblemDetails();
@@ -410,8 +456,11 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_WithOneField_ReturnEntries() {
         String[] fieldNames = {"Sender"};
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1)
-                                .setFields(fieldNames).setPrefer("maxpagesize=5"));
+                .getEntryListing(new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setFields(fieldNames)
+                        .setPrefer("maxpagesize=5"));
         assertNotNull(entries);
         for (Entry entry : entries.getValue()) {
             int numberOfReturnedFields = (int) entry
@@ -431,8 +480,11 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_WithFields_ReturnEntries() {
         String[] fieldNames = {"Sender", "Subject"};
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1)
-                                .setFields(fieldNames).setPrefer("maxpagesize=5"));
+                .getEntryListing(new ParametersForGetEntryListing()
+                        .setRepoId(repoId)
+                        .setEntryId(1)
+                        .setFields(fieldNames)
+                        .setPrefer("maxpagesize=5"));
         assertNotNull(entries);
         for (Entry entry : entries.getValue()) {
             int numberOfReturnedFields = (int) entry
@@ -452,7 +504,9 @@ class EntriesApiTest extends BaseTest {
     void getDocumentContentType_Returns_Valid_Error_Message_ForInvalidRepoId() {
         String invalidRepoId = String.format("%s-%s", repoId, repoId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .getDocumentContentType(new ParametersForGetDocumentContentType().setRepoId(invalidRepoId).setEntryId(1)));
+                .getDocumentContentType(new ParametersForGetDocumentContentType()
+                        .setRepoId(invalidRepoId)
+                        .setEntryId(1)));
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());
         assertEquals("Not Found", apiException.getMessage());
@@ -465,7 +519,9 @@ class EntriesApiTest extends BaseTest {
         PutTemplateRequest request = new PutTemplateRequest();
         request.setTemplateName("fake_template");
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(3)
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(3)
                         .setRequestBody(request)));
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -4,6 +4,7 @@ import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +33,7 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getEntry_ReturnRootFolder() {
-        Entry entry = client.getEntry(repoId, 1, null);
+        Entry entry = client.getEntry(new ParametersForGetEntry().setRepoId(repoId).setEntryId(1));
 
         assertNotNull(entry);
         assertTrue(entry instanceof Folder); // We know the root folder is of type Folder.
@@ -40,7 +41,7 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getEntry_ReturnEntryWhenTypeInfoMissing() {
-        Entry entry = client.getEntry(repoId, 1, "name");
+        Entry entry = client.getEntry(new ParametersForGetEntry().setRepoId(repoId).setEntryId(1).setSelect("name"));
 
         assertNotNull(entry);
         assertFalse(entry instanceof Folder
@@ -52,7 +53,7 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getEntryListing_ReturnEntries() {
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(repoId, 1, false, null, false, "maxpagesize=5", null, null, null, null, null, false);
+                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1).setPrefer("maxpagesize=5"));
 
         assertNotNull(entries);
 
@@ -75,8 +76,8 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfEntry entryList = client
-                .getEntryListing(repoId, 1, false, null, false, String.format("maxpagesize=%d", maxPageSize), null,
-                        null, null, null, null, false);
+                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1).
+                        setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(entryList);
 
@@ -114,14 +115,14 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getEntryListingForEach(callback, maxPageSize, repoId, 1, false, null, false, null, null, null, null,
-                null, null, false);
+        client.getEntryListingForEach( callback, maxPageSize,
+                new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1));
     }
 
     @Test
     void getFieldValues_ReturnFields() {
         ODataValueContextOfIListOfFieldValue fieldValueList = client
-                .getFieldValues(repoId, 1, null, null, null, null, null, null, null, false);
+                .getFieldValues(new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1));
 
         assertNotNull(fieldValueList);
     }
@@ -129,7 +130,7 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getLinkValuesFromEntry_ReturnLinks() {
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
-                .getLinkValuesFromEntry(repoId, 1, null, null, null, null, null, false);
+                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1));
 
         assertNotNull(linkInfoList);
     }
@@ -138,8 +139,8 @@ class EntriesApiTest extends BaseTest {
     void getFieldValues_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfFieldValue fieldValueList = client
-                .getFieldValues(repoId, 1, String.format("maxpagesize=%d", maxPageSize), null, null, null, null, null,
-                        null, false);
+                .getFieldValues(new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1)
+                                                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(fieldValueList);
 
@@ -178,8 +179,7 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getFieldValuesForEach(callback, maxPageSize, repoId, 1, null, null, null, null, null, null, null,
-                false);
+        client.getFieldValuesForEach(callback, maxPageSize, new ParametersForGetFieldValues().setRepoId(repoId).setEntryId(1));
     }
 
 
@@ -187,8 +187,8 @@ class EntriesApiTest extends BaseTest {
     void getLinkValuesFromEntry_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
-                .getLinkValuesFromEntry(repoId, 1, String.format("maxpagesize=%d", maxPageSize), null, null, null, null,
-                        false);
+                .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1)
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(linkInfoList);
 
@@ -232,7 +232,7 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getLinkValuesFromEntryForEach(callback, maxPageSize, repoId, 1, null, null, null, null, null, false);
+        client.getLinkValuesFromEntryForEach(callback, maxPageSize, new ParametersForGetLinkValuesFromEntry().setRepoId(repoId).setEntryId(1));
     }
 
     @Test
@@ -240,8 +240,8 @@ class EntriesApiTest extends BaseTest {
         Entry entryToDelete = createEntry(createEntryClient,
                 "RepositoryApiClientIntegrationTest Java DeleteFolder", 1, true);
 
-        AcceptedOperation deleteEntryResponse = client.deleteEntryInfo(repoId, entryToDelete.getId(),
-                new DeleteEntryWithAuditReason());
+        AcceptedOperation deleteEntryResponse = client.deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId)
+                        .setEntryId(entryToDelete.getId()).setRequestBody(new DeleteEntryWithAuditReason()));
 
         String token = deleteEntryResponse
                 .getToken();
@@ -253,8 +253,8 @@ class EntriesApiTest extends BaseTest {
     void getTagsAssignedToEntry_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagsAssignedToEntry(repoId, 1, String.format("maxpagesize=%d", maxPageSize), null, null, null, null,
-                        false);
+                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry().setRepoId(repoId)
+                                .setEntryId(1).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(tagInfoList);
 
@@ -298,13 +298,13 @@ class EntriesApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTagsAssignedToEntryForEach(callback, maxPageSize, repoId, 1, null, null, null, null, null, false);
+        client.getTagsAssignedToEntryForEach(callback, maxPageSize, new ParametersForGetTagsAssignedToEntry().setRepoId(repoId).setEntryId(1));
     }
 
     @Test
     void getTagsAssignedToEntry_ReturnTags() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagsAssignedToEntry(repoId, 1, null, null, null, null, null, false);
+                .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry().setRepoId(repoId).setEntryId(1));
 
         assertNotNull(tagInfoList);
     }
@@ -313,7 +313,7 @@ class EntriesApiTest extends BaseTest {
     void getDynamicFieldsEntry_ReturnDynamicFields() {
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -325,7 +325,7 @@ class EntriesApiTest extends BaseTest {
                 .getId());
 
         Map<String, String[]> dynamicFieldValueResponse = client
-                .getDynamicFieldValues(repoId, 1, request);
+                .getDynamicFieldValues(new ParametersForGetDynamicFieldValues().setRepoId(repoId).setEntryId(1).setRequestBody(request));
         assertNotNull(dynamicFieldValueResponse);
     }
 
@@ -333,7 +333,7 @@ class EntriesApiTest extends BaseTest {
     void getEntryByFullPath_ReturnRootFolder() {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
-                .getEntryByPath(repoId, rootPath, false);
+                .getEntryByPath(new ParametersForGetEntryByPath().setRepoId(repoId).setFullPath(rootPath));
 
         assertNotNull(entry);
         assertEquals(1, entry
@@ -353,7 +353,7 @@ class EntriesApiTest extends BaseTest {
     void getEntryByFullPath_ReturnAncestorRootFolder() {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
-                .getEntryByPath(repoId, nonExistingPath, true);
+                .getEntryByPath(new ParametersForGetEntryByPath().setRepoId(repoId).setFullPath(nonExistingPath).setFallbackToClosestAncestor(true));
 
         assertNotNull(entry);
         assertEquals(1, entry
@@ -372,7 +372,8 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getDocumentContentType_ReturnsExpectedHeaders() {
         ODataValueContextOfIListOfEntry entryList = client
-                .getEntryListing(repoId, 1, false, null, false, "maxpagesize=100", null, null, null, null, null, false);
+                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId)
+                        .setEntryId(1).setPrefer("maxpagesize=100"));
         assertNotNull(entryList);
 
         Optional<Entry> optionalEntry = entryList
@@ -384,7 +385,7 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(entry);
 
         Map<String, String> headers = client
-                .getDocumentContentType(repoId, entry.getId());
+                .getDocumentContentType(new ParametersForGetDocumentContentType().setRepoId(repoId).setEntryId(entry.getId()));
         assertNotNull(headers.get("Content-Type"));
         assertNotNull(headers.get("Content-Length"));
     }
@@ -393,8 +394,8 @@ class EntriesApiTest extends BaseTest {
     void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() {
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> {
             client
-                    .getEntryListing(repoId, -1, false, null, false, "maxpagesize=100", null, null, null, null, null,
-                            false);
+                    .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId)
+                                    .setEntryId(-1).setPrefer("maxpagesize=100"));
         });
         assertNotNull(apiException);
         ProblemDetails problemDetails = apiException.getProblemDetails();
@@ -409,8 +410,8 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_WithOneField_ReturnEntries() {
         String[] fieldNames = {"Sender"};
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(repoId, 1, false, fieldNames, false, "maxpagesize=5", null, null, null, null, null,
-                        false);
+                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1)
+                                .setFields(fieldNames).setPrefer("maxpagesize=5"));
         assertNotNull(entries);
         for (Entry entry : entries.getValue()) {
             int numberOfReturnedFields = (int) entry
@@ -430,8 +431,8 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_WithFields_ReturnEntries() {
         String[] fieldNames = {"Sender", "Subject"};
         ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(repoId, 1, false, fieldNames, false, "maxpagesize=5", null, null, null, null, null,
-                        false);
+                .getEntryListing(new ParametersForGetEntryListing().setRepoId(repoId).setEntryId(1)
+                                .setFields(fieldNames).setPrefer("maxpagesize=5"));
         assertNotNull(entries);
         for (Entry entry : entries.getValue()) {
             int numberOfReturnedFields = (int) entry
@@ -451,7 +452,7 @@ class EntriesApiTest extends BaseTest {
     void getDocumentContentType_Returns_Valid_Error_Message_ForInvalidRepoId() {
         String invalidRepoId = String.format("%s-%s", repoId, repoId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .getDocumentContentType(invalidRepoId, 1));
+                .getDocumentContentType(new ParametersForGetDocumentContentType().setRepoId(invalidRepoId).setEntryId(1)));
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());
         assertEquals("Not Found", apiException.getMessage());
@@ -464,7 +465,8 @@ class EntriesApiTest extends BaseTest {
         PutTemplateRequest request = new PutTemplateRequest();
         request.setTemplateName("fake_template");
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
-                .writeTemplateValueToEntry(repoId, 3, request, null));
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(3)
+                        .setRequestBody(request)));
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());
         assertTrue(apiException

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -34,7 +34,10 @@ public class ExportDocumentApiTest extends BaseTest {
         if (createdEntryId != 0) {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             client
-                    .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(createdEntryId).setRequestBody(body));
+                    .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                            .setRepoId(repoId)
+                            .setEntryId(createdEntryId)
+                            .setRequestBody(body));
         }
     }
 
@@ -59,7 +62,10 @@ public class ExportDocumentApiTest extends BaseTest {
             }
         };
 
-        client.exportDocument(new ParametersForExportDocument().setRepoId(repoId).setEntryId(createdEntryId).setInputStreamConsumer(consumer));
+        client.exportDocument(new ParametersForExportDocument()
+                .setRepoId(repoId)
+                .setEntryId(createdEntryId)
+                .setInputStreamConsumer(consumer));
         File exportedFile = new File(FILE_NAME);
         assertTrue(exportedFile.exists());
         assertEquals(0, exportedFile.length());
@@ -74,7 +80,10 @@ public class ExportDocumentApiTest extends BaseTest {
             assertTrue(false, "Consumer should not have been called.");
         };
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
-            client.exportDocument(new ParametersForExportDocument().setRepoId(repoId).setEntryId(-createdEntryId).setInputStreamConsumer(consumer));
+            client.exportDocument(new ParametersForExportDocument()
+                    .setRepoId(repoId)
+                    .setEntryId(-createdEntryId)
+                    .setInputStreamConsumer(consumer));
         });
         Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')",
                 thrown.getMessage());
@@ -88,9 +97,13 @@ public class ExportDocumentApiTest extends BaseTest {
             String fileName = "JavaClientLibrary_ExportDocumentApiTest";
             File toUpload = File.createTempFile(fileName, "txt");
             CreateEntryResult result = client
-                    .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
-                                    .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
-                                    .setRequestBody(new PostEntryWithEdocMetadataRequest()));
+                    .importDocument(new ParametersForImportDocument()
+                            .setRepoId(repoId)
+                            .setParentEntryId(1)
+                            .setFileName(fileName)
+                            .setAutoRename(true)
+                            .setInputStream(new FileInputStream(toUpload))
+                            .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
             CreateEntryOperations operations = result.getOperations();
             createdEntryId = operations

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -6,6 +6,9 @@ import com.laserfiche.repository.api.clients.impl.model.CreateEntryOperations;
 import com.laserfiche.repository.api.clients.impl.model.CreateEntryResult;
 import com.laserfiche.repository.api.clients.impl.model.DeleteEntryWithAuditReason;
 import com.laserfiche.repository.api.clients.impl.model.PostEntryWithEdocMetadataRequest;
+import com.laserfiche.repository.api.clients.params.ParametersForDeleteEntryInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForExportDocument;
+import com.laserfiche.repository.api.clients.params.ParametersForImportDocument;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,7 +34,7 @@ public class ExportDocumentApiTest extends BaseTest {
         if (createdEntryId != 0) {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             client
-                    .deleteEntryInfo(repoId, createdEntryId, body);
+                    .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(createdEntryId).setRequestBody(body));
         }
     }
 
@@ -39,7 +42,7 @@ public class ExportDocumentApiTest extends BaseTest {
     @Test
     void exportDocument_Returns_Exported_File() {
         final String FILE_NAME = "exportDocument_temp_file.txt";
-        Consumer<InputStream> c = inputStream -> {
+        Consumer<InputStream> consumer = inputStream -> {
             File exportedFile = new File(FILE_NAME);
             try (FileOutputStream f = new FileOutputStream(exportedFile)) {
                 byte[] buffer = new byte[1024];
@@ -56,7 +59,7 @@ public class ExportDocumentApiTest extends BaseTest {
             }
         };
 
-        client.exportDocument(repoId, createdEntryId, null, c);
+        client.exportDocument(new ParametersForExportDocument().setRepoId(repoId).setEntryId(createdEntryId).setInputStreamConsumer(consumer));
         File exportedFile = new File(FILE_NAME);
         assertTrue(exportedFile.exists());
         assertEquals(0, exportedFile.length());
@@ -71,7 +74,7 @@ public class ExportDocumentApiTest extends BaseTest {
             assertTrue(false, "Consumer should not have been called.");
         };
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
-            client.exportDocument(repoId, -createdEntryId, null, consumer);
+            client.exportDocument(new ParametersForExportDocument().setRepoId(repoId).setEntryId(-createdEntryId).setInputStreamConsumer(consumer));
         });
         Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')",
                 thrown.getMessage());
@@ -85,8 +88,9 @@ public class ExportDocumentApiTest extends BaseTest {
             String fileName = "JavaClientLibrary_ExportDocumentApiTest";
             File toUpload = File.createTempFile(fileName, "txt");
             CreateEntryResult result = client
-                    .importDocument(repoId, 1, fileName, true, null,
-                            new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest());
+                    .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
+                                    .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
+                                    .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
             CreateEntryOperations operations = result.getOperations();
             createdEntryId = operations

--- a/src/test/java/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/integration/FieldDefinitionsApiTest.java
@@ -8,7 +8,6 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinit
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -25,7 +24,9 @@ class FieldDefinitionsApiTest extends BaseTest {
     @Test
     void getFieldDefinitionById_ReturnField() {
         WFieldInfo fieldInfo = client
-                .getFieldDefinitionById(new ParametersForGetFieldDefinitionById().setRepoId(repoId).setFieldDefinitionId(1));
+                .getFieldDefinitionById(new ParametersForGetFieldDefinitionById()
+                        .setRepoId(repoId)
+                        .setFieldDefinitionId(1));
 
         assertNotNull(fieldInfo);
     }
@@ -42,8 +43,9 @@ class FieldDefinitionsApiTest extends BaseTest {
     void getFieldDefinitions_NextLink() throws InterruptedException {
         int maxPageSize = 10;
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
-                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId)
-                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions()
+                        .setRepoId(repoId)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(fieldInfoList);
 
         String nextLink = fieldInfoList.getOdataNextLink();
@@ -81,6 +83,7 @@ class FieldDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getFieldDefinitionsForEach(callback, maxPageSize, new ParametersForGetFieldDefinitions().setRepoId(repoId));
+        client.getFieldDefinitionsForEach(callback, maxPageSize,
+                new ParametersForGetFieldDefinitions().setRepoId(repoId));
     }
 }

--- a/src/test/java/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/integration/FieldDefinitionsApiTest.java
@@ -3,6 +3,8 @@ package integration;
 import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWFieldInfo;
 import com.laserfiche.repository.api.clients.impl.model.WFieldInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -23,7 +25,7 @@ class FieldDefinitionsApiTest extends BaseTest {
     @Test
     void getFieldDefinitionById_ReturnField() {
         WFieldInfo fieldInfo = client
-                .getFieldDefinitionById(repoId, 1, null, null);
+                .getFieldDefinitionById(new ParametersForGetFieldDefinitionById().setRepoId(repoId).setFieldDefinitionId(1));
 
         assertNotNull(fieldInfo);
     }
@@ -31,7 +33,7 @@ class FieldDefinitionsApiTest extends BaseTest {
     @Test
     void getFieldDefinitions_ReturnAllFields() {
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
-                .getFieldDefinitions(repoId, null, null, null, null, null, null, false);
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId));
 
         assertNotNull(fieldInfoList);
     }
@@ -40,8 +42,8 @@ class FieldDefinitionsApiTest extends BaseTest {
     void getFieldDefinitions_NextLink() throws InterruptedException {
         int maxPageSize = 10;
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
-                .getFieldDefinitions(repoId, String.format("maxpagesize=%d", maxPageSize), null, null, null, null, null,
-                        false);
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId)
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(fieldInfoList);
 
         String nextLink = fieldInfoList.getOdataNextLink();
@@ -79,6 +81,6 @@ class FieldDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getFieldDefinitionsForEach(callback, maxPageSize, repoId, null, null, null, null, null, null, null);
+        client.getFieldDefinitionsForEach(callback, maxPageSize, new ParametersForGetFieldDefinitions().setRepoId(repoId));
     }
 }

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -34,7 +34,10 @@ public class ImportDocumentApiTest extends BaseTest {
     public void deleteEntries() {
         if (createdEntryId != 0) {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-            client.deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(createdEntryId).setRequestBody(body));
+            client.deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                    .setRepoId(repoId)
+                    .setEntryId(createdEntryId)
+                    .setRequestBody(body));
         }
     }
 
@@ -51,8 +54,12 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(toUpload);
 
         CreateEntryResult result = client
-                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
-                                .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
+                .importDocument(new ParametersForImportDocument()
+                        .setRepoId(repoId)
+                        .setParentEntryId(1)
+                        .setFileName(fileName)
+                        .setAutoRename(true)
+                        .setInputStream(new FileInputStream(toUpload))
                         .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
@@ -86,7 +93,8 @@ public class ImportDocumentApiTest extends BaseTest {
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionFieldsResult = repositoryApiClient
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
+                            .setRepoId(repoId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionFieldsResult.getValue() != null && allFalse(
                     templateDefinitionFieldsResult.getValue())) {
@@ -109,8 +117,12 @@ public class ImportDocumentApiTest extends BaseTest {
         request.setTemplate(template.getName());
 
         CreateEntryResult result = client
-                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(parentEntryId)
-                                .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
+                .importDocument(new ParametersForImportDocument()
+                        .setRepoId(repoId)
+                        .setParentEntryId(parentEntryId)
+                        .setFileName(fileName)
+                        .setAutoRename(true)
+                        .setInputStream(new FileInputStream(toUpload))
                         .setRequestBody(request));
 
         CreateEntryOperations operations = result.getOperations();
@@ -147,8 +159,13 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(inputStream);
 
         result = client
-                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1).setFileName(fileName)
-                        .setAutoRename(true).setInputStream(inputStream).setRequestBody(new PostEntryWithEdocMetadataRequest()));
+                .importDocument(new ParametersForImportDocument()
+                        .setRepoId(repoId)
+                        .setParentEntryId(1)
+                        .setFileName(fileName)
+                        .setAutoRename(true)
+                        .setInputStream(inputStream)
+                        .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -178,8 +195,13 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(inputStream);
 
         result = client
-                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
-                                .setFileName(fileName).setAutoRename(true).setInputStream(inputStream).setRequestBody(new PostEntryWithEdocMetadataRequest()));
+                .importDocument(new ParametersForImportDocument()
+                        .setRepoId(repoId)
+                        .setParentEntryId(1)
+                        .setFileName(fileName)
+                        .setAutoRename(true)
+                        .setInputStream(inputStream)
+                        .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -211,8 +233,13 @@ public class ImportDocumentApiTest extends BaseTest {
         PostEntryWithEdocMetadataRequest request = new PostEntryWithEdocMetadataRequest();
         request.setTemplate("invalidTemplateName");
         result = client
-                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
-                                .setFileName(fileName).setAutoRename(true).setInputStream(inputStream).setRequestBody(request));
+                .importDocument(new ParametersForImportDocument()
+                        .setRepoId(repoId)
+                        .setParentEntryId(1)
+                        .setFileName(fileName)
+                        .setAutoRename(true)
+                        .setInputStream(inputStream)
+                        .setRequestBody(request));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -2,6 +2,10 @@ package integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.ParametersForDeleteEntryInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForImportDocument;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +34,7 @@ public class ImportDocumentApiTest extends BaseTest {
     public void deleteEntries() {
         if (createdEntryId != 0) {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
-            client.deleteEntryInfo(repoId, createdEntryId, body);
+            client.deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(createdEntryId).setRequestBody(body));
         }
     }
 
@@ -47,8 +51,9 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(toUpload);
 
         CreateEntryResult result = client
-                .importDocument(repoId, 1, fileName, true, null,
-                        new FileInputStream(toUpload), new PostEntryWithEdocMetadataRequest());
+                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
+                                .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
+                        .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -74,15 +79,15 @@ public class ImportDocumentApiTest extends BaseTest {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionResult.getValue();
         assertNotNull(templateDefinitions);
         Assertions.assertTrue(templateDefinitions.size() > 0);
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionFieldsResult = repositoryApiClient
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(repoId,
-                            templateDefinition.getId(), null, null, null, null, null, null, null);
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                            .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionFieldsResult.getValue() != null && allFalse(
                     templateDefinitionFieldsResult.getValue())) {
                 template = templateDefinition;
@@ -104,8 +109,9 @@ public class ImportDocumentApiTest extends BaseTest {
         request.setTemplate(template.getName());
 
         CreateEntryResult result = client
-                .importDocument(repoId, parentEntryId, fileName,
-                        true, null, new FileInputStream(toUpload), request);
+                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(parentEntryId)
+                                .setFileName(fileName).setAutoRename(true).setInputStream(new FileInputStream(toUpload))
+                        .setRequestBody(request));
 
         CreateEntryOperations operations = result.getOperations();
         assertNotNull(operations);
@@ -141,8 +147,8 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(inputStream);
 
         result = client
-                .importDocument(repoId, 1, fileName, true, null,
-                        inputStream, new PostEntryWithEdocMetadataRequest());
+                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1).setFileName(fileName)
+                        .setAutoRename(true).setInputStream(inputStream).setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -172,8 +178,8 @@ public class ImportDocumentApiTest extends BaseTest {
         assertNotNull(inputStream);
 
         result = client
-                .importDocument(repoId, 1, fileName, true, null,
-                        inputStream, new PostEntryWithEdocMetadataRequest());
+                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
+                                .setFileName(fileName).setAutoRename(true).setInputStream(inputStream).setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();
@@ -205,8 +211,8 @@ public class ImportDocumentApiTest extends BaseTest {
         PostEntryWithEdocMetadataRequest request = new PostEntryWithEdocMetadataRequest();
         request.setTemplate("invalidTemplateName");
         result = client
-                .importDocument(repoId, 1, fileName, true, null,
-                        inputStream, request);
+                .importDocument(new ParametersForImportDocument().setRepoId(repoId).setParentEntryId(1)
+                                .setFileName(fileName).setAutoRename(true).setInputStream(inputStream).setRequestBody(request));
 
         assertNotNull(result);
         CreateEntryOperations operations = result.getOperations();

--- a/src/test/java/integration/LinkDefinitionsApiTest.java
+++ b/src/test/java/integration/LinkDefinitionsApiTest.java
@@ -37,7 +37,9 @@ public class LinkDefinitionsApiTest extends BaseTest {
         assertNotNull(firstLinkDefinition);
 
         EntryLinkTypeInfo linkDefinitions = client.getLinkDefinitionById(
-                new ParametersForGetLinkDefinitionById().setRepoId(repoId).setLinkTypeId(firstLinkDefinition.getLinkTypeId()));
+                new ParametersForGetLinkDefinitionById()
+                        .setRepoId(repoId)
+                        .setLinkTypeId(firstLinkDefinition.getLinkTypeId()));
 
         assertNotNull(linkDefinitions);
         assertEquals(linkDefinitions.getLinkTypeId(), firstLinkDefinition.getLinkTypeId());

--- a/src/test/java/integration/LinkDefinitionsApiTest.java
+++ b/src/test/java/integration/LinkDefinitionsApiTest.java
@@ -3,6 +3,8 @@ package integration;
 import com.laserfiche.repository.api.clients.LinkDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.EntryLinkTypeInfo;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfEntryLinkTypeInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefinitions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -19,8 +21,8 @@ public class LinkDefinitionsApiTest extends BaseTest {
 
     @Test
     void getLinkDefinitions_ReturnAllLinks() {
-        ODataValueContextOfIListOfEntryLinkTypeInfo linkDefinitionsResponse = client.getLinkDefinitions(repoId, null,
-                null, null, null, null, null);
+        ODataValueContextOfIListOfEntryLinkTypeInfo linkDefinitionsResponse = client.getLinkDefinitions(
+                new ParametersForGetLinkDefinitions().setRepoId(repoId));
 
         assertNotNull(linkDefinitionsResponse.getValue());
     }
@@ -28,14 +30,14 @@ public class LinkDefinitionsApiTest extends BaseTest {
     @Test
     void getLinkDefinitionsById_ReturnLinkDefinition() {
         ODataValueContextOfIListOfEntryLinkTypeInfo allLinkDefinitionsResult = client.getLinkDefinitions(
-                repoId, null, null, null, null, null, null);
+                new ParametersForGetLinkDefinitions().setRepoId(repoId));
         EntryLinkTypeInfo firstLinkDefinition = allLinkDefinitionsResult
                 .getValue()
                 .get(0);
         assertNotNull(firstLinkDefinition);
 
-        EntryLinkTypeInfo linkDefinitions = client.getLinkDefinitionById(repoId,
-                firstLinkDefinition.getLinkTypeId(), null);
+        EntryLinkTypeInfo linkDefinitions = client.getLinkDefinitionById(
+                new ParametersForGetLinkDefinitionById().setRepoId(repoId).setLinkTypeId(firstLinkDefinition.getLinkTypeId()));
 
         assertNotNull(linkDefinitions);
         assertEquals(linkDefinitions.getLinkTypeId(), firstLinkDefinition.getLinkTypeId());

--- a/src/test/java/integration/SearchApiTest.java
+++ b/src/test/java/integration/SearchApiTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.laserfiche.repository.api.clients.SearchesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class SearchApiTest extends BaseTest {
     @AfterEach
     void cancelCloseSearch() {
         if (searchToken != null) {
-            client.cancelOrCloseSearch(repoId, searchToken);
+            client.cancelOrCloseSearch(new ParametersForCancelOrCloseSearch().setRepoId(repoId).setSearchToken(searchToken));
         }
     }
 
@@ -34,15 +35,15 @@ public class SearchApiTest extends BaseTest {
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client
-                .createSearchOperation(repoId, request);
+                .createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId).setRequestBody(request));
         searchToken = searchResponse.getToken();
 
         assertNotNull(searchToken);
 
         TimeUnit.SECONDS.sleep(5);
 
-        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(repoId,
-                searchToken, null, null, null, null, null, null, null, null, null, null, null);
+        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(new ParametersForGetSearchResults().setRepoId(repoId)
+                        .setSearchToken(searchToken));
 
         assertNotNull(searchResults);
         assertTrue(searchResults
@@ -55,7 +56,8 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(repoId, searchToken, rowNum, null, null, null, null, null, null);
+                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
+                        .setSearchToken(searchToken).setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
     }
@@ -65,7 +67,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
 
@@ -73,8 +76,8 @@ public class SearchApiTest extends BaseTest {
 
         TimeUnit.SECONDS.sleep(5);
 
-        ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(repoId,
-                searchToken, null, null, null, null, null, null, null, null, null, null, null);
+        ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
+                new ParametersForGetSearchResults().setRepoId(repoId).setSearchToken(searchToken));
         assertNotNull(searchResultResponse);
     }
 
@@ -83,14 +86,15 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
         assertNotNull(searchToken);
 
         TimeUnit.SECONDS.sleep(5);
 
-        OperationProgress searchStatusResponse = client.getSearchStatus(repoId, searchToken);
+        OperationProgress searchStatusResponse = client.getSearchStatus(new ParametersForGetSearchStatus().setRepoId(repoId).setSearchToken(searchToken));
 
         assertNotNull(searchStatusResponse);
     }
@@ -101,14 +105,14 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         AcceptedOperation searchOperationResponse = client
-                .createSearchOperation(repoId, request);
+                .createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId).setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
 
         assertNotNull(searchToken);
 
         ODataValueOfBoolean closeSearchResponse = client
-                .cancelOrCloseSearch(repoId, searchToken);
+                .cancelOrCloseSearch(new ParametersForCancelOrCloseSearch().setRepoId(repoId).setSearchToken(searchToken));
 
         assertTrue(closeSearchResponse.isValue());
     }
@@ -121,7 +125,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
         assertTrue(searchToken != null && !searchToken
@@ -130,9 +135,9 @@ public class SearchApiTest extends BaseTest {
 
         TimeUnit.SECONDS.sleep(10);
 
-        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(repoId,
-                searchToken, null, null, null, null, String.format("maxpagesize=%d", maxPageSize), null, null, null,
-                null, null, null);
+        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
+                new ParametersForGetSearchResults().setRepoId(repoId).setSearchToken(searchToken)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResults);
         if (searchResults
@@ -162,7 +167,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
 
-        AcceptedOperation searchOperationResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchOperationResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
         assertTrue(searchToken != null && !searchToken
@@ -184,8 +190,8 @@ public class SearchApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getSearchResultsForEach(callback, maxPageSize, repoId, searchToken, null, null, null, null, null,
-                null, null, null, null, null, null);
+        client.getSearchResultsForEach(callback, maxPageSize, new ParametersForGetSearchResults().setRepoId(repoId)
+                        .setSearchToken(searchToken));
     }
 
     @Test
@@ -195,16 +201,17 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
         request.setFuzzyFactor(2);
 
-        AcceptedOperation searchResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
         assertNotNull(searchToken);
 
         TimeUnit.SECONDS.sleep(5);
 
-        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(repoId,
-                searchToken, null, null, null, null, String.format("maxpagesize=%d", maxPageSize), null, null, null,
-                null, null, null);
+        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
+                new ParametersForGetSearchResults().setRepoId(repoId)
+                        .setSearchToken(searchToken).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResults);
         assertTrue(searchResults
@@ -217,7 +224,8 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(repoId, searchToken, rowNum, null, null, null, null, null, null);
+                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
+                        .setSearchToken(searchToken).setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
 
@@ -245,16 +253,17 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
         request.setFuzzyFactor(2);
 
-        AcceptedOperation searchResponse = client.createSearchOperation(repoId, request);
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+                .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
         assertNotNull(searchToken);
 
         TimeUnit.SECONDS.sleep(5);
 
-        ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(repoId,
-                searchToken, null, null, null, null, String.format("maxpagesize=%d", maxPageSize), null, null, null,
-                null, null, null);
+        ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
+                new ParametersForGetSearchResults().setRepoId(repoId)
+                        .setSearchToken(searchToken).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResultResponse);
         assertTrue(searchResultResponse
@@ -267,7 +276,8 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(repoId, searchToken, rowNum, null, null, null, null, null, null);
+                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
+                        .setSearchToken(searchToken).setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
 
@@ -284,7 +294,7 @@ public class SearchApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getSearchContextHitsForEach(callback, maxPageSize, repoId, searchToken, 1, null, null, null, null,
-                null, null);
+        client.getSearchContextHitsForEach(callback, maxPageSize,
+                new ParametersForGetSearchContextHits().setRepoId(repoId).setSearchToken(searchToken).setRowNumber(1));
     }
 }

--- a/src/test/java/integration/SearchApiTest.java
+++ b/src/test/java/integration/SearchApiTest.java
@@ -24,7 +24,9 @@ public class SearchApiTest extends BaseTest {
     @AfterEach
     void cancelCloseSearch() {
         if (searchToken != null) {
-            client.cancelOrCloseSearch(new ParametersForCancelOrCloseSearch().setRepoId(repoId).setSearchToken(searchToken));
+            client.cancelOrCloseSearch(new ParametersForCancelOrCloseSearch()
+                    .setRepoId(repoId)
+                    .setSearchToken(searchToken));
         }
     }
 
@@ -35,15 +37,18 @@ public class SearchApiTest extends BaseTest {
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client
-                .createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId).setRequestBody(request));
+                .createSearchOperation(new ParametersForCreateSearchOperation()
+                        .setRepoId(repoId)
+                        .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
         assertNotNull(searchToken);
 
         TimeUnit.SECONDS.sleep(5);
 
-        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(new ParametersForGetSearchResults().setRepoId(repoId)
-                        .setSearchToken(searchToken));
+        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(new ParametersForGetSearchResults()
+                .setRepoId(repoId)
+                .setSearchToken(searchToken));
 
         assertNotNull(searchResults);
         assertTrue(searchResults
@@ -56,8 +61,10 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
-                        .setSearchToken(searchToken).setRowNumber(rowNum));
+                .getSearchContextHits(new ParametersForGetSearchContextHits()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
     }
@@ -67,7 +74,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
+                .setRepoId(repoId)
                 .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
@@ -77,7 +85,9 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(5);
 
         ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
-                new ParametersForGetSearchResults().setRepoId(repoId).setSearchToken(searchToken));
+                new ParametersForGetSearchResults()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken));
         assertNotNull(searchResultResponse);
     }
 
@@ -86,7 +96,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
+                .setRepoId(repoId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -94,7 +105,9 @@ public class SearchApiTest extends BaseTest {
 
         TimeUnit.SECONDS.sleep(5);
 
-        OperationProgress searchStatusResponse = client.getSearchStatus(new ParametersForGetSearchStatus().setRepoId(repoId).setSearchToken(searchToken));
+        OperationProgress searchStatusResponse = client.getSearchStatus(new ParametersForGetSearchStatus()
+                .setRepoId(repoId)
+                .setSearchToken(searchToken));
 
         assertNotNull(searchStatusResponse);
     }
@@ -105,14 +118,18 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         AcceptedOperation searchOperationResponse = client
-                .createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId).setRequestBody(request));
+                .createSearchOperation(new ParametersForCreateSearchOperation()
+                        .setRepoId(repoId)
+                        .setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
 
         assertNotNull(searchToken);
 
         ODataValueOfBoolean closeSearchResponse = client
-                .cancelOrCloseSearch(new ParametersForCancelOrCloseSearch().setRepoId(repoId).setSearchToken(searchToken));
+                .cancelOrCloseSearch(new ParametersForCancelOrCloseSearch()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken));
 
         assertTrue(closeSearchResponse.isValue());
     }
@@ -125,7 +142,8 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
 
-        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
+                .setRepoId(repoId)
                 .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
@@ -136,7 +154,9 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(10);
 
         ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
-                new ParametersForGetSearchResults().setRepoId(repoId).setSearchToken(searchToken)
+                new ParametersForGetSearchResults()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResults);
@@ -167,8 +187,10 @@ public class SearchApiTest extends BaseTest {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
 
-        AcceptedOperation searchOperationResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
-                .setRequestBody(request));
+        AcceptedOperation searchOperationResponse = client.createSearchOperation(
+                new ParametersForCreateSearchOperation()
+                        .setRepoId(repoId)
+                        .setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
         assertTrue(searchToken != null && !searchToken
@@ -190,8 +212,9 @@ public class SearchApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getSearchResultsForEach(callback, maxPageSize, new ParametersForGetSearchResults().setRepoId(repoId)
-                        .setSearchToken(searchToken));
+        client.getSearchResultsForEach(callback, maxPageSize, new ParametersForGetSearchResults()
+                .setRepoId(repoId)
+                .setSearchToken(searchToken));
     }
 
     @Test
@@ -201,7 +224,8 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
         request.setFuzzyFactor(2);
 
-        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
+                .setRepoId(repoId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -210,8 +234,10 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(5);
 
         ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
-                new ParametersForGetSearchResults().setRepoId(repoId)
-                        .setSearchToken(searchToken).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                new ParametersForGetSearchResults()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResults);
         assertTrue(searchResults
@@ -224,8 +250,10 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
-                        .setSearchToken(searchToken).setRowNumber(rowNum));
+                .getSearchContextHits(new ParametersForGetSearchContextHits()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
 
@@ -253,7 +281,8 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
         request.setFuzzyFactor(2);
 
-        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation().setRepoId(repoId)
+        AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
+                .setRepoId(repoId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -262,8 +291,10 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(5);
 
         ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
-                new ParametersForGetSearchResults().setRepoId(repoId)
-                        .setSearchToken(searchToken).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                new ParametersForGetSearchResults()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(searchResultResponse);
         assertTrue(searchResultResponse
@@ -276,8 +307,10 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(new ParametersForGetSearchContextHits().setRepoId(repoId)
-                        .setSearchToken(searchToken).setRowNumber(rowNum));
+                .getSearchContextHits(new ParametersForGetSearchContextHits()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setRowNumber(rowNum));
 
         assertNotNull(contextHitResponse);
 
@@ -295,6 +328,9 @@ public class SearchApiTest extends BaseTest {
             }
         };
         client.getSearchContextHitsForEach(callback, maxPageSize,
-                new ParametersForGetSearchContextHits().setRepoId(repoId).setSearchToken(searchToken).setRowNumber(1));
+                new ParametersForGetSearchContextHits()
+                        .setRepoId(repoId)
+                        .setSearchToken(searchToken)
+                        .setRowNumber(1));
     }
 }

--- a/src/test/java/integration/SetEntriesApiTest.java
+++ b/src/test/java/integration/SetEntriesApiTest.java
@@ -29,7 +29,10 @@ public class SetEntriesApiTest extends BaseTest {
                     .getId();
             repositoryApiClient
                     .getEntriesClient()
-                    .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(num).setRequestBody(body));
+                    .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                            .setRepoId(repoId)
+                            .setEntryId(num)
+                            .setRequestBody(body));
         }
         entry = null;
     }
@@ -57,7 +60,10 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueOfIListOfWTagInfo assignTagsResponse = repositoryApiClient
                 .getEntriesClient()
-                .assignTags(new ParametersForAssignTags().setRepoId(repoId).setEntryId(num).setRequestBody(request));
+                .assignTags(new ParametersForAssignTags()
+                        .setRepoId(repoId)
+                        .setEntryId(num)
+                        .setRequestBody(request));
         List<WTagInfo> tags = assignTagsResponse.getValue();
 
         assertNotNull(tags);
@@ -80,7 +86,9 @@ public class SetEntriesApiTest extends BaseTest {
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = repositoryApiClient
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId).setTemplateId(templateDefinition.getId()));
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
+                            .setRepoId(repoId)
+                            .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
@@ -96,8 +104,11 @@ public class SetEntriesApiTest extends BaseTest {
 
         Entry setTemplateResponse = repositoryApiClient
                 .getEntriesClient()
-                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(entry
-                        .getId()).setRequestBody(request));
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(entry
+                                .getId())
+                        .setRequestBody(request));
 
         assertNotNull(setTemplateResponse);
         assertEquals(setTemplateResponse
@@ -149,7 +160,9 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueOfIListOfFieldValue assignFieldValuesResponse = repositoryApiClient
                 .getEntriesClient()
-                .assignFieldValues(new ParametersForAssignFieldValues().setRepoId(repoId).setEntryId(entryId)
+                .assignFieldValues(new ParametersForAssignFieldValues()
+                        .setRepoId(repoId)
+                        .setEntryId(entryId)
                         .setRequestBody(requestBody));
         List<FieldValue> fields = assignFieldValuesResponse
                 .getValue();
@@ -176,8 +189,9 @@ public class SetEntriesApiTest extends BaseTest {
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = client
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
-                                    .setTemplateId(templateDefinition.getId()));
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
+                            .setRepoId(repoId)
+                            .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(
                     templateDefinitionsFieldsResponse.getValue())) {
@@ -195,8 +209,11 @@ public class SetEntriesApiTest extends BaseTest {
 
         Entry writeTemplateValueToEntryResponse = client
                 .getEntriesClient()
-                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(entry
-                        .getId()).setRequestBody(request));
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
+                        .setRepoId(repoId)
+                        .setEntryId(entry
+                                .getId())
+                        .setRequestBody(request));
 
         assertNotNull(writeTemplateValueToEntryResponse);
         assertEquals(writeTemplateValueToEntryResponse

--- a/src/test/java/integration/SetEntriesApiTest.java
+++ b/src/test/java/integration/SetEntriesApiTest.java
@@ -2,6 +2,7 @@ package integration;
 
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -28,7 +29,7 @@ public class SetEntriesApiTest extends BaseTest {
                     .getId();
             repositoryApiClient
                     .getEntriesClient()
-                    .deleteEntryInfo(repoId, num, body);
+                    .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(num).setRequestBody(body));
         }
         entry = null;
     }
@@ -37,7 +38,7 @@ public class SetEntriesApiTest extends BaseTest {
     void setTags_ReturnTags() {
         ODataValueContextOfIListOfWTagInfo tagDefinitionsResponse = repositoryApiClient
                 .getTagDefinitionsClient()
-                .getTagDefinitions(repoId, null, null, null, null, null, null, null);
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
         List<WTagInfo> tagDefinitions = tagDefinitionsResponse.getValue();
 
         assertNotNull(tagDefinitions);
@@ -56,7 +57,7 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueOfIListOfWTagInfo assignTagsResponse = repositoryApiClient
                 .getEntriesClient()
-                .assignTags(repoId, num, request);
+                .assignTags(new ParametersForAssignTags().setRepoId(repoId).setEntryId(num).setRequestBody(request));
         List<WTagInfo> tags = assignTagsResponse.getValue();
 
         assertNotNull(tags);
@@ -70,7 +71,7 @@ public class SetEntriesApiTest extends BaseTest {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -79,8 +80,7 @@ public class SetEntriesApiTest extends BaseTest {
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = repositoryApiClient
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(repoId, templateDefinition.getId(), null, null, null, null, null, null,
-                            null);
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId).setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
@@ -96,8 +96,8 @@ public class SetEntriesApiTest extends BaseTest {
 
         Entry setTemplateResponse = repositoryApiClient
                 .getEntriesClient()
-                .writeTemplateValueToEntry(repoId, entry
-                        .getId(), request, null);
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(entry
+                        .getId()).setRequestBody(request));
 
         assertNotNull(setTemplateResponse);
         assertEquals(setTemplateResponse
@@ -112,7 +112,7 @@ public class SetEntriesApiTest extends BaseTest {
         // Find a field definition that accepts String and has constraint.
         ODataValueContextOfIListOfWFieldInfo fieldDefinitionsResponse = repositoryApiClient
                 .getFieldDefinitionsClient()
-                .getFieldDefinitions(repoId, null, null, null, null, null, null, null);
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId));
         List<WFieldInfo> fieldDefinitions = fieldDefinitionsResponse.getValue();
         for (WFieldInfo fieldDefinition : fieldDefinitions) {
             if (fieldDefinition
@@ -149,7 +149,8 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueOfIListOfFieldValue assignFieldValuesResponse = repositoryApiClient
                 .getEntriesClient()
-                .assignFieldValues(repoId, entryId, requestBody, null);
+                .assignFieldValues(new ParametersForAssignFieldValues().setRepoId(repoId).setEntryId(entryId)
+                        .setRequestBody(requestBody));
         List<FieldValue> fields = assignFieldValuesResponse
                 .getValue();
 
@@ -166,7 +167,7 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = client
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -175,8 +176,8 @@ public class SetEntriesApiTest extends BaseTest {
         for (WTemplateInfo templateDefinition : templateDefinitions) {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = client
                     .getTemplateDefinitionClient()
-                    .getTemplateFieldDefinitions(repoId, templateDefinition.getId(), null, null, null, null, null, null,
-                            null);
+                    .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                                    .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(
                     templateDefinitionsFieldsResponse.getValue())) {
@@ -194,8 +195,8 @@ public class SetEntriesApiTest extends BaseTest {
 
         Entry writeTemplateValueToEntryResponse = client
                 .getEntriesClient()
-                .writeTemplateValueToEntry(repoId, entry
-                        .getId(), request, null);
+                .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry().setRepoId(repoId).setEntryId(entry
+                        .getId()).setRequestBody(request));
 
         assertNotNull(writeTemplateValueToEntryResponse);
         assertEquals(writeTemplateValueToEntryResponse

--- a/src/test/java/integration/SetLinksApiTest.java
+++ b/src/test/java/integration/SetLinksApiTest.java
@@ -35,8 +35,10 @@ public class SetLinksApiTest extends BaseTest {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 client
                         .getEntriesClient()
-                        .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId)
-                                .setEntryId(createdEntry.getId()).setRequestBody(body));
+                        .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                                .setRepoId(repoId)
+                                .setEntryId(createdEntry.getId())
+                                .setRequestBody(body));
             }
         }
     }
@@ -55,8 +57,11 @@ public class SetLinksApiTest extends BaseTest {
         request.add(linkRequest);
         ODataValueOfIListOfWEntryLinkInfo result = client
                 .getEntriesClient()
-                .assignEntryLinks(new ParametersForAssignEntryLinks().setRepoId(repoId).setEntryId(sourceEntry
-                        .getId()).setRequestBody(request));
+                .assignEntryLinks(new ParametersForAssignEntryLinks()
+                        .setRepoId(repoId)
+                        .setEntryId(sourceEntry
+                                .getId())
+                        .setRequestBody(request));
         List<WEntryLinkInfo> links = result.getValue();
         assertNotNull(links);
         assertEquals(request.size(), links.size());

--- a/src/test/java/integration/SetLinksApiTest.java
+++ b/src/test/java/integration/SetLinksApiTest.java
@@ -2,6 +2,8 @@ package integration;
 
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.ParametersForAssignEntryLinks;
+import com.laserfiche.repository.api.clients.params.ParametersForDeleteEntryInfo;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,7 +35,8 @@ public class SetLinksApiTest extends BaseTest {
                 DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
                 client
                         .getEntriesClient()
-                        .deleteEntryInfo(repoId, createdEntry.getId(), body);
+                        .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId)
+                                .setEntryId(createdEntry.getId()).setRequestBody(body));
             }
         }
     }
@@ -52,8 +55,8 @@ public class SetLinksApiTest extends BaseTest {
         request.add(linkRequest);
         ODataValueOfIListOfWEntryLinkInfo result = client
                 .getEntriesClient()
-                .assignEntryLinks(repoId, sourceEntry
-                        .getId(), request);
+                .assignEntryLinks(new ParametersForAssignEntryLinks().setRepoId(repoId).setEntryId(sourceEntry
+                        .getId()).setRequestBody(request));
         List<WEntryLinkInfo> links = result.getValue();
         assertNotNull(links);
         assertEquals(request.size(), links.size());

--- a/src/test/java/integration/SimpleSearchesApiTest.java
+++ b/src/test/java/integration/SimpleSearchesApiTest.java
@@ -3,6 +3,7 @@ package integration;
 import com.laserfiche.repository.api.clients.SimpleSearchesClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueOfIListOfEntry;
 import com.laserfiche.repository.api.clients.impl.model.SimpleSearchRequest;
+import com.laserfiche.repository.api.clients.params.ParametersForCreateSimpleSearchOperation;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -16,7 +17,8 @@ class SimpleSearchesApiTest extends BaseTest {
         searchRequest.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         ODataValueOfIListOfEntry entryList = client
-                .createSimpleSearchOperation(null, null, null, repoId, null, null, searchRequest, null);
+                .createSimpleSearchOperation(new ParametersForCreateSimpleSearchOperation().setRepoId(repoId).
+        setRequestBody(searchRequest));
 
         assertNotNull(entryList);
     }

--- a/src/test/java/integration/SimpleSearchesApiTest.java
+++ b/src/test/java/integration/SimpleSearchesApiTest.java
@@ -17,8 +17,9 @@ class SimpleSearchesApiTest extends BaseTest {
         searchRequest.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         ODataValueOfIListOfEntry entryList = client
-                .createSimpleSearchOperation(new ParametersForCreateSimpleSearchOperation().setRepoId(repoId).
-        setRequestBody(searchRequest));
+                .createSimpleSearchOperation(new ParametersForCreateSimpleSearchOperation()
+                        .setRepoId(repoId).
+                        setRequestBody(searchRequest));
 
         assertNotNull(entryList);
     }

--- a/src/test/java/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/integration/TagDefinitionsApiTest.java
@@ -3,6 +3,8 @@ package integration;
 import com.laserfiche.repository.api.clients.TagDefinitionsClient;
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTagInfo;
 import com.laserfiche.repository.api.clients.impl.model.WTagInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -22,7 +24,7 @@ class TagDefinitionsApiTest extends BaseTest {
     @Test
     void getTagDefinitions_ReturnAllTags() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(repoId, null, null, null, null, null, null, false);
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
 
         assertNotNull(tagInfoList);
     }
@@ -31,8 +33,8 @@ class TagDefinitionsApiTest extends BaseTest {
     void getTagDefinitions_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(repoId, String.format("maxpagesize=%d", maxPageSize), null, null, null, null, null,
-                        false);
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId)
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(tagInfoList);
 
@@ -56,7 +58,7 @@ class TagDefinitionsApiTest extends BaseTest {
     @Test
     void getTagDefinitions_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(repoId, null, null, null, null, null, null, false);
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
 
         assertNotNull(tagInfoList);
 
@@ -76,21 +78,22 @@ class TagDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTagDefinitionsForEach(callback, maxPageSize, repoId, null, null, null, null, null, null, null);
+        client.getTagDefinitionsForEach(callback, maxPageSize, new ParametersForGetTagDefinitions().setRepoId(repoId));
     }
 
     @Test
     void getTagDefinitionById_ReturnTag() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(repoId, null, null, null, null, null, null, false);
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
 
         assertNotNull(tagInfoList);
 
         WTagInfo tagInfo = client
-                .getTagDefinitionById(repoId, tagInfoList
+                .getTagDefinitionById(new ParametersForGetTagDefinitionById().setRepoId(repoId)
+                        .setTagId(tagInfoList
                         .getValue()
                         .get(0)
-                        .getId(), null, null);
+                        .getId()));
 
         assertNotNull(tagInfo);
     }

--- a/src/test/java/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/integration/TagDefinitionsApiTest.java
@@ -33,8 +33,9 @@ class TagDefinitionsApiTest extends BaseTest {
     void getTagDefinitions_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId)
-                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                .getTagDefinitions(new ParametersForGetTagDefinitions()
+                        .setRepoId(repoId)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(tagInfoList);
 
@@ -89,11 +90,12 @@ class TagDefinitionsApiTest extends BaseTest {
         assertNotNull(tagInfoList);
 
         WTagInfo tagInfo = client
-                .getTagDefinitionById(new ParametersForGetTagDefinitionById().setRepoId(repoId)
+                .getTagDefinitionById(new ParametersForGetTagDefinitionById()
+                        .setRepoId(repoId)
                         .setTagId(tagInfoList
-                        .getValue()
-                        .get(0)
-                        .getId()));
+                                .getValue()
+                                .get(0)
+                                .getId()));
 
         assertNotNull(tagInfo);
     }

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -35,7 +35,10 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                        .setRepoId(repoId)
+                        .setEntryId(deleteEntry.getId())
+                        .setRequestBody(body));
 
         String token = result.getToken();
 
@@ -44,7 +47,9 @@ public class TasksApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(10);
 
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
-            client.cancelOperation(new ParametersForCancelOperation().setRepoId(repoId).setOperationToken(token));
+            client.cancelOperation(new ParametersForCancelOperation()
+                    .setRepoId(repoId)
+                    .setOperationToken(token));
         });
 
         Assertions.assertEquals(
@@ -61,12 +66,17 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                        .setRepoId(repoId)
+                        .setEntryId(deleteEntry.getId())
+                        .setRequestBody(body));
 
         String token = result.getToken();
         assertNotNull(token);
 
-        boolean cancellationResult = client.cancelOperation(new ParametersForCancelOperation().setRepoId(repoId).setOperationToken(token));
+        boolean cancellationResult = client.cancelOperation(new ParametersForCancelOperation()
+                .setRepoId(repoId)
+                .setOperationToken(token));
         assertTrue(cancellationResult);
     }
 
@@ -79,7 +89,10 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo()
+                        .setRepoId(repoId)
+                        .setEntryId(deleteEntry.getId())
+                        .setRequestBody(body));
 
         String token = result.getToken();
 
@@ -87,7 +100,10 @@ public class TasksApiTest extends BaseTest {
 
         TimeUnit.SECONDS.sleep(5);
 
-        OperationProgress operationProgressResponse = client.getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress().setRepoId(repoId).setOperationToken(token));
+        OperationProgress operationProgressResponse = client.getOperationStatusAndProgress(
+                new ParametersForGetOperationStatusAndProgress()
+                        .setRepoId(repoId)
+                        .setOperationToken(token));
 
         assertNotNull(operationProgressResponse);
         Assertions.assertSame(operationProgressResponse.getStatus(), OperationStatus.COMPLETED);

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -4,6 +4,9 @@ import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.TasksClient;
 import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
+import com.laserfiche.repository.api.clients.params.ParametersForCancelOperation;
+import com.laserfiche.repository.api.clients.params.ParametersForDeleteEntryInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetOperationStatusAndProgress;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -32,7 +35,7 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(repoId, deleteEntry.getId(), body);
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
 
         String token = result.getToken();
 
@@ -41,7 +44,7 @@ public class TasksApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(10);
 
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
-            client.cancelOperation(repoId, token);
+            client.cancelOperation(new ParametersForCancelOperation().setRepoId(repoId).setOperationToken(token));
         });
 
         Assertions.assertEquals(
@@ -58,12 +61,12 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(repoId, deleteEntry.getId(), body);
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
 
         String token = result.getToken();
         assertNotNull(token);
 
-        boolean cancellationResult = client.cancelOperation(repoId, token);
+        boolean cancellationResult = client.cancelOperation(new ParametersForCancelOperation().setRepoId(repoId).setOperationToken(token));
         assertTrue(cancellationResult);
     }
 
@@ -76,7 +79,7 @@ public class TasksApiTest extends BaseTest {
 
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
-                .deleteEntryInfo(repoId, deleteEntry.getId(), body);
+                .deleteEntryInfo(new ParametersForDeleteEntryInfo().setRepoId(repoId).setEntryId(deleteEntry.getId()).setRequestBody(body));
 
         String token = result.getToken();
 
@@ -84,7 +87,7 @@ public class TasksApiTest extends BaseTest {
 
         TimeUnit.SECONDS.sleep(5);
 
-        OperationProgress operationProgressResponse = client.getOperationStatusAndProgress(repoId, token);
+        OperationProgress operationProgressResponse = client.getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress().setRepoId(repoId).setOperationToken(token));
 
         assertNotNull(operationProgressResponse);
         Assertions.assertSame(operationProgressResponse.getStatus(), OperationStatus.COMPLETED);

--- a/src/test/java/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/integration/TemplateDefinitionsApiTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -49,7 +48,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
-                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                        new ParametersForGetTemplateFieldDefinitions()
+                                .setRepoId(repoId)
                                 .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -63,7 +63,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(
-                        new ParametersForGetTemplateDefinitions().setRepoId(repoId)
+                        new ParametersForGetTemplateDefinitions()
+                                .setRepoId(repoId)
                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(templateInfoList);
@@ -107,7 +108,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTemplateDefinitionsForEach(callback, maxPageSize, new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+        client.getTemplateDefinitionsForEach(callback, maxPageSize,
+                new ParametersForGetTemplateDefinitions().setRepoId(repoId));
     }
 
     @Test
@@ -115,7 +117,9 @@ class TemplateDefinitionsApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(
-                        new ParametersForGetTemplateDefinitions().setRepoId(repoId).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                        new ParametersForGetTemplateDefinitions()
+                                .setRepoId(repoId)
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -125,8 +129,10 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
-                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId).setTemplateId(tempDef.getId())
-                                                                      .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
+                        new ParametersForGetTemplateFieldDefinitions()
+                                .setRepoId(repoId)
+                                .setTemplateId(tempDef.getId())
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(result);
         Assertions.assertSame(maxPageSize, result
@@ -162,7 +168,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
-                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                        new ParametersForGetTemplateFieldDefinitions()
+                                .setRepoId(repoId)
                                 .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -187,7 +194,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
             }
         };
         client.getTemplateFieldDefinitionsForEach(callback, maxPageSize,
-                new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                new ParametersForGetTemplateFieldDefinitions()
+                        .setRepoId(repoId)
                         .setTemplateId(tempDef.getId()));
     }
 
@@ -203,7 +211,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         WTemplateInfo result = client
-                .getTemplateDefinitionById(new ParametersForGetTemplateDefinitionById().setRepoId(repoId)
+                .getTemplateDefinitionById(new ParametersForGetTemplateDefinitionById()
+                        .setRepoId(repoId)
                         .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -222,7 +231,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfWTemplateInfo result = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId)
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions()
+                        .setRepoId(repoId)
                         .setTemplateName(tempDef.getName()));
 
         assertNotNull(result);
@@ -239,7 +249,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitionsByTemplateName(
-                        new ParametersForGetTemplateFieldDefinitionsByTemplateName().setRepoId(repoId)
+                        new ParametersForGetTemplateFieldDefinitionsByTemplateName()
+                                .setRepoId(repoId)
                                 .setTemplateName(firstTemplateDefinitions.getName()));
         List<TemplateFieldInfo> templateFieldDefinitions = result.getValue();
         assertNotNull(templateFieldDefinitions);

--- a/src/test/java/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/integration/TemplateDefinitionsApiTest.java
@@ -5,6 +5,10 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIList
 import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIListOfWTemplateInfo;
 import com.laserfiche.repository.api.clients.impl.model.TemplateFieldInfo;
 import com.laserfiche.repository.api.clients.impl.model.WTemplateInfo;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitionById;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
+import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitionsByTemplateName;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +31,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitions_ReturnAllTemplates() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         assertNotNull(templateInfoList);
     }
@@ -35,7 +39,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsFields_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -44,7 +48,9 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
-                .getTemplateFieldDefinitions(repoId, tempDef.getId(), null, null, null, null, null, null, false);
+                .getTemplateFieldDefinitions(
+                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                                .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
         Assertions.assertSame(result
@@ -56,8 +62,9 @@ class TemplateDefinitionsApiTest extends BaseTest {
     void getTemplateDefinitions_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, String.format("maxpagesize=%d", maxPageSize), null, null, null,
-                        null, null, false);
+                .getTemplateDefinitions(
+                        new ParametersForGetTemplateDefinitions().setRepoId(repoId)
+                                .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(templateInfoList);
         String nextLink = templateInfoList.getOdataNextLink();
@@ -80,7 +87,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitions_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         assertNotNull(templateInfoList);
 
@@ -100,16 +107,15 @@ class TemplateDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTemplateDefinitionsForEach(callback, maxPageSize, repoId, null, null, null, null, null, null,
-                null, null);
+        client.getTemplateDefinitionsForEach(callback, maxPageSize, new ParametersForGetTemplateDefinitions().setRepoId(repoId));
     }
 
     @Test
     void getTemplateDefinitionsFields_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, String.format("maxpagesize=%d", maxPageSize), null, null, null,
-                        null, null, false);
+                .getTemplateDefinitions(
+                        new ParametersForGetTemplateDefinitions().setRepoId(repoId).setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -118,8 +124,9 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
-                .getTemplateFieldDefinitions(repoId, tempDef.getId(), String.format("maxpagesize=%d", maxPageSize),
-                        null, null, null, null, null, false);
+                .getTemplateFieldDefinitions(
+                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId).setTemplateId(tempDef.getId())
+                                                                      .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(result);
         Assertions.assertSame(maxPageSize, result
@@ -145,7 +152,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsFields_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -154,7 +161,9 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
-                .getTemplateFieldDefinitions(repoId, tempDef.getId(), null, null, null, null, null, null, false);
+                .getTemplateFieldDefinitions(
+                        new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                                .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
         Assertions.assertSame(result
@@ -177,14 +186,15 @@ class TemplateDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTemplateFieldDefinitionsForEach(callback, maxPageSize, repoId, tempDef.getId(), null, null, null,
-                null, null, null, false);
+        client.getTemplateFieldDefinitionsForEach(callback, maxPageSize,
+                new ParametersForGetTemplateFieldDefinitions().setRepoId(repoId)
+                        .setTemplateId(tempDef.getId()));
     }
 
     @Test
     void getTemplateDefinitionsFieldsById_ReturnTemplate() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -193,7 +203,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         WTemplateInfo result = client
-                .getTemplateDefinitionById(repoId, tempDef.getId(), null, null);
+                .getTemplateDefinitionById(new ParametersForGetTemplateDefinitionById().setRepoId(repoId)
+                        .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
         Assertions.assertSame(result.getId(), tempDef.getId());
@@ -202,7 +213,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsByTemplateName_TemplateNameQueryParameter_ReturnSingleTemplate() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -211,7 +222,8 @@ class TemplateDefinitionsApiTest extends BaseTest {
         assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfWTemplateInfo result = client
-                .getTemplateDefinitions(repoId, tempDef.getName(), null, null, null, null, null, null, false);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId)
+                        .setTemplateName(tempDef.getName()));
 
         assertNotNull(result);
     }
@@ -219,15 +231,16 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsByTemplateName_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo allTemplateDefinitionsFuture = client
-                .getTemplateDefinitions(repoId, null, null, null, null, null, null, null, null);
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
         WTemplateInfo firstTemplateDefinitions = allTemplateDefinitionsFuture
                 .getValue()
                 .get(0);
         assertNotNull(firstTemplateDefinitions);
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
-                .getTemplateFieldDefinitionsByTemplateName(repoId, firstTemplateDefinitions.getName(), null, null, null,
-                        null, null, null, null);
+                .getTemplateFieldDefinitionsByTemplateName(
+                        new ParametersForGetTemplateFieldDefinitionsByTemplateName().setRepoId(repoId)
+                                .setTemplateName(firstTemplateDefinitions.getName()));
         List<TemplateFieldInfo> templateFieldDefinitions = result.getValue();
         assertNotNull(templateFieldDefinitions);
         assertEquals(templateFieldDefinitions.size(), firstTemplateDefinitions.getFieldCount());


### PR DESCRIPTION
The client implementations, e.g. EntriesClient, include methods with several parameters, while not all of those parameters are required. As Java does not support default value for method parameters, we decided to refactor the code generator to encapsulate the parameters of such methods in a separate class, and use that class as the parameter type. This way, when an api method is being called, it is not necessary to pass null arguments to the method.

In this PR:

- for each api method, a new class is created to encapsulate its parameters.
- that class is used as the parameter type for that api method
- As now the client doesn't need to send arguments for all the method parameters, there is no need to make the parameters nullable. So, the parameters are changed from wrapper classes to the primitive data types. For instance, from Integer to int.
Before this, we used null-check to decide which arguments need to be ignored, when using method parameters in the query parameters or in path.... This is changed as not the parameters are not Wrapper class, but primitive data type. So, the code ignores the arguments which are equal to the default value of the parameter. This means the method getNonNullParameters in the client library is replaced with getParametersWithNonDefaultValue.
- Integration tests are refactored to use the encapsulation classes