### PR TITLE
fixed importDoc with an invalid repo error message bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   - 401 status code response is being returned
   - Idempotent http request
 
+### Fixes
+- For sending an importDocument API with an invalid repo, changed error message displayed from `HTTP status code 404` to `Error: Repository with the given Id not found or no connection could be made.`
+
 ## 1.2.0
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,6 @@
   - 401 status code response is being returned
   - Idempotent http request
 
-### Fixes
-- For sending an importDocument API with an invalid repo, changed error message displayed from `HTTP status code 404` to `Error: Repository with the given Id not found or no connection could be made.`
-
 ## 1.2.0
 
 ### Features

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -170,18 +170,29 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                             if (httpResponse.getStatus() == 400 || httpResponse.getStatus() == 404 || httpResponse.getStatus() == 409 || httpResponse.getStatus() == 500) {
                                 try {
                                     String jsonString = new JSONObject(body).toString();
-                                    problemDetails = ProblemDetails.create(httpResponse.getStatus(), headersMap);
-                                    CreateEntryResult result = objectMapper.readValue(jsonString,
-                                            CreateEntryResult.class);
-                                    if (result != null && result.getOperations() != null) {
-                                        problemDetails
-                                                .getExtensions()
-                                                .put(CreateEntryResult.class.getSimpleName(), result);
-                                        String summary = ApiClientUtils.getCreateEntryResultSummary(result);
-                                        if (summary != null && !summary
-                                                .trim()
-                                                .isEmpty())
-                                            problemDetails.setTitle(summary);
+                                    if (httpResponse
+                                            .getBody()
+                                            .toString()
+                                            .contains("title") && httpResponse
+                                            .getBody()
+                                            .toString()
+                                            .contains("type")) {
+                                        problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper,
+                                                jsonString);
+                                    } else {
+                                        problemDetails = ProblemDetails.create(httpResponse.getStatus(), headersMap);
+                                        CreateEntryResult result = objectMapper.readValue(jsonString,
+                                                CreateEntryResult.class);
+                                        if (result != null && result.getOperations() != null) {
+                                            problemDetails
+                                                    .getExtensions()
+                                                    .put(CreateEntryResult.class.getSimpleName(), result);
+                                            String summary = ApiClientUtils.getCreateEntryResultSummary(result);
+                                            if (summary != null && !summary
+                                                    .trim()
+                                                    .isEmpty())
+                                                problemDetails.setTitle(summary);
+                                        }
                                     }
                                 } catch (Exception e) {
                                     throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -171,12 +171,9 @@ public class EntriesClientImpl extends ApiClient implements EntriesClient {
                                 try {
                                     String jsonString = new JSONObject(body).toString();
                                     if (httpResponse
-                                            .getBody()
-                                            .toString()
-                                            .contains("title") && httpResponse
-                                            .getBody()
-                                            .toString()
-                                            .contains("type")) {
+                                            .getHeaders()
+                                            .getFirst("Content-Type")
+                                            .contains("application/problem+json")) {
                                         problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper,
                                                 jsonString);
                                     } else {


### PR DESCRIPTION
- changed the exception error message from `HTTP status code 404` to `Error: Repository with the given Id not found or no connection could be made.` for sending an importDocument API with an invalid repo query parameter