### PR TITLE
Update api error handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: 1.0.0
+  VERSION_PREFIX: 2.0.0
 
 jobs:
   build-n-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@
 - **[BREAKING]** Every async API are replaced with normal blocking API.
 - The ApiClient class is now abstract.
 - Improved documentation.
+- Only throw the `ApiException` type when error API responses occur.
+- **[BREAKING]** `EntriesClient.importDocument` API v1 can succeed in creating a document, but fail in setting some or all of its metadata components. To retrieve errors in the case of a partial success, inspect the content of the `ProblemDetails.getExtensions()`. See example below.
+  ```java
+  try {
+    repositoryApiClient.getEntriesClient().importDocument(...);
+  } catch (ApiException e) {
+    e.printStackTrace();
+    if (e.getProblemDetails() != null && e.getProblemDetails().getExtensions() != null) {
+      Object obj = e.getProblemDetails().getExtensions().getOrDefault(CreateEntryResult.class.getSimpleName(), null);
+      CreateEntryResult result = obj instanceof CreateEntryResult ? (CreateEntryResult) obj : null;
+      if (result != null && result.getOperations() != null && result.getOperations().getEntryCreate() != null) {
+        Integer createdEntryId = result.getOperations().getEntryCreate().getEntryId();
+      }
+    }
+  }
+  ```
 
 ## 1.2.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -258,7 +258,7 @@
     <dependency>
       <groupId>com.laserfiche</groupId>
       <artifactId>lf-api-client-core</artifactId>
-      <version>2.1.0</version>
+      <version>1.0.0-preview-4046010584-SNAPSHOT</version>
     </dependency>
 
     

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -1,6 +1,5 @@
 package com.laserfiche.repository.api.clients.impl;
 
-import com.laserfiche.api.client.model.ProblemDetails;
 import kong.unirest.Header;
 import kong.unirest.Headers;
 import kong.unirest.ObjectMapper;
