### PR TITLE
refactor baseTest file

### DIFF
--- a/src/test/java/integration/AttributesApiTest.java
+++ b/src/test/java/integration/AttributesApiTest.java
@@ -25,7 +25,7 @@ class AttributesApiTest extends BaseTest {
     void getTrusteeAttributeKeyValuePairs_ReturnAttributes() {
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
                 new ParametersForGetTrusteeAttributeKeyValuePairs()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEveryone(true));
 
         assertNotNull(attributeList);
@@ -35,13 +35,13 @@ class AttributesApiTest extends BaseTest {
     void getAttributeValueByKey_ReturnAttribute() {
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
                 new ParametersForGetTrusteeAttributeKeyValuePairs()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEveryone(true));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
                 new ParametersForGetTrusteeAttributeValueByKey()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setAttributeKey(attributeList
                                 .getValue()
                                 .get(0)
@@ -55,14 +55,14 @@ class AttributesApiTest extends BaseTest {
         int maxPageSize = 5;
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
                 new ParametersForGetTrusteeAttributeKeyValuePairs()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEveryone(true)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
                 new ParametersForGetTrusteeAttributeValueByKey()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setAttributeKey(attributeList
                                 .getValue()
                                 .get(0)
@@ -93,14 +93,14 @@ class AttributesApiTest extends BaseTest {
         int maxPageSize = 90;
         ODataValueContextOfListOfAttribute attributeList = client.getTrusteeAttributeKeyValuePairs(
                 new ParametersForGetTrusteeAttributeKeyValuePairs()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEveryone(true)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(attributeList);
 
         Attribute attribute = client.getTrusteeAttributeValueByKey(
                 new ParametersForGetTrusteeAttributeValueByKey()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setAttributeKey(attributeList
                                 .getValue()
                                 .get(0)
@@ -125,7 +125,7 @@ class AttributesApiTest extends BaseTest {
         };
         client.getTrusteeAttributeKeyValuePairsForEach(callback, maxPageSize,
                 new ParametersForGetTrusteeAttributeKeyValuePairs()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEveryone(true));
     }
 }

--- a/src/test/java/integration/AuditReasonsApiTest.java
+++ b/src/test/java/integration/AuditReasonsApiTest.java
@@ -11,7 +11,7 @@ class AuditReasonsApiTest extends BaseTest {
     @Test
     void getAuditReasons_ReturnAuditReasons() {
         AuditReasonsClient client = repositoryApiClient.getAuditReasonsClient();
-        AuditReasons reasons = client.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repoId));
+        AuditReasons reasons = client.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repositoryId));
 
         assertNotNull(reasons);
     }

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -57,9 +57,6 @@ public class BaseTest {
                     getEnvironmentVariable(AUTHORIZATION_TYPE));
         }
         repositoryId = getEnvironmentVariable(REPOSITORY_ID);
-        if (nullOrEmpty(repositoryId)) {
-            throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
-        }
         if (authorizationType == AuthorizationType.CLOUD_ACCESS_KEY) {
             servicePrincipalKey = getEnvironmentVariable(SERVICE_PRINCIPAL_KEY);
             String accessKeyBase64 = getEnvironmentVariable(ACCESS_KEY);

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -40,13 +40,14 @@ public class BaseTest {
     private static final String BASE_URL = "APISERVER_REPOSITORY_API_BASE_URL";
     private static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
     private static AuthorizationType authorizationType;
-
+    private static final boolean IS_NOT_GITHUB_ENVIRONMENT = nullOrEmpty(System.getenv("GITHUB_WORKSPACE"));
     @BeforeAll
     public static void setUp() {
         Dotenv dotenv = Dotenv
                 .configure()
                 .filename(".env")
                 .systemProperties()
+                .ignoreIfMissing()
                 .load();
         try {
             authorizationType = AuthorizationType.valueOf(getEnvironmentVariable(AUTHORIZATION_TYPE));
@@ -79,7 +80,7 @@ public class BaseTest {
         String environmentVariable = System.getenv(environmentVariableName);
         if (nullOrEmpty(environmentVariable)) {
             environmentVariable = System.getProperty(environmentVariableName);
-            if (nullOrEmpty(environmentVariable))
+            if (nullOrEmpty(environmentVariable) && IS_NOT_GITHUB_ENVIRONMENT)
                 throw new IllegalStateException(
                         "Environment variable '" + environmentVariableName + "' does not exist.");
         }

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -22,15 +22,15 @@ enum AuthorizationType {
 }
 
 public class BaseTest {
-    protected static String servicePrincipalKey;
-    protected static AccessKey accessKey;
+    private static String servicePrincipalKey;
+    private static AccessKey accessKey;
     protected static String repositoryId;
-    protected static Map<String, String> testHeaders;
+    private static Map<String, String> testHeaders;
     protected static RepositoryApiClient repositoryApiClient;
-    protected static String testHeaderValue;
-    protected static String username;
-    protected static String password;
-    protected static String baseUrl;
+    private static String testHeaderValue;
+    private static String username;
+    private static String password;
+    private static String baseUrl;
     private static final String TEST_HEADER = "TEST_HEADER";
     private static final String ACCESS_KEY = "ACCESS_KEY";
     private static final String SERVICE_PRINCIPAL_KEY = "SERVICE_PRINCIPAL_KEY";
@@ -39,7 +39,7 @@ public class BaseTest {
     private static final String PASSWORD = "APISERVER_PASSWORD";
     private static final String BASE_URL = "APISERVER_REPOSITORY_API_BASE_URL";
     private static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
-    protected static AuthorizationType authorizationType;
+    private static AuthorizationType authorizationType;
 
     @BeforeAll
     public static void setUp() {

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -22,61 +22,110 @@ enum AuthorizationType {
 }
 
 public class BaseTest {
-    protected static String spKey;
+    protected static String servicePrincipalKey;
     protected static AccessKey accessKey;
-    protected static String repoId;
+    protected static String repositoryId;
     protected static Map<String, String> testHeaders;
     protected static RepositoryApiClient repositoryApiClient;
+    protected static String testHeaderValue;
     protected static String username;
     protected static String password;
     protected static String baseUrl;
-
-    protected static String authorizationType;
+    private static final String TEST_HEADER = "TEST_HEADER";
+    private static final String ACCESS_KEY = "ACCESS_KEY";
+    private static final String SERVICE_PRINCIPAL_KEY = "SERVICE_PRINCIPAL_KEY";
+    private static final String REPOSITORY_ID = "REPOSITORY_ID";
+    private static final String USERNAME = "APISERVER_USERNAME";
+    private static final String PASSWORD = "APISERVER_PASSWORD";
+    private static final String BASE_URL = "APISERVER_REPOSITORY_API_BASE_URL";
+    private static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
+    protected static AuthorizationType authorizationType;
 
     @BeforeAll
     public static void setUp() {
-        spKey = System.getenv("SERVICE_PRINCIPAL_KEY");
-        String accessKeyBase64 = System.getenv("ACCESS_KEY");
-        if (!nullOrEmpty(accessKeyBase64)) {
-            accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
+        Dotenv dotenv = Dotenv
+                .configure()
+                .filename(".env")
+                .systemProperties()
+                .load();
+        try {
+            authorizationType = AuthorizationType.valueOf(getEnvironmentVariable(AUTHORIZATION_TYPE));
+            testHeaderValue = getEnvironmentVariable(TEST_HEADER);
+        } catch (EnumConstantNotPresentException e) {
+            throw new EnumConstantNotPresentException(AuthorizationType.class,
+                    getEnvironmentVariable(AUTHORIZATION_TYPE));
         }
-        repoId = System.getenv("REPOSITORY_ID");
-        username = System.getenv("APISERVER_USERNAME");
-        password = System.getenv("APISERVER_PASSWORD");
-        baseUrl = System.getenv("APISERVER_REPOSITORY_API_BASE_URL");
-        authorizationType = System.getenv("AUTHORIZATION_TYPE");
-        String testHeaderValue = System.getenv("TEST_HEADER");
-        if (nullOrEmpty(authorizationType)) {
-            // Load environment variables
-            Dotenv dotenv = Dotenv
-                    .configure()
-                    .filename(".env")
-                    .load();
-            authorizationType = dotenv.get("AUTHORIZATION_TYPE");
-            testHeaderValue = dotenv.get("TEST_HEADER");
-            repoId = dotenv.get("REPOSITORY_ID");
-            if (nullOrEmpty(repoId)) {
-                throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
-            }
-            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
-                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
-                    accessKeyBase64 = dotenv.get("ACCESS_KEY");
-                    spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
-                    accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
-                }
-            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
-                if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
-                    username = dotenv.get("APISERVER_USERNAME");
-                    password = dotenv.get("APISERVER_PASSWORD");
-                    baseUrl = dotenv.get("APISERVER_REPOSITORY_API_BASE_URL");
-                }
-            } else {
-                throw new IllegalStateException("Invalid Authorization Type Value");
-            }
+        repositoryId = getEnvironmentVariable(REPOSITORY_ID);
+        if (nullOrEmpty(repositoryId)) {
+            throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
+        }
+        if (authorizationType == AuthorizationType.CLOUD_ACCESS_KEY) {
+            servicePrincipalKey = getEnvironmentVariable(SERVICE_PRINCIPAL_KEY);
+            String accessKeyBase64 = getEnvironmentVariable(ACCESS_KEY);
+            accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
+        } else if (authorizationType == AuthorizationType.API_SERVER_USERNAME_PASSWORD) {
+            username = getEnvironmentVariable(USERNAME);
+            password = getEnvironmentVariable(PASSWORD);
+            baseUrl = getEnvironmentVariable(BASE_URL);
+        } else {
+            throw new IllegalStateException("Invalid Authorization Type Value");
         }
         testHeaders = new HashMap<>();
         testHeaders.put(testHeaderValue, "true");
         repositoryApiClient = createClient();
+//        spKey = System.getenv("SERVICE_PRINCIPAL_KEY");
+//        String accessKeyBase64 = System.getenv("ACCESS_KEY");
+//        if (!nullOrEmpty(accessKeyBase64)) {
+//            accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
+//        }
+//        repoId = System.getenv("REPOSITORY_ID");
+//        username = System.getenv("APISERVER_USERNAME");
+//        password = System.getenv("APISERVER_PASSWORD");
+//        baseUrl = System.getenv("APISERVER_REPOSITORY_API_BASE_URL");
+//        authorizationType = System.getenv("AUTHORIZATION_TYPE");
+//        String testHeaderValue = System.getenv("TEST_HEADER");
+//        if (nullOrEmpty(authorizationType)) {
+//            // Load environment variables
+//            Dotenv dotenv = Dotenv
+//                    .configure()
+//                    .filename(".env")
+//                    .load();
+//            authorizationType = dotenv.get("AUTHORIZATION_TYPE");
+//            testHeaderValue = dotenv.get("TEST_HEADER");
+//            repoId = dotenv.get("REPOSITORY_ID");
+//            if (nullOrEmpty(repoId)) {
+//                throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
+//            }
+//            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
+//                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
+//                    accessKeyBase64 = dotenv.get("ACCESS_KEY");
+//                    spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
+//                    accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
+//                }
+//            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
+//                if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
+//                    username = dotenv.get("APISERVER_USERNAME");
+//                    password = dotenv.get("APISERVER_PASSWORD");
+//                    baseUrl = dotenv.get("APISERVER_REPOSITORY_API_BASE_URL");
+//                }
+//            } else {
+//                throw new IllegalStateException("Invalid Authorization Type Value");
+//            }
+//        }
+//        testHeaders = new HashMap<>();
+//        testHeaders.put(testHeaderValue, "true");
+//        repositoryApiClient = createClient();
+    }
+
+    private static String getEnvironmentVariable(String environmentVariableName) {
+        String environmentVariable = System.getenv(environmentVariableName);
+        if (nullOrEmpty(environmentVariable)) {
+            environmentVariable = System.getProperty(environmentVariableName);
+            if (nullOrEmpty(environmentVariable))
+                throw new IllegalStateException(
+                        "Environment variable '" + environmentVariableName + "' does not exist.");
+        }
+        return environmentVariable;
     }
 
     @AfterAll
@@ -86,14 +135,15 @@ public class BaseTest {
 
     public static RepositoryApiClient createClient() {
         if (repositoryApiClient == null) {
-            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
-                if (nullOrEmpty(spKey) || accessKey == null)
+            if (authorizationType.equals(AuthorizationType.CLOUD_ACCESS_KEY)) {
+                if (nullOrEmpty(servicePrincipalKey) || accessKey == null)
                     return null;
-                repositoryApiClient = RepositoryApiClientImpl.createFromAccessKey(spKey, accessKey);
-            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
-                if (nullOrEmpty(repoId) || nullOrEmpty(username) || nullOrEmpty(password) || nullOrEmpty(baseUrl))
+                repositoryApiClient = RepositoryApiClientImpl.createFromAccessKey(servicePrincipalKey, accessKey);
+            } else if (authorizationType.equals(AuthorizationType.API_SERVER_USERNAME_PASSWORD)) {
+                if (nullOrEmpty(repositoryId) || nullOrEmpty(username) || nullOrEmpty(password) || nullOrEmpty(baseUrl))
                     return null;
-                repositoryApiClient = RepositoryApiClientImpl.createFromUsernamePassword(repoId, username, password,
+                repositoryApiClient = RepositoryApiClientImpl.createFromUsernamePassword(repositoryId, username,
+                        password,
                         baseUrl);
             }
             repositoryApiClient.setDefaultRequestHeaders(testHeaders);
@@ -110,7 +160,7 @@ public class BaseTest {
         return client
                 .getEntriesClient()
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(autoRename));

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -73,48 +73,6 @@ public class BaseTest {
         testHeaders = new HashMap<>();
         testHeaders.put(testHeaderValue, "true");
         repositoryApiClient = createClient();
-//        spKey = System.getenv("SERVICE_PRINCIPAL_KEY");
-//        String accessKeyBase64 = System.getenv("ACCESS_KEY");
-//        if (!nullOrEmpty(accessKeyBase64)) {
-//            accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
-//        }
-//        repoId = System.getenv("REPOSITORY_ID");
-//        username = System.getenv("APISERVER_USERNAME");
-//        password = System.getenv("APISERVER_PASSWORD");
-//        baseUrl = System.getenv("APISERVER_REPOSITORY_API_BASE_URL");
-//        authorizationType = System.getenv("AUTHORIZATION_TYPE");
-//        String testHeaderValue = System.getenv("TEST_HEADER");
-//        if (nullOrEmpty(authorizationType)) {
-//            // Load environment variables
-//            Dotenv dotenv = Dotenv
-//                    .configure()
-//                    .filename(".env")
-//                    .load();
-//            authorizationType = dotenv.get("AUTHORIZATION_TYPE");
-//            testHeaderValue = dotenv.get("TEST_HEADER");
-//            repoId = dotenv.get("REPOSITORY_ID");
-//            if (nullOrEmpty(repoId)) {
-//                throw new IllegalStateException("Environment variable REPOSITORY_ID does not exist.");
-//            }
-//            if (authorizationType.equalsIgnoreCase(AuthorizationType.CLOUD_ACCESS_KEY.name())) {
-//                if (nullOrEmpty(spKey) && nullOrEmpty(accessKeyBase64)) {
-//                    accessKeyBase64 = dotenv.get("ACCESS_KEY");
-//                    spKey = dotenv.get("SERVICE_PRINCIPAL_KEY");
-//                    accessKey = AccessKey.createFromBase64EncodedAccessKey(accessKeyBase64);
-//                }
-//            } else if (authorizationType.equalsIgnoreCase(AuthorizationType.API_SERVER_USERNAME_PASSWORD.name())) {
-//                if (nullOrEmpty(username) && nullOrEmpty(password) && nullOrEmpty(baseUrl)) {
-//                    username = dotenv.get("APISERVER_USERNAME");
-//                    password = dotenv.get("APISERVER_PASSWORD");
-//                    baseUrl = dotenv.get("APISERVER_REPOSITORY_API_BASE_URL");
-//                }
-//            } else {
-//                throw new IllegalStateException("Invalid Authorization Type Value");
-//            }
-//        }
-//        testHeaders = new HashMap<>();
-//        testHeaders.put(testHeaderValue, "true");
-//        repositoryApiClient = createClient();
     }
 
     private static String getEnvironmentVariable(String environmentVariableName) {

--- a/src/test/java/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/integration/CreateCopyEntryApiTest.java
@@ -37,7 +37,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
                 repositoryApiClient
                         .getEntriesClient()
                         .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setEntryId(num)
                                 .setRequestBody(body));
             }
@@ -56,7 +56,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry createdEntry = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -82,7 +82,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry targetEntry = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -101,7 +101,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry shortCut = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -128,7 +128,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry targetEntry = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(testFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -144,7 +144,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         copyAsyncRequest.setSourceId(targetEntry.getId());
 
         AcceptedOperation copyEntryResponse = client.copyEntryAsync(new ParametersForCopyEntryAsync()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(testFolder.getId())
                 .setRequestBody(copyAsyncRequest)
                 .setAutoRename(true));
@@ -156,7 +156,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         OperationProgress getOperationStatusAndProgressResponse = repositoryApiClient
                 .getTasksClient()
                 .getOperationStatusAndProgress(new ParametersForGetOperationStatusAndProgress()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setOperationToken(opToken));
 
         assertEquals(getOperationStatusAndProgressResponse.getStatus(), OperationStatus.COMPLETED);
@@ -164,7 +164,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         DeleteEntryWithAuditReason deleteEntryWithAuditReason = new DeleteEntryWithAuditReason();
         AcceptedOperation deleteEntryResponse = client
                 .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(testFolder.getId())
                         .setRequestBody(deleteEntryWithAuditReason));
         assertNotNull(deleteEntryResponse);
@@ -181,7 +181,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry targetEntry = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -202,7 +202,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry createOrCopyEntryResponse = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -220,7 +220,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry newEntryResponse = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(parentEntryId)
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -249,7 +249,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         Entry movedEntry = client
                 .moveOrRenameEntry(new ParametersForMoveOrRenameEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(childFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
@@ -276,7 +276,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         request.setParentId(parentFolder.getId());
         request.setName("RepositoryApiClientIntegrationTest Java MovedFolder");
 
-        String invalidRepoId = String.format("%s-%s", repoId, repoId);
+        String invalidRepoId = String.format("%s-%s", repositoryId, repositoryId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
                 .moveOrRenameEntry(new ParametersForMoveOrRenameEntry()
                         .setRepoId(invalidRepoId)

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -34,7 +34,7 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getEntry_ReturnRootFolder() {
         Entry entry = client.getEntry(new ParametersForGetEntry()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(1));
 
         assertNotNull(entry);
@@ -44,7 +44,7 @@ class EntriesApiTest extends BaseTest {
     @Test
     void getEntry_ReturnEntryWhenTypeInfoMissing() {
         Entry entry = client.getEntry(new ParametersForGetEntry()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(1)
                 .setSelect("name"));
 
@@ -59,7 +59,7 @@ class EntriesApiTest extends BaseTest {
     void getEntryListing_ReturnEntries() {
         ODataValueContextOfIListOfEntry entries = client
                 .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setPrefer("maxpagesize=5"));
 
@@ -85,7 +85,7 @@ class EntriesApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfEntry entryList = client
                 .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1).
                         setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -127,7 +127,7 @@ class EntriesApiTest extends BaseTest {
         };
         client.getEntryListingForEach(callback, maxPageSize,
                 new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1));
     }
 
@@ -135,7 +135,7 @@ class EntriesApiTest extends BaseTest {
     void getFieldValues_ReturnFields() {
         ODataValueContextOfIListOfFieldValue fieldValueList = client
                 .getFieldValues(new ParametersForGetFieldValues()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1));
 
         assertNotNull(fieldValueList);
@@ -145,7 +145,7 @@ class EntriesApiTest extends BaseTest {
     void getLinkValuesFromEntry_ReturnLinks() {
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
                 .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1));
 
         assertNotNull(linkInfoList);
@@ -156,7 +156,7 @@ class EntriesApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfFieldValue fieldValueList = client
                 .getFieldValues(new ParametersForGetFieldValues()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -198,7 +198,7 @@ class EntriesApiTest extends BaseTest {
             }
         };
         client.getFieldValuesForEach(callback, maxPageSize, new ParametersForGetFieldValues()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(1));
     }
 
@@ -208,7 +208,7 @@ class EntriesApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWEntryLinkInfo linkInfoList = client
                 .getLinkValuesFromEntry(new ParametersForGetLinkValuesFromEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -255,7 +255,7 @@ class EntriesApiTest extends BaseTest {
             }
         };
         client.getLinkValuesFromEntryForEach(callback, maxPageSize, new ParametersForGetLinkValuesFromEntry()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(1));
     }
 
@@ -265,7 +265,7 @@ class EntriesApiTest extends BaseTest {
                 "RepositoryApiClientIntegrationTest Java DeleteFolder", 1, true);
 
         AcceptedOperation deleteEntryResponse = client.deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(entryToDelete.getId())
                 .setRequestBody(new DeleteEntryWithAuditReason()));
 
@@ -280,7 +280,7 @@ class EntriesApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
                 .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -327,7 +327,7 @@ class EntriesApiTest extends BaseTest {
             }
         };
         client.getTagsAssignedToEntryForEach(callback, maxPageSize, new ParametersForGetTagsAssignedToEntry()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(1));
     }
 
@@ -335,7 +335,7 @@ class EntriesApiTest extends BaseTest {
     void getTagsAssignedToEntry_ReturnTags() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
                 .getTagsAssignedToEntry(new ParametersForGetTagsAssignedToEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1));
 
         assertNotNull(tagInfoList);
@@ -345,7 +345,7 @@ class EntriesApiTest extends BaseTest {
     void getDynamicFieldsEntry_ReturnDynamicFields() {
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -358,7 +358,7 @@ class EntriesApiTest extends BaseTest {
 
         Map<String, String[]> dynamicFieldValueResponse = client
                 .getDynamicFieldValues(new ParametersForGetDynamicFieldValues()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setRequestBody(request));
         assertNotNull(dynamicFieldValueResponse);
@@ -369,7 +369,7 @@ class EntriesApiTest extends BaseTest {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
                 .getEntryByPath(new ParametersForGetEntryByPath()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setFullPath(rootPath));
 
         assertNotNull(entry);
@@ -391,7 +391,7 @@ class EntriesApiTest extends BaseTest {
         FindEntryResult entry = repositoryApiClient
                 .getEntriesClient()
                 .getEntryByPath(new ParametersForGetEntryByPath()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setFullPath(nonExistingPath)
                         .setFallbackToClosestAncestor(true));
 
@@ -413,7 +413,7 @@ class EntriesApiTest extends BaseTest {
     void getDocumentContentType_ReturnsExpectedHeaders() {
         ODataValueContextOfIListOfEntry entryList = client
                 .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setPrefer("maxpagesize=100"));
         assertNotNull(entryList);
@@ -428,7 +428,7 @@ class EntriesApiTest extends BaseTest {
 
         Map<String, String> headers = client
                 .getDocumentContentType(new ParametersForGetDocumentContentType()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(entry.getId()));
         assertNotNull(headers.get("Content-Type"));
         assertNotNull(headers.get("Content-Length"));
@@ -439,7 +439,7 @@ class EntriesApiTest extends BaseTest {
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> {
             client
                     .getEntryListing(new ParametersForGetEntryListing()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setEntryId(-1)
                             .setPrefer("maxpagesize=100"));
         });
@@ -457,7 +457,7 @@ class EntriesApiTest extends BaseTest {
         String[] fieldNames = {"Sender"};
         ODataValueContextOfIListOfEntry entries = client
                 .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setFields(fieldNames)
                         .setPrefer("maxpagesize=5"));
@@ -481,7 +481,7 @@ class EntriesApiTest extends BaseTest {
         String[] fieldNames = {"Sender", "Subject"};
         ODataValueContextOfIListOfEntry entries = client
                 .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(1)
                         .setFields(fieldNames)
                         .setPrefer("maxpagesize=5"));
@@ -502,7 +502,7 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getDocumentContentType_Returns_Valid_Error_Message_ForInvalidRepoId() {
-        String invalidRepoId = String.format("%s-%s", repoId, repoId);
+        String invalidRepoId = String.format("%s-%s", repositoryId, repositoryId);
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
                 .getDocumentContentType(new ParametersForGetDocumentContentType()
                         .setRepoId(invalidRepoId)
@@ -520,7 +520,7 @@ class EntriesApiTest extends BaseTest {
         request.setTemplateName("fake_template");
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> client
                 .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(3)
                         .setRequestBody(request)));
         assertNotNull(apiException);

--- a/src/test/java/integration/ExportDocumentApiTest.java
+++ b/src/test/java/integration/ExportDocumentApiTest.java
@@ -35,7 +35,7 @@ public class ExportDocumentApiTest extends BaseTest {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             client
                     .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setEntryId(createdEntryId)
                             .setRequestBody(body));
         }
@@ -63,7 +63,7 @@ public class ExportDocumentApiTest extends BaseTest {
         };
 
         client.exportDocument(new ParametersForExportDocument()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setEntryId(createdEntryId)
                 .setInputStreamConsumer(consumer));
         File exportedFile = new File(FILE_NAME);
@@ -81,7 +81,7 @@ public class ExportDocumentApiTest extends BaseTest {
         };
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocument(new ParametersForExportDocument()
-                    .setRepoId(repoId)
+                    .setRepoId(repositoryId)
                     .setEntryId(-createdEntryId)
                     .setInputStreamConsumer(consumer));
         });
@@ -98,7 +98,7 @@ public class ExportDocumentApiTest extends BaseTest {
             File toUpload = File.createTempFile(fileName, "txt");
             CreateEntryResult result = client
                     .importDocument(new ParametersForImportDocument()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setParentEntryId(1)
                             .setFileName(fileName)
                             .setAutoRename(true)

--- a/src/test/java/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/integration/FieldDefinitionsApiTest.java
@@ -25,7 +25,7 @@ class FieldDefinitionsApiTest extends BaseTest {
     void getFieldDefinitionById_ReturnField() {
         WFieldInfo fieldInfo = client
                 .getFieldDefinitionById(new ParametersForGetFieldDefinitionById()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setFieldDefinitionId(1));
 
         assertNotNull(fieldInfo);
@@ -34,7 +34,7 @@ class FieldDefinitionsApiTest extends BaseTest {
     @Test
     void getFieldDefinitions_ReturnAllFields() {
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
-                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId));
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repositoryId));
 
         assertNotNull(fieldInfoList);
     }
@@ -44,7 +44,7 @@ class FieldDefinitionsApiTest extends BaseTest {
         int maxPageSize = 10;
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
                 .getFieldDefinitions(new ParametersForGetFieldDefinitions()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
         assertNotNull(fieldInfoList);
 
@@ -84,6 +84,6 @@ class FieldDefinitionsApiTest extends BaseTest {
             }
         };
         client.getFieldDefinitionsForEach(callback, maxPageSize,
-                new ParametersForGetFieldDefinitions().setRepoId(repoId));
+                new ParametersForGetFieldDefinitions().setRepoId(repositoryId));
     }
 }

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -35,7 +35,7 @@ public class ImportDocumentApiTest extends BaseTest {
         if (createdEntryId != 0) {
             DeleteEntryWithAuditReason body = new DeleteEntryWithAuditReason();
             client.deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                    .setRepoId(repoId)
+                    .setRepoId(repositoryId)
                     .setEntryId(createdEntryId)
                     .setRequestBody(body));
         }
@@ -55,7 +55,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         CreateEntryResult result = client
                 .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setParentEntryId(1)
                         .setFileName(fileName)
                         .setAutoRename(true)
@@ -86,7 +86,7 @@ public class ImportDocumentApiTest extends BaseTest {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionResult.getValue();
         assertNotNull(templateDefinitions);
         Assertions.assertTrue(templateDefinitions.size() > 0);
@@ -94,7 +94,7 @@ public class ImportDocumentApiTest extends BaseTest {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionFieldsResult = repositoryApiClient
                     .getTemplateDefinitionClient()
                     .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionFieldsResult.getValue() != null && allFalse(
                     templateDefinitionFieldsResult.getValue())) {
@@ -118,7 +118,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         CreateEntryResult result = client
                 .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setParentEntryId(parentEntryId)
                         .setFileName(fileName)
                         .setAutoRename(true)
@@ -160,7 +160,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         result = client
                 .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setParentEntryId(1)
                         .setFileName(fileName)
                         .setAutoRename(true)
@@ -196,7 +196,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         result = client
                 .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setParentEntryId(1)
                         .setFileName(fileName)
                         .setAutoRename(true)
@@ -234,7 +234,7 @@ public class ImportDocumentApiTest extends BaseTest {
         request.setTemplate("invalidTemplateName");
         result = client
                 .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setParentEntryId(1)
                         .setFileName(fileName)
                         .setAutoRename(true)

--- a/src/test/java/integration/LinkDefinitionsApiTest.java
+++ b/src/test/java/integration/LinkDefinitionsApiTest.java
@@ -22,7 +22,7 @@ public class LinkDefinitionsApiTest extends BaseTest {
     @Test
     void getLinkDefinitions_ReturnAllLinks() {
         ODataValueContextOfIListOfEntryLinkTypeInfo linkDefinitionsResponse = client.getLinkDefinitions(
-                new ParametersForGetLinkDefinitions().setRepoId(repoId));
+                new ParametersForGetLinkDefinitions().setRepoId(repositoryId));
 
         assertNotNull(linkDefinitionsResponse.getValue());
     }
@@ -30,7 +30,7 @@ public class LinkDefinitionsApiTest extends BaseTest {
     @Test
     void getLinkDefinitionsById_ReturnLinkDefinition() {
         ODataValueContextOfIListOfEntryLinkTypeInfo allLinkDefinitionsResult = client.getLinkDefinitions(
-                new ParametersForGetLinkDefinitions().setRepoId(repoId));
+                new ParametersForGetLinkDefinitions().setRepoId(repositoryId));
         EntryLinkTypeInfo firstLinkDefinition = allLinkDefinitionsResult
                 .getValue()
                 .get(0);
@@ -38,7 +38,7 @@ public class LinkDefinitionsApiTest extends BaseTest {
 
         EntryLinkTypeInfo linkDefinitions = client.getLinkDefinitionById(
                 new ParametersForGetLinkDefinitionById()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setLinkTypeId(firstLinkDefinition.getLinkTypeId()));
 
         assertNotNull(linkDefinitions);

--- a/src/test/java/integration/SearchApiTest.java
+++ b/src/test/java/integration/SearchApiTest.java
@@ -25,7 +25,7 @@ public class SearchApiTest extends BaseTest {
     void cancelCloseSearch() {
         if (searchToken != null) {
             client.cancelOrCloseSearch(new ParametersForCancelOrCloseSearch()
-                    .setRepoId(repoId)
+                    .setRepoId(repositoryId)
                     .setSearchToken(searchToken));
         }
     }
@@ -38,7 +38,7 @@ public class SearchApiTest extends BaseTest {
 
         AcceptedOperation searchResponse = client
                 .createSearchOperation(new ParametersForCreateSearchOperation()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -47,7 +47,7 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(5);
 
         ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(new ParametersForGetSearchResults()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setSearchToken(searchToken));
 
         assertNotNull(searchResults);
@@ -62,7 +62,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
                 .getSearchContextHits(new ParametersForGetSearchContextHits()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setRowNumber(rowNum));
 
@@ -75,7 +75,7 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
@@ -86,7 +86,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
                 new ParametersForGetSearchResults()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken));
         assertNotNull(searchResultResponse);
     }
@@ -97,7 +97,7 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -106,7 +106,7 @@ public class SearchApiTest extends BaseTest {
         TimeUnit.SECONDS.sleep(5);
 
         OperationProgress searchStatusResponse = client.getSearchStatus(new ParametersForGetSearchStatus()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setSearchToken(searchToken));
 
         assertNotNull(searchStatusResponse);
@@ -119,7 +119,7 @@ public class SearchApiTest extends BaseTest {
 
         AcceptedOperation searchOperationResponse = client
                 .createSearchOperation(new ParametersForCreateSearchOperation()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
@@ -128,7 +128,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueOfBoolean closeSearchResponse = client
                 .cancelOrCloseSearch(new ParametersForCancelOrCloseSearch()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken));
 
         assertTrue(closeSearchResponse.isValue());
@@ -143,7 +143,7 @@ public class SearchApiTest extends BaseTest {
         request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setRequestBody(request));
 
         searchToken = searchResponse.getToken();
@@ -155,7 +155,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
                 new ParametersForGetSearchResults()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -189,7 +189,7 @@ public class SearchApiTest extends BaseTest {
 
         AcceptedOperation searchOperationResponse = client.createSearchOperation(
                 new ParametersForCreateSearchOperation()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setRequestBody(request));
 
         searchToken = searchOperationResponse.getToken();
@@ -213,7 +213,7 @@ public class SearchApiTest extends BaseTest {
             }
         };
         client.getSearchResultsForEach(callback, maxPageSize, new ParametersForGetSearchResults()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setSearchToken(searchToken));
     }
 
@@ -225,7 +225,7 @@ public class SearchApiTest extends BaseTest {
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -235,7 +235,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(
                 new ParametersForGetSearchResults()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -251,7 +251,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
                 .getSearchContextHits(new ParametersForGetSearchContextHits()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setRowNumber(rowNum));
 
@@ -282,7 +282,7 @@ public class SearchApiTest extends BaseTest {
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
 
@@ -292,7 +292,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfEntry searchResultResponse = client.getSearchResults(
                 new ParametersForGetSearchResults()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -308,7 +308,7 @@ public class SearchApiTest extends BaseTest {
 
         ODataValueContextOfIListOfContextHit contextHitResponse = client
                 .getSearchContextHits(new ParametersForGetSearchContextHits()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setRowNumber(rowNum));
 
@@ -329,7 +329,7 @@ public class SearchApiTest extends BaseTest {
         };
         client.getSearchContextHitsForEach(callback, maxPageSize,
                 new ParametersForGetSearchContextHits()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
                         .setRowNumber(1));
     }

--- a/src/test/java/integration/SetEntriesApiTest.java
+++ b/src/test/java/integration/SetEntriesApiTest.java
@@ -30,7 +30,7 @@ public class SetEntriesApiTest extends BaseTest {
             repositoryApiClient
                     .getEntriesClient()
                     .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setEntryId(num)
                             .setRequestBody(body));
         }
@@ -41,7 +41,7 @@ public class SetEntriesApiTest extends BaseTest {
     void setTags_ReturnTags() {
         ODataValueContextOfIListOfWTagInfo tagDefinitionsResponse = repositoryApiClient
                 .getTagDefinitionsClient()
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repositoryId));
         List<WTagInfo> tagDefinitions = tagDefinitionsResponse.getValue();
 
         assertNotNull(tagDefinitions);
@@ -61,7 +61,7 @@ public class SetEntriesApiTest extends BaseTest {
         ODataValueOfIListOfWTagInfo assignTagsResponse = repositoryApiClient
                 .getEntriesClient()
                 .assignTags(new ParametersForAssignTags()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(num)
                         .setRequestBody(request));
         List<WTagInfo> tags = assignTagsResponse.getValue();
@@ -77,7 +77,7 @@ public class SetEntriesApiTest extends BaseTest {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = repositoryApiClient
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -87,7 +87,7 @@ public class SetEntriesApiTest extends BaseTest {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = repositoryApiClient
                     .getTemplateDefinitionClient()
                     .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(templateDefinitionsFieldsResponse.getValue())) {
@@ -105,7 +105,7 @@ public class SetEntriesApiTest extends BaseTest {
         Entry setTemplateResponse = repositoryApiClient
                 .getEntriesClient()
                 .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(entry
                                 .getId())
                         .setRequestBody(request));
@@ -123,7 +123,7 @@ public class SetEntriesApiTest extends BaseTest {
         // Find a field definition that accepts String and has constraint.
         ODataValueContextOfIListOfWFieldInfo fieldDefinitionsResponse = repositoryApiClient
                 .getFieldDefinitionsClient()
-                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repoId));
+                .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repositoryId));
         List<WFieldInfo> fieldDefinitions = fieldDefinitionsResponse.getValue();
         for (WFieldInfo fieldDefinition : fieldDefinitions) {
             if (fieldDefinition
@@ -161,7 +161,7 @@ public class SetEntriesApiTest extends BaseTest {
         ODataValueOfIListOfFieldValue assignFieldValuesResponse = repositoryApiClient
                 .getEntriesClient()
                 .assignFieldValues(new ParametersForAssignFieldValues()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(entryId)
                         .setRequestBody(requestBody));
         List<FieldValue> fields = assignFieldValuesResponse
@@ -180,7 +180,7 @@ public class SetEntriesApiTest extends BaseTest {
 
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionsResponse = client
                 .getTemplateDefinitionClient()
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         List<WTemplateInfo> templateDefinitions = templateDefinitionsResponse.getValue();
 
         assertNotNull(templateDefinitions);
@@ -190,7 +190,7 @@ public class SetEntriesApiTest extends BaseTest {
             ODataValueContextOfIListOfTemplateFieldInfo templateDefinitionsFieldsResponse = client
                     .getTemplateDefinitionClient()
                     .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
-                            .setRepoId(repoId)
+                            .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
                     .getValue() != null && allFalse(
@@ -210,7 +210,7 @@ public class SetEntriesApiTest extends BaseTest {
         Entry writeTemplateValueToEntryResponse = client
                 .getEntriesClient()
                 .writeTemplateValueToEntry(new ParametersForWriteTemplateValueToEntry()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(entry
                                 .getId())
                         .setRequestBody(request));

--- a/src/test/java/integration/SetLinksApiTest.java
+++ b/src/test/java/integration/SetLinksApiTest.java
@@ -36,7 +36,7 @@ public class SetLinksApiTest extends BaseTest {
                 client
                         .getEntriesClient()
                         .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setEntryId(createdEntry.getId())
                                 .setRequestBody(body));
             }
@@ -58,7 +58,7 @@ public class SetLinksApiTest extends BaseTest {
         ODataValueOfIListOfWEntryLinkInfo result = client
                 .getEntriesClient()
                 .assignEntryLinks(new ParametersForAssignEntryLinks()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(sourceEntry
                                 .getId())
                         .setRequestBody(request));

--- a/src/test/java/integration/SimpleSearchesApiTest.java
+++ b/src/test/java/integration/SimpleSearchesApiTest.java
@@ -18,7 +18,7 @@ class SimpleSearchesApiTest extends BaseTest {
 
         ODataValueOfIListOfEntry entryList = client
                 .createSimpleSearchOperation(new ParametersForCreateSimpleSearchOperation()
-                        .setRepoId(repoId).
+                        .setRepoId(repositoryId).
                         setRequestBody(searchRequest));
 
         assertNotNull(entryList);

--- a/src/test/java/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/integration/TagDefinitionsApiTest.java
@@ -24,7 +24,7 @@ class TagDefinitionsApiTest extends BaseTest {
     @Test
     void getTagDefinitions_ReturnAllTags() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repositoryId));
 
         assertNotNull(tagInfoList);
     }
@@ -34,7 +34,7 @@ class TagDefinitionsApiTest extends BaseTest {
         int maxPageSize = 1;
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
                 .getTagDefinitions(new ParametersForGetTagDefinitions()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(tagInfoList);
@@ -59,7 +59,7 @@ class TagDefinitionsApiTest extends BaseTest {
     @Test
     void getTagDefinitions_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repositoryId));
 
         assertNotNull(tagInfoList);
 
@@ -79,19 +79,20 @@ class TagDefinitionsApiTest extends BaseTest {
                 return false;
             }
         };
-        client.getTagDefinitionsForEach(callback, maxPageSize, new ParametersForGetTagDefinitions().setRepoId(repoId));
+        client.getTagDefinitionsForEach(callback, maxPageSize, new ParametersForGetTagDefinitions().setRepoId(
+                repositoryId));
     }
 
     @Test
     void getTagDefinitionById_ReturnTag() {
         ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repoId));
+                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repositoryId));
 
         assertNotNull(tagInfoList);
 
         WTagInfo tagInfo = client
                 .getTagDefinitionById(new ParametersForGetTagDefinitionById()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setTagId(tagInfoList
                                 .getValue()
                                 .get(0)

--- a/src/test/java/integration/TasksApiTest.java
+++ b/src/test/java/integration/TasksApiTest.java
@@ -36,7 +36,7 @@ public class TasksApiTest extends BaseTest {
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
                 .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(deleteEntry.getId())
                         .setRequestBody(body));
 
@@ -48,7 +48,7 @@ public class TasksApiTest extends BaseTest {
 
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.cancelOperation(new ParametersForCancelOperation()
-                    .setRepoId(repoId)
+                    .setRepoId(repositoryId)
                     .setOperationToken(token));
         });
 
@@ -67,7 +67,7 @@ public class TasksApiTest extends BaseTest {
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
                 .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(deleteEntry.getId())
                         .setRequestBody(body));
 
@@ -75,7 +75,7 @@ public class TasksApiTest extends BaseTest {
         assertNotNull(token);
 
         boolean cancellationResult = client.cancelOperation(new ParametersForCancelOperation()
-                .setRepoId(repoId)
+                .setRepoId(repositoryId)
                 .setOperationToken(token));
         assertTrue(cancellationResult);
     }
@@ -90,7 +90,7 @@ public class TasksApiTest extends BaseTest {
         AcceptedOperation result = repositoryApiClient
                 .getEntriesClient()
                 .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setEntryId(deleteEntry.getId())
                         .setRequestBody(body));
 
@@ -102,7 +102,7 @@ public class TasksApiTest extends BaseTest {
 
         OperationProgress operationProgressResponse = client.getOperationStatusAndProgress(
                 new ParametersForGetOperationStatusAndProgress()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setOperationToken(token));
 
         assertNotNull(operationProgressResponse);

--- a/src/test/java/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/integration/TemplateDefinitionsApiTest.java
@@ -30,7 +30,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitions_ReturnAllTemplates() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         assertNotNull(templateInfoList);
     }
@@ -38,7 +38,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsFields_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -49,7 +49,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
                         new ParametersForGetTemplateFieldDefinitions()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -64,7 +64,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(
                         new ParametersForGetTemplateDefinitions()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(templateInfoList);
@@ -88,7 +88,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitions_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         assertNotNull(templateInfoList);
 
@@ -109,7 +109,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
             }
         };
         client.getTemplateDefinitionsForEach(callback, maxPageSize,
-                new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
     }
 
     @Test
@@ -118,7 +118,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(
                         new ParametersForGetTemplateDefinitions()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         WTemplateInfo tempDef = templateInfoList
@@ -130,7 +130,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
                         new ParametersForGetTemplateFieldDefinitions()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setTemplateId(tempDef.getId())
                                 .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
@@ -158,7 +158,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsFields_ForEach() throws InterruptedException {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -169,7 +169,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
                         new ParametersForGetTemplateFieldDefinitions()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -195,14 +195,14 @@ class TemplateDefinitionsApiTest extends BaseTest {
         };
         client.getTemplateFieldDefinitionsForEach(callback, maxPageSize,
                 new ParametersForGetTemplateFieldDefinitions()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setTemplateId(tempDef.getId()));
     }
 
     @Test
     void getTemplateDefinitionsFieldsById_ReturnTemplate() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -212,7 +212,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         WTemplateInfo result = client
                 .getTemplateDefinitionById(new ParametersForGetTemplateDefinitionById()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setTemplateId(tempDef.getId()));
 
         assertNotNull(result);
@@ -222,7 +222,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsByTemplateName_TemplateNameQueryParameter_ReturnSingleTemplate() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
@@ -232,7 +232,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         ODataValueContextOfIListOfWTemplateInfo result = client
                 .getTemplateDefinitions(new ParametersForGetTemplateDefinitions()
-                        .setRepoId(repoId)
+                        .setRepoId(repositoryId)
                         .setTemplateName(tempDef.getName()));
 
         assertNotNull(result);
@@ -241,7 +241,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     @Test
     void getTemplateDefinitionsByTemplateName_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo allTemplateDefinitionsFuture = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repoId));
+                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         WTemplateInfo firstTemplateDefinitions = allTemplateDefinitionsFuture
                 .getValue()
                 .get(0);
@@ -250,7 +250,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitionsByTemplateName(
                         new ParametersForGetTemplateFieldDefinitionsByTemplateName()
-                                .setRepoId(repoId)
+                                .setRepoId(repositoryId)
                                 .setTemplateName(firstTemplateDefinitions.getName()));
         List<TemplateFieldInfo> templateFieldDefinitions = result.getValue();
         assertNotNull(templateFieldDefinitions);


### PR DESCRIPTION
- added a helper `getEnvironmentVariable` function in the basetest file
- removed abbreviated variable names
- refactored basetest implementation to be the same as the sample project implementation
- did not update the changelog since this is only involving the integration tests
- added the `IS_NOT_GITHUB_ENVIRONMENT` variable so the integration tests can also run on github when pipeline is enabled