### PR TITLE
Return CreateEntryResult for import doc api with an invalid parent ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.2.1
+
+### Fixes
+
+- Return type of `CreateEntryResult` response for import document api with a parent ID that is not found
+
 ## 1.2.0
 
 ### Features

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>1.2.0</version>
+  <version>1.2.1</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -204,7 +204,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         if (response.getOperations() == null) {
                             throw new IllegalStateException();
                         }
-                        return objectMapper.readValue(jsonString, CreateEntryResult.class);
+                        return response;
                     } catch (JsonProcessingException | IllegalStateException e) {
                         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
                         ProblemDetails problemDetails;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -200,10 +200,8 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                     Object body = httpResponse.getBody();
                     String jsonString = new JSONObject(body).toString();
                     try {
-                        //String jsonString = new JSONObject(body).toString();
-                        //ProblemDetails problemDetails = deserializeToProblemDetails(jsonString);
                         CreateEntryResult response = objectMapper.readValue(jsonString, CreateEntryResult.class);
-                        if (response.getOperations() == null){
+                        if (response.getOperations() == null) {
                             throw new IllegalStateException();
                         }
                         return objectMapper.readValue(jsonString, CreateEntryResult.class);
@@ -243,51 +241,6 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                         else
                             throw new RuntimeException(httpResponse.getStatusText());
                     }
-//                    if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
-//                        try {
-//                            String jsonString = new JSONObject(body).toString();
-//                            return objectMapper.readValue(jsonString, CreateEntryResult.class);
-//                        } catch (JsonProcessingException | IllegalStateException e) {
-//                            e.printStackTrace();
-//                            return null;
-//                        }
-//                    } else {
-//                        ProblemDetails problemDetails;
-//                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
-//                        try {
-//                            String jsonString = new JSONObject(body).toString();
-//                            problemDetails = deserializeToProblemDetails(jsonString);
-//                        } catch (JsonProcessingException | IllegalStateException e) {
-//                            Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-//                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-//                                    (parsingException.isPresent() ? parsingException
-//                                            .get()
-//                                            .getOriginalBody() : null), headersMap, null);
-//                        }
-//                        if (httpResponse.getStatus() == 400)
-//                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else if (httpResponse.getStatus() == 401)
-//                            throw new ApiException(
-//                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else if (httpResponse.getStatus() == 403)
-//                            throw new ApiException(
-//                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else if (httpResponse.getStatus() == 404)
-//                            throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else if (httpResponse.getStatus() == 429)
-//                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else if (httpResponse.getStatus() == 500)
-//                            throw new ApiException(
-//                                    decideErrorMessage(problemDetails, "Document creation is complete failure."),
-//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-//                        else
-//                            throw new RuntimeException(httpResponse.getStatusText());
-//                    }
                 });
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -198,51 +198,64 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .asObjectAsync(Object.class)
                 .thenApply(httpResponse -> {
                     Object body = httpResponse.getBody();
-                    if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
+                    String jsonString = new JSONObject(body).toString();
+                    try {
+                        //String jsonString = new JSONObject(body).toString();
+                        ProblemDetails problemDetails = deserializeToProblemDetails(jsonString);
+                        return objectMapper.readValue(jsonString, CreateEntryResult.class);
+                    } catch (JsonProcessingException | IllegalStateException e) {
                         try {
-                            String jsonString = new JSONObject(body).toString();
-                            return objectMapper.readValue(jsonString, CreateEntryResult.class);
-                        } catch (JsonProcessingException | IllegalStateException e) {
-                            e.printStackTrace();
-                            return null;
+                            ProblemDetails problemDetails = deserializeToProblemDetails(jsonString);
+                        } catch (JsonProcessingException ex) {
+                            throw new RuntimeException(ex);
                         }
-                    } else {
-                        ProblemDetails problemDetails;
-                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
-                        try {
-                            String jsonString = new JSONObject(body).toString();
-                            problemDetails = deserializeToProblemDetails(jsonString);
-                        } catch (JsonProcessingException | IllegalStateException e) {
-                            Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                                    (parsingException.isPresent() ? parsingException
-                                            .get()
-                                            .getOriginalBody() : null), headersMap, null);
-                        }
-                        if (httpResponse.getStatus() == 400)
-                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 401)
-                            throw new ApiException(
-                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 403)
-                            throw new ApiException(
-                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 404)
-                            throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 429)
-                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else if (httpResponse.getStatus() == 500)
-                            throw new ApiException(
-                                    decideErrorMessage(problemDetails, "Document creation is complete failure."),
-                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-                        else
-                            throw new RuntimeException(httpResponse.getStatusText());
+                        throw new RuntimeException(e);
                     }