@@ -94,37 +93,5 @@ public abstract class ApiClient {
                 .all()
                 .stream()
                 .collect(Collectors.toMap(Header::getName, Header::getValue));
-    }
-
-    protected ProblemDetails deserializeToProblemDetails(String jsonString) {
-        ProblemDetails problemDetails = objectMapper.readValue(jsonString, ProblemDetails.class);
-        if (problemDetails.get("title") != null)
-            problemDetails.setTitle(problemDetails
-                    .get("title")
-                    .toString());
-        if (problemDetails.get("type") != null)
-            problemDetails.setType(problemDetails
-                    .get("type")
-                    .toString());
-        if (problemDetails.get("instance") != null)
-            problemDetails.setInstance(problemDetails
-                    .get("instance")
-                    .toString());
-        if (problemDetails.get("detail") != null)
-            problemDetails.setDetail(problemDetails
-                    .get("detail")
-                    .toString());
-        problemDetails.setStatus(Integer.parseInt(problemDetails
-                .get("status")
-                .toString()));
-        problemDetails.setExtensions((Map<String, Object>) problemDetails.get("extensions"));
-        return problemDetails;
-    }
-
-    protected String decideErrorMessage(ProblemDetails problemDetails, String genericErrorMessage) {
-        return (problemDetails != null && problemDetails.getTitle() != null && problemDetails
-                .getTitle()
-                .trim()
-                .length() > 0) ? problemDetails.getTitle() : genericErrorMessage;
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -27,10 +27,15 @@ class ApiClientUtils {
         Collection<String> messages = new ArrayList<>();
         if (createEntryResult != null && createEntryResult.getOperations() != null) {
             CreateEntryOperations operations = createEntryResult.getOperations();
-            if (operations.getEntryCreate() != null)
+            if (operations.getEntryCreate() != null) {
+                Integer entryId = operations.getEntryCreate().getEntryId();
+                if (entryId != null && entryId > 0) {
+                    messages.add(String.format("EntryId=%s.", entryId));
+                }
                 messages.add(getErrorMessagesFromAPIServerExceptions(operations
                         .getEntryCreate()
                         .getExceptions()));
+            }
             if (operations.getSetEdoc() != null)
                 messages.add(getErrorMessagesFromAPIServerExceptions(operations
                         .getSetEdoc()

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -10,9 +10,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
- * Helper class containing utility functions for the RepositoryApiClient.
+ * Internal helper class containing utility functions for the RepositoryApiClient.
  */
-class ApiClientUtils {
+public class ApiClientUtils {
     private ApiClientUtils() {
         throw new IllegalStateException("Utility class with all static methods are not meant to be instantiated.");
     }
@@ -23,7 +23,7 @@ class ApiClientUtils {
      * @param createEntryResult The createEntryResult.
      * @return A human-readable summary of the {@link CreateEntryResult}.
      */
-    static String getCreateEntryResultSummary(CreateEntryResult createEntryResult) {
+    public static String getCreateEntryResultSummary(CreateEntryResult createEntryResult) {
         Collection<String> messages = new ArrayList<>();
         if (createEntryResult != null && createEntryResult.getOperations() != null) {
             CreateEntryOperations operations = createEntryResult.getOperations();

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -1,0 +1,72 @@
+package com.laserfiche.repository.api.clients.impl;
+
+import com.laserfiche.repository.api.clients.impl.model.APIServerException;
+import com.laserfiche.repository.api.clients.impl.model.CreateEntryOperations;
+import com.laserfiche.repository.api.clients.impl.model.CreateEntryResult;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Helper class containing utility functions for the RepositoryApiClient.
+ */
+class ApiClientUtils {
+    private ApiClientUtils() {
+        throw new IllegalStateException("Utility class with all static methods are not meant to be instantiated.");
+    }
+
+    /**
+     * Returns a human-readable summary of the {@link CreateEntryResult}.
+     *
+     * @param createEntryResult The createEntryResult.
+     * @return A human-readable summary of the {@link CreateEntryResult}.
+     */
+    static String getCreateEntryResultSummary(CreateEntryResult createEntryResult) {
+        Collection<String> messages = new ArrayList<>();
+        if (createEntryResult != null && createEntryResult.getOperations() != null) {
+            CreateEntryOperations operations = createEntryResult.getOperations();
+            if (operations.getEntryCreate() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getEntryCreate()
+                        .getExceptions()));
+            if (operations.getSetEdoc() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getSetEdoc()
+                        .getExceptions()));
+            if (operations.getSetTemplate() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getSetTemplate()
+                        .getExceptions()));
+            if (operations.getSetFields() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getSetFields()
+                        .getExceptions()));
+            if (operations.getSetTags() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getSetTags()
+                        .getExceptions()));
+            if (operations.getSetLinks() != null)
+                messages.add(getErrorMessagesFromAPIServerExceptions(operations
+                        .getSetLinks()
+                        .getExceptions()));
+        }
+        return messages
+                .stream()
+                .filter(Objects::nonNull)
+                .collect(Collectors.joining(" "))
+                .trim();
+    }
+
+    private static String getErrorMessagesFromAPIServerExceptions(Collection<APIServerException> errors) {
+        if (errors == null || errors.isEmpty())
+            return null;
+        return errors
+                .stream()
+                .filter(Objects::nonNull)
+                .map(APIServerException::getMessage)
+                .collect(Collectors.joining(" "))
+                .trim();
+    }
+}

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.AttributesClient;
@@ -9,11 +10,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttri
 import com.laserfiche.repository.api.clients.params.ParametersForGetTrusteeAttributeValueByKey;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -39,44 +38,34 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Attribute.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested attribute key not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -107,44 +96,34 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfListOfAttribute.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.AuditReasonsClient;
@@ -7,11 +8,9 @@ import com.laserfiche.repository.api.clients.impl.model.AuditReasons;
 import com.laserfiche.repository.api.clients.params.ParametersForGetAuditReasons;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The Laserfiche Repository AuditReasons API client.
@@ -31,44 +30,34 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, AuditReasons.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.EntriesClient;
@@ -8,7 +9,6 @@ import com.laserfiche.repository.api.clients.params.*;
 import kong.unirest.Header;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.*;
@@ -49,44 +49,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfFieldValue.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -121,47 +111,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfIListOfFieldValue.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -181,47 +160,43 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
-        if (httpResponse.getStatus() == 201 || httpResponse.getStatus() == 409) {
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
+        if (httpResponse.getStatus() == 201) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, CreateEntryResult.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
-            try {
-                String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+            if (httpResponse.getStatus() == 400 || httpResponse.getStatus() == 404 || httpResponse.getStatus() == 409 || httpResponse.getStatus() == 500) {
+                try {
+                    String jsonString = new JSONObject(body).toString();
+                    problemDetails = ProblemDetails.create(httpResponse.getStatus(), headersMap);
+                    CreateEntryResult result = objectMapper.readValue(jsonString, CreateEntryResult.class);
+                    if (result != null && result.getOperations() != null) {
+                        problemDetails
+                                .getExtensions()
+                                .put(CreateEntryResult.class.getSimpleName(), result);
+                        String summary = ApiClientUtils.getCreateEntryResultSummary(result);
+                        if (summary != null && !summary
+                                .trim()
+                                .isEmpty())
+                            problemDetails.setTitle(summary);
+                    }
+                } catch (Exception e) {
+                    throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
+                }
+            } else {
+                try {
+                    String jsonString = new JSONObject(body).toString();
+                    problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+                } catch (Exception e) {
+                    throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
+                }
             }
-            if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Parent entry is not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 500)
-                throw new ApiException(decideErrorMessage(problemDetails, "Document creation is complete failure."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else
-                throw new RuntimeException(httpResponse.getStatusText());
+            throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -252,44 +227,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWEntryLinkInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -321,47 +286,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfIListOfWEntryLinkInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -379,47 +333,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Entry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -432,47 +375,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Entry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -487,44 +419,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject((new HashMap<String, String[]>()).getClass());
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, new HashMap<String, String[]>().getClass());
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -541,44 +463,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, FindEntryResult.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry path not found"),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -597,44 +509,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 201) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, AcceptedOperation.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -650,44 +552,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Entry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -706,50 +598,38 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Entry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -764,44 +644,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 201) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, AcceptedOperation.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -833,40 +703,28 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
                             try {
                                 String jsonString = rawResponse.getContentAsString();
-                                problemDetails = deserializeToProblemDetails(jsonString);
-                            } catch (IllegalStateException e) {
-                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
-                                        rawResponse.getContentAsString(), headersMap, null);
+                                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+                            } catch (Exception e) {
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, null, e);
                             }
                             if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Request entry id not found."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else
                                 exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
@@ -903,40 +761,28 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             Map<String, String> headersMap = getHeadersMap(rawResponse.getHeaders());
                             try {
                                 String jsonString = rawResponse.getContentAsString();
-                                problemDetails = deserializeToProblemDetails(jsonString);
-                            } catch (IllegalStateException e) {
-                                exception[0] = new ApiException(rawResponse.getStatusText(), rawResponse.getStatus(),
-                                        rawResponse.getContentAsString(), headersMap, null);
+                                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+                            } catch (Exception e) {
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, null, e);
                             }
                             if (rawResponse.getStatus() == 400)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Invalid or bad request."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 401)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 403)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Access denied for the operation."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 404)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Request entry id not found."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 423)
-                                exception[0] = new ApiException(decideErrorMessage(problemDetails, "Entry is locked."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else if (rawResponse.getStatus() == 429)
-                                exception[0] = new ApiException(
-                                        decideErrorMessage(problemDetails, "Rate limit is reached."),
-                                        rawResponse.getStatus(), rawResponse.getStatusText(), headersMap,
-                                        problemDetails);
+                                exception[0] = ApiException.create(rawResponse.getStatus(), headersMap, problemDetails,
+                                        null);
                             else
                                 exception[0] = new RuntimeException(rawResponse.getStatusText());
                         }
@@ -956,47 +802,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -1009,6 +844,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(new HashMap<String, String>().getClass());
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             return httpResponse
                     .getHeaders()
@@ -1016,38 +852,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                     .stream()
                     .collect(Collectors.toMap(Header::getName, Header::getValue));
         } else {
-            ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
-            try {
-                String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
-            }
-            if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
-            else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
-            else
-                throw new RuntimeException(httpResponse.getStatusText());
+            throw ApiException.create(httpResponse.getStatus(), headersMap, null, null);
         }
     }
 
@@ -1063,47 +868,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -1137,44 +931,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -1210,47 +994,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 201) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, Entry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 409)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry name conflicts."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -1280,44 +1053,34 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request entry id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -1349,47 +1112,36 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfIListOfWTagInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 423)
-                throw new ApiException(decideErrorMessage(problemDetails, "Entry is locked."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.FieldDefinitionsClient;
@@ -9,11 +10,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinit
 import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinitions;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -39,44 +38,34 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, WFieldInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Requested field definition id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -106,44 +95,34 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWFieldInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.LinkDefinitionsClient;
@@ -9,11 +10,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefiniti
 import com.laserfiche.repository.api.clients.params.ParametersForGetLinkDefinitions;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -38,45 +37,34 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, EntryLinkTypeInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(
-                        decideErrorMessage(problemDetails, "Requested link type definition ID not found"),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -106,44 +94,34 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntryLinkTypeInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,18 +1,17 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The Laserfiche Repository Repositories API client.
@@ -29,41 +28,32 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 .get(baseUrl + "/v1/Repositories")
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONArray(((ArrayList) body).toArray()).toString();
                 return objectMapper.readValue(jsonString, RepositoryInfo[].class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.SearchesClient;
@@ -7,10 +8,12 @@ import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.*;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -33,44 +36,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, OperationProgress.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -84,44 +77,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -154,44 +137,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfContextHit.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -223,44 +196,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 201) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, AcceptedOperation.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -293,44 +256,34 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request search token not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.ServerSessionClient;
@@ -10,11 +11,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForInvalidateServe
 import com.laserfiche.repository.api.clients.params.ParametersForRefreshServerSession;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The Laserfiche Repository ServerSession API client.
@@ -34,44 +33,34 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -84,35 +73,28 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfBoolean.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -125,44 +107,34 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueOfDateTime.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.SimpleSearchesClient;
@@ -7,10 +8,12 @@ import com.laserfiche.repository.api.clients.impl.model.ODataValueContextOfIList
 import com.laserfiche.repository.api.clients.params.ParametersForCreateSimpleSearchOperation;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 
 /**
  * The Laserfiche Repository SimpleSearches API client.
@@ -41,44 +44,34 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 .body(parameters.getRequestBody())
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 204 || httpResponse.getStatus() == 206) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfEntry.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Operation limit or request limit reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.TagDefinitionsClient;
@@ -9,11 +10,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitio
 import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitions;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -52,44 +51,34 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTagInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Not found."), httpResponse.getStatus(),
-                        httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -122,44 +111,34 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, WTagInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request tag definition id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.TasksClient;
@@ -8,11 +9,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForCancelOperation
 import com.laserfiche.repository.api.clients.params.ParametersForGetOperationStatusAndProgress;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 
 /**
  * The Laserfiche Repository Tasks API client.
@@ -33,44 +32,34 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200 || httpResponse.getStatus() == 201 || httpResponse.getStatus() == 202) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, OperationProgress.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -84,38 +73,29 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 204) {
             return true;
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request operationToken not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -1,5 +1,6 @@
 package com.laserfiche.repository.api.clients.impl;
 
+import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.TemplateDefinitionsClient;
@@ -12,11 +13,9 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFiel
 import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitionsByTemplateName;
 import kong.unirest.HttpResponse;
 import kong.unirest.UnirestInstance;
-import kong.unirest.UnirestParsingException;
 import kong.unirest.json.JSONObject;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -56,44 +55,34 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfWTemplateInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -142,44 +131,34 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfTemplateFieldInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template name not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -231,44 +210,34 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .headers(headerParametersWithStringTypeValue)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, ODataValueContextOfIListOfTemplateFieldInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 
@@ -303,44 +272,34 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 .routeParam(pathParameters)
                 .asObject(Object.class);
         Object body = httpResponse.getBody();
+        Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
         if (httpResponse.getStatus() == 200) {
             try {
                 String jsonString = new JSONObject(body).toString();
                 return objectMapper.readValue(jsonString, WTemplateInfo.class);
-            } catch (IllegalStateException e) {
-                e.printStackTrace();
-                return null;
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
         } else {
             ProblemDetails problemDetails;
-            Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
             try {
                 String jsonString = new JSONObject(body).toString();
-                problemDetails = deserializeToProblemDetails(jsonString);
-            } catch (IllegalStateException e) {
-                Optional<UnirestParsingException> parsingException = httpResponse.getParsingError();
-                throw new ApiException(httpResponse.getStatusText(), httpResponse.getStatus(),
-                        (parsingException.isPresent() ? parsingException
-                                .get()
-                                .getOriginalBody() : null), headersMap, null);
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
             }
             if (httpResponse.getStatus() == 400)
-                throw new ApiException(decideErrorMessage(problemDetails, "Invalid or bad request."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 401)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access token is invalid or expired."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 403)
-                throw new ApiException(decideErrorMessage(problemDetails, "Access denied for the operation."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 404)
-                throw new ApiException(decideErrorMessage(problemDetails, "Request template id not found."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else if (httpResponse.getStatus() == 429)
-                throw new ApiException(decideErrorMessage(problemDetails, "Rate limit is reached."),
-                        httpResponse.getStatus(), httpResponse.getStatusText(), headersMap, problemDetails);
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
             else
-                throw new RuntimeException(httpResponse.getStatusText());
+                throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
         }
     }
 }

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -22,15 +22,15 @@ enum AuthorizationType {
 }
 
 public class BaseTest {
-    private static String servicePrincipalKey;
-    private static AccessKey accessKey;
+    protected static String servicePrincipalKey;
+    protected static AccessKey accessKey;
     protected static String repositoryId;
     private static Map<String, String> testHeaders;
     protected static RepositoryApiClient repositoryApiClient;
     private static String testHeaderValue;
-    private static String username;
-    private static String password;
-    private static String baseUrl;
+    protected static String username;
+    protected static String password;
+    protected static String baseUrl;
     private static final String TEST_HEADER = "TEST_HEADER";
     private static final String ACCESS_KEY = "ACCESS_KEY";
     private static final String SERVICE_PRINCIPAL_KEY = "SERVICE_PRINCIPAL_KEY";
@@ -39,7 +39,7 @@ public class BaseTest {
     private static final String PASSWORD = "APISERVER_PASSWORD";
     private static final String BASE_URL = "APISERVER_REPOSITORY_API_BASE_URL";
     private static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
-    private static AuthorizationType authorizationType;
+    protected static AuthorizationType authorizationType;
     private static final boolean IS_NOT_GITHUB_ENVIRONMENT = nullOrEmpty(System.getenv("GITHUB_WORKSPACE"));
     @BeforeAll
     public static void setUp() {

--- a/src/test/java/integration/EntriesApiTest.java
+++ b/src/test/java/integration/EntriesApiTest.java
@@ -436,7 +436,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getDocumentContentType_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() {
+    void getEntryListing_ProblemDetails_Fields_Are_Valid_When_Exception_Thrown() {
         ApiException apiException = Assertions.assertThrows(ApiException.class, () -> {
             client
                     .getEntryListing(new ParametersForGetEntryListing()
@@ -510,9 +510,13 @@ class EntriesApiTest extends BaseTest {
                         .setEntryId(1)));
         assertNotNull(apiException);
         assertEquals(404, apiException.getStatusCode());
-        assertEquals("Not Found", apiException.getMessage());
+        assertEquals("Error: Repository with the given Id not found or no connection could be made.", apiException.getMessage());
+        assertTrue(apiException.getHeaders().size() > 0);
         ProblemDetails problemDetails = apiException.getProblemDetails();
-        assertNull(problemDetails);
+        assertNotNull(problemDetails);
+        assertEquals(apiException.getStatusCode(), problemDetails.getStatus());
+        assertEquals(apiException.getMessage(), problemDetails.getTitle());
+        assertNotNull(problemDetails.getOperationId());
     }
 
     @Test

--- a/src/test/java/integration/ImportDocumentApiTest.java
+++ b/src/test/java/integration/ImportDocumentApiTest.java
@@ -278,7 +278,7 @@ public class ImportDocumentApiTest extends BaseTest {
         assertTrue(setTemplateException
                 .getMessage()
                 .startsWith("Template not found."), setTemplateException.getMessage());
-        assertEquals(apiException.getMessage(), setTemplateException.getMessage());
+        assertEquals(apiException.getMessage(), String.format("EntryId=%s. %s", createdEntryId, setTemplateException.getMessage()));
         assertEquals(HttpURLConnection.HTTP_CONFLICT, setTemplateException.getStatusCode());
         assertEquals(ErrorSource.LASERFICHE_SERVER.getName(), setTemplateException.getErrorSource());
     }

--- a/src/test/java/integration/RepositoryApiClientTest.java
+++ b/src/test/java/integration/RepositoryApiClientTest.java
@@ -1,0 +1,43 @@
+package integration;
+
+import com.laserfiche.api.client.model.ApiException;
+import com.laserfiche.repository.api.RepositoryApiClient;
+import com.laserfiche.repository.api.RepositoryApiClientImpl;
+import com.laserfiche.repository.api.clients.params.ParametersForGetEntry;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RepositoryApiClientTest extends BaseTest {
+    @Test
+    void invalidCredentials_ThrowsApiExceptionWhenMakingApiCall() {
+        RepositoryApiClient invalidClient = null;
+        try {
+            if (authorizationType.equals(AuthorizationType.CLOUD_ACCESS_KEY)) {
+                invalidClient = RepositoryApiClientImpl.createFromAccessKey("fake key", accessKey);
+            } else if (authorizationType.equals(AuthorizationType.API_SERVER_USERNAME_PASSWORD)) {
+                invalidClient = RepositoryApiClientImpl.createFromUsernamePassword(repositoryId, username,
+                        "fake password", baseUrl);
+            } else {
+                fail(String.format("Test not implemented for AuthorizationType %s.", authorizationType));
+            }
+
+            final RepositoryApiClient finalInvalidClient = invalidClient;
+            ApiException exception = assertThrows(ApiException.class, () -> finalInvalidClient
+                    .getEntriesClient().getEntry(new ParametersForGetEntry()
+                            .setRepoId(repositoryId)
+                            .setEntryId(1)));
+
+            assertEquals(401, exception.getStatusCode());
+            assertEquals(exception.getStatusCode(), exception.getProblemDetails().getStatus());
+            assertEquals(exception.getMessage(), exception.getProblemDetails().getTitle());
+            assertTrue(exception.getHeaders().size() > 0);
+            assertNotNull(exception.getProblemDetails().getOperationId());
+            assertNotNull(exception.getProblemDetails().getInstance());
+            assertNotNull(exception.getProblemDetails().getType());
+        } finally {
+            if (invalidClient != null)
+                invalidClient.close();
+        }
+    }
+}

--- a/src/test/java/unit/clients/impl/ApiClientUtilsTest.java
+++ b/src/test/java/unit/clients/impl/ApiClientUtilsTest.java
@@ -1,0 +1,170 @@
+package unit.clients.impl;
+
+import com.laserfiche.repository.api.clients.impl.ApiClientUtils;
+import com.laserfiche.repository.api.clients.impl.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ApiClientUtilsTest {
+    @Test
+    void getCreateEntryResultSummary_NullCreateEntryResult() {
+        String result = ApiClientUtils.getCreateEntryResultSummary(null);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_NullCreateEntryOperations() {
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(null);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        assertEquals("", result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_NullExceptionsList() {
+        String errorMessage1 = "There was an error.";
+        APIServerException apiServerException = new APIServerException();
+        apiServerException.setMessage(errorMessage1);
+        List<APIServerException> exceptions = new ArrayList<>();
+        exceptions.add(apiServerException);
+
+        CreateEntryOperations createEntryOperations = new CreateEntryOperations();
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(createEntryOperations);
+
+        SetTemplate setTemplate = new SetTemplate();
+        setTemplate.setExceptions(null);
+        createEntryOperations.setTemplate(setTemplate);
+
+        SetFields setFields = new SetFields();
+        setFields.setExceptions(exceptions);
+        createEntryOperations.setFields(setFields);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        String expectedResult = String.format("%s", errorMessage1);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_NullException() {
+        String errorMessage1 = "There was an error.";
+        APIServerException apiServerException = new APIServerException();
+        apiServerException.setMessage(errorMessage1);
+        List<APIServerException> exceptions = new ArrayList<>();
+        exceptions.add(null);
+        exceptions.add(apiServerException);
+        exceptions.add(null);
+
+        CreateEntryOperations createEntryOperations = new CreateEntryOperations();
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(createEntryOperations);
+
+        SetFields setFields = new SetFields();
+        setFields.setExceptions(exceptions);
+        createEntryOperations.setFields(setFields);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        String expectedResult = String.format("%s", errorMessage1);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_NoOperationsHaveExceptions() {
+        int entryId = 123;
+        EntryCreate entryCreate = new EntryCreate();
+        entryCreate.setEntryId(entryId);
+        CreateEntryOperations createEntryOperations = new CreateEntryOperations();
+        createEntryOperations.setEntryCreate(entryCreate);
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(createEntryOperations);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        assertEquals(String.format("EntryId=%s.", entryId), result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_OperationHasMultipleExceptions() {
+        String errorMessage1 = "There was an error.";
+        APIServerException apiServerException1 = new APIServerException();
+        apiServerException1.setMessage(errorMessage1);
+        String errorMessage2 = "There was another error.";
+        APIServerException apiServerException2 = new APIServerException();
+        apiServerException2.setMessage(errorMessage2);
+        List<APIServerException> exceptions = new ArrayList<>();
+        exceptions.add(apiServerException1);
+        exceptions.add(apiServerException2);
+
+        CreateEntryOperations createEntryOperations = new CreateEntryOperations();
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(createEntryOperations);
+
+        SetFields setFields = new SetFields();
+        setFields.setExceptions(exceptions);
+        createEntryOperations.setFields(setFields);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        String expectedResult = String.format("%s %s", errorMessage1, errorMessage2);
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void getCreateEntryResultSummary_AllOperationsHaveExceptions() {
+        String errorMessage1 = "There was an error.";
+        APIServerException apiServerException1 = new APIServerException();
+        apiServerException1.setMessage(errorMessage1);
+        List<APIServerException> exceptions1 = new ArrayList<>();
+        exceptions1.add(apiServerException1);
+
+        String errorMessage2 = "There was another error.";
+        APIServerException apiServerException2 = new APIServerException();
+        apiServerException2.setMessage(errorMessage2);
+        List<APIServerException> exceptions2 = new ArrayList<>();
+        exceptions2.add(apiServerException2);
+
+        CreateEntryOperations createEntryOperations = new CreateEntryOperations();
+        CreateEntryResult createEntryResult = new CreateEntryResult();
+        createEntryResult.setOperations(createEntryOperations);
+
+        int entryId = 123;
+        EntryCreate entryCreate = new EntryCreate();
+        entryCreate.setEntryId(entryId);
+        entryCreate.setExceptions(exceptions1);
+        createEntryOperations.setEntryCreate(entryCreate);
+
+        SetEdoc setEdoc = new SetEdoc();
+        setEdoc.setExceptions(exceptions2);
+        createEntryOperations.setEdoc(setEdoc);
+
+        SetTemplate setTemplate = new SetTemplate();
+        setTemplate.setExceptions(exceptions1);
+        createEntryOperations.setTemplate(setTemplate);
+
+        SetFields setFields = new SetFields();
+        setFields.setExceptions(exceptions2);
+        createEntryOperations.setFields(setFields);
+
+        SetTags setTags = new SetTags();
+        setTags.setExceptions(exceptions1);
+        createEntryOperations.setTags(setTags);
+
+        SetLinks setLinks = new SetLinks();
+        setLinks.setExceptions(exceptions2);
+        createEntryOperations.setLinks(setLinks);
+
+        String result = ApiClientUtils.getCreateEntryResultSummary(createEntryResult);
+
+        String expectedResult = String.format("EntryId=%s. %2$s %3$s %2$s %3$s %2$s %3$s", entryId, errorMessage1, errorMessage2);
+        assertEquals(expectedResult, result);
+    }
+}


### PR DESCRIPTION
Resolves https://github.com/Laserfiche/lf-repository-api-client-java/issues/87
- Error handling has been updated to
  - throw ApiException when unable to deserialize response
  - throw ApiException when an undocumented status code is returned
- EntriesClient.importDocument has been updated to only return CreateEntryResult when a 200 status code is returned. When other error status codes return a CreateEntryResult, it will be a property in the ApiException.ProblemDetails.Extensions and the error will be thrown. 
- EntriesClient.getDocumentContentType error handling has been simplified
