### PR TITLE
replace the error handling implementation by calling createApiException

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -83,10 +83,10 @@ public class ApiClientUtils {
                 .trim();
     }
 
-    protected static void createApiException(HttpResponse<Object> httpResponse, ProblemDetails problemDetails) {
+    protected static ApiException createApiException(HttpResponse<Object> httpResponse, ProblemDetails problemDetails) {
         int statusCode = httpResponse.getStatus();
         Map<String, String> headersMap = getHeadersMap(httpResponse.getHeaders());
-        throw ApiException.create(statusCode, headersMap, problemDetails, null);
+        return ApiException.create(statusCode, headersMap, problemDetails, null);
     }
 
     /**

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -52,18 +52,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -109,18 +98,7 @@ public class AttributesClientImpl extends ApiClient implements AttributesClient 
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -46,18 +46,7 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -65,4 +54,3 @@ public class AuditReasonsClientImpl extends ApiClient implements AuditReasonsCli
                 new HashMap<String, String>(), false, parseResponse);
     }
 }
-

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -64,18 +64,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -124,20 +113,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -288,18 +264,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -346,20 +311,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -393,20 +345,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -438,20 +377,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -482,18 +408,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -527,18 +442,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -572,18 +476,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -617,18 +510,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -662,22 +544,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 409)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -709,18 +576,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -928,20 +784,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -997,20 +840,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -1058,18 +888,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, "fields",
@@ -1122,20 +941,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 409)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -1182,18 +988,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -1240,20 +1035,7 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 423)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -54,18 +54,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -110,18 +99,7 @@ public class FieldDefinitionsClientImpl extends ApiClient implements FieldDefini
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -53,18 +53,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -109,18 +98,7 @@ public class LinkDefinitionsClientImpl extends ApiClient implements LinkDefiniti
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -45,19 +45,9 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
-        return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET",
-                null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
+        return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET", null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -47,18 +47,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -89,18 +78,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -148,18 +126,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -205,18 +172,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -261,18 +217,7 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, "fields",
@@ -299,5 +244,4 @@ public class SearchesClientImpl extends ApiClient implements SearchesClient {
         }
     }
 }
-
 

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -49,18 +49,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -90,12 +79,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -125,18 +109,7 @@ public class ServerSessionClientImpl extends ApiClient implements ServerSessionC
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -50,18 +50,7 @@ public class SimpleSearchesClientImpl extends ApiClient implements SimpleSearche
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -64,18 +64,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -125,18 +114,7 @@ public class TagDefinitionsClientImpl extends ApiClient implements TagDefinition
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -48,18 +48,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,
@@ -85,18 +74,7 @@ public class TasksClientImpl extends ApiClient implements TasksClient {
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -69,18 +69,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -143,18 +132,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -221,18 +199,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, url, "GET", null, null, null, null,
@@ -284,18 +251,7 @@ public class TemplateDefinitionsClientImpl extends ApiClient implements Template
                 } catch (Exception e) {
                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
                 }
-                if (httpResponse.getStatus() == 400)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 401)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 403)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 404)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else if (httpResponse.getStatus() == 429)
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
-                else
-                    throw ApiException.create(httpResponse.getStatus(), headersMap, problemDetails, null);
+                throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler,


### PR DESCRIPTION
- refactored the `createApiException()` function in the `ApiClientUtil` class
- replace the error handling implementation in almost all of the lambda functions in the API client methods by calling the `createApiException()` function in the `ApiClientUtil` class
- did not change the import and export API method error handling implementation since it was a pretty unique implementation compared to the rest of the APIs 