+//                    if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
+//                        try {
+//                            String jsonString = new JSONObject(body).toString();
+//                            return objectMapper.readValue(jsonString, CreateEntryResult.class);
+//                        } catch (JsonProcessingException | IllegalStateException e) {
+//                            e.printStackTrace();
+//                            return null;
+//                        }
+//                    } else {
+//                        ProblemDetails problemDetails;
+//                        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
+//                        try {
+//                            String jsonString = new JSONObject(body).toString();
+//                            problemDetails = deserializeToProblemDetails(jsonString);
+//                        } catch (JsonProcessingException | IllegalStateException e) {
+//                            Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
+//                            throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
+//                                    (parsingException.isPresent() ? parsingException
+//                                            .get()
+//                                            .getOriginalBody() : null), headersMap, null);
+//                        }
+//                        if (httpResponse.getStatus() == 400)
+//                            throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else if (httpResponse.getStatus() == 401)
+//                            throw new ApiException(
+//                                    decideErrorMessage(problemDetails, "Access token is invalid or expired."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else if (httpResponse.getStatus() == 403)
+//                            throw new ApiException(
+//                                    decideErrorMessage(problemDetails, "Access denied for the operation."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else if (httpResponse.getStatus() == 404)
+//                            throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else if (httpResponse.getStatus() == 429)
+//                            throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else if (httpResponse.getStatus() == 500)
+//                            throw new ApiException(
+//                                    decideErrorMessage(problemDetails, "Document creation is complete failure."),
+//                                    httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+//                        else
+//                            throw new RuntimeException(httpResponse.getStatusText());
+//                    }
                 });
     }
 

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -1,6 +1,7 @@
 package integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;
+import com.laserfiche.repository.api.clients.impl.ApiException;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
@@ -11,6 +12,7 @@ import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.List;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -293,4 +295,22 @@ public class ImportDocumentApiTest extends BaseTest {
         assertEquals(ErrorSource.LASERFICHE_SERVER.getName(), entryCreateException.getErrorSource());
     }
 
+    @Test
+    void importDocument_InvalidRepoID_Exception_Thrown(){
+        String fileName = "myFile";
+        String fileContent = "This is the file content";
+        InputStream inputStream = new ByteArrayInputStream(fileContent.getBytes());
+        assertNotNull(inputStream);
+
+        PostEntryWithEdocMetadataRequest request = new PostEntryWithEdocMetadataRequest();
+        request.setTemplate("invalidTemplateName");
+        CompletionException exception = assertThrows(CompletionException.class, () -> client
+                .importDocument("test", 1, fileName, true, null,
+                        inputStream, request)
+                .join());
+        ProblemDetails problemDetailsException = ((ApiException)exception.getCause()).getProblemDetails();
+        assertTrue(exception.getMessage().contains("ApiException"));
+        assertEquals(HttpURLConnection.HTTP_NOT_FOUND, problemDetailsException.getStatus());
+        assertTrue(problemDetailsException.getTitle().contains("Repository with the given Id not found or no connection could be made."));
+    }
 }


### PR DESCRIPTION
- Return `CreateEntryResult` type of response for an import document request with an invalid parent ID
- Added 2 additional integration tests
- Updated changelog
- Updated pom.xml file
- Ensured that the other import doc test cases were still running