### PR TITLE
Update github page to refer to 1.2.0 instead of 1.0.0.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 
 ## Documentation
 
-- [Java Doc for Laserfiche Repository API Client](https://s01.oss.sonatype.org/service/local/repositories/releases/archive/com/laserfiche/lf-repository-api-client/1.0.0/lf-repository-api-client-1.0.0-javadoc.jar/!/index.html)
+- [Java Doc for Laserfiche Repository API Client](https://s01.oss.sonatype.org/service/local/repositories/releases/archive/com/laserfiche/lf-repository-api-client/1.2.0/lf-repository-api-client-1.2.0-javadoc.jar/!/index.html)
 
 ## Installation
 
@@ -14,6 +14,6 @@ Include the following in your pom.xml file:
 <dependency>
     <groupId>com.laserfiche</groupId>
     <artifactId>lf-repository-api-client</artifactId>
-    <version>1.0.0</version>
+    <version>1.2.0</version>
 </dependency>
 ```


### PR DESCRIPTION
Update github page to refer to 1.2.0, instead of 1.0.0

- in the documentation link
- in the installation guide