### PR TITLE
added getSelfHosted repo implementation and integration test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  VERSION_PREFIX: 2.0.2
+  VERSION_PREFIX: 2.0.3
 
 jobs:
   build-n-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 2.0.3
+## 2.0.3 Pre-release
 
 ### Features
 
-- Added `getSelfHostedRepositoryList(String url)` to `RepositoryApiClientImpl` for self hosted users
+- Added `RepositoriesClientImpl.getSelfHostedRepositoryList` method that will enable self hosted users to get their repository list without an access token.
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Added `getSelfHostedRepositoryList(String url)` to `RepositoriesClientImpl` for self hosted users
+- Added `getSelfHostedRepositoryList(String url)` to `RepositoryApiClientImpl` for self hosted users
 
 ## 2.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.3
+
+### Features
+
+- Added `getSelfHostedRepositoryList(String url)` to `RepositoriesClientImpl` for self hosted users
+
 ## 2.0.2
 
 ### Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client</name>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -124,35 +124,6 @@ public class RepositoryApiClientImpl implements RepositoryApiClient, AutoCloseab
         return new RepositoryApiClientImpl(baseUrl, usernamePasswordHandler);
     }
 
-    /**
-     * Returns the repository resource list that current user has access to given the API server base URL. Only available in Laserfiche Self-Hosted.
-     *
-     * @param url API server base URL e.g., https://{APIServerName}/LFRepositoryAPI
-     * @return Get the respository resource list successfully.
-     */
-    public static RepositoryInfo[] getSelfHostedRepositoryList(String url) {
-        Map<String, String> headerKeyValuePairs = new HashMap<>();
-        headerKeyValuePairs.put("accept", "application/json");
-        HttpResponse<Object> httpResponse = null;
-        if (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-        String baseUrl = url + "/v1/Repositories";
-        String responseJson;
-        ObjectMapper objectMapper = new TokenClientObjectMapper();
-        UnirestInstance httpClient = Unirest.spawnInstance();
-        httpClient
-                .config()
-                .setObjectMapper(objectMapper);
-        httpResponse = httpClient
-                .get(baseUrl)
-                .headers(headerKeyValuePairs)
-                .asObject(Object.class);
-        Object body = httpResponse.getBody();
-        responseJson = new JSONArray(((ArrayList) body).toArray()).toString();
-        return objectMapper.readValue(responseJson, RepositoryInfo[].class);
-    }
-
     @Override
     public void setDefaultRequestHeaders(Map<String, String> defaultRequestHeaders) {
         defaultHeaders = defaultRequestHeaders;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,15 +1,12 @@
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
-import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.HttpResponse;
-import kong.unirest.ObjectMapper;
-import kong.unirest.Unirest;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
@@ -53,28 +50,5 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET",
                 null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
-    }
-
-    public static RepositoryInfo[] getSelfHostedRepositoryList(String url) {
-        Map<String, String> headerKeyValuePairs = new HashMap<>();
-        headerKeyValuePairs.put("accept", "application/json");
-        HttpResponse<Object> httpResponse = null;
-        if (url.endsWith("/")) {
-            url = url.substring(0, url.length() - 1);
-        }
-        String baseUrl = url + "/v1/Repositories";
-        String responseJson;
-        ObjectMapper objectMapper = new TokenClientObjectMapper();
-        UnirestInstance httpClient = Unirest.spawnInstance();
-        httpClient
-                .config()
-                .setObjectMapper(objectMapper);
-        httpResponse = httpClient
-                .get(baseUrl)
-                .headers(headerKeyValuePairs)
-                .asObject(Object.class);
-        Object body = httpResponse.getBody();
-        responseJson = new JSONArray(((ArrayList) body).toArray()).toString();
-        return objectMapper.readValue(responseJson, RepositoryInfo[].class);
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,12 +1,15 @@
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
+import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.HttpResponse;
+import kong.unirest.ObjectMapper;
+import kong.unirest.Unirest;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
@@ -48,6 +51,30 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
                 throw ApiClientUtils.createApiException(httpResponse, problemDetails);
             }
         };
-        return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET", null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
+        return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET",
+                null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
+    }
+
+    public static RepositoryInfo[] getSelfHostedRepositoryList(String url) {
+        Map<String, String> headerKeyValuePairs = new HashMap<>();
+        headerKeyValuePairs.put("accept", "application/json");
+        HttpResponse<Object> httpResponse = null;
+        if (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        String baseUrl = url + "/v1/Repositories";
+        String responseJson;
+        ObjectMapper objectMapper = new TokenClientObjectMapper();
+        UnirestInstance httpClient = Unirest.spawnInstance();
+        httpClient
+                .config()
+                .setObjectMapper(objectMapper);
+        httpResponse = httpClient
+                .get(baseUrl)
+                .headers(headerKeyValuePairs)
+                .asObject(Object.class);
+        Object body = httpResponse.getBody();
+        responseJson = new JSONArray(((ArrayList) body).toArray()).toString();
+        return objectMapper.readValue(responseJson, RepositoryInfo[].class);
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,12 +1,15 @@
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;
+import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import kong.unirest.HttpResponse;
+import kong.unirest.ObjectMapper;
+import kong.unirest.Unirest;
 import kong.unirest.UnirestInstance;
 import kong.unirest.json.JSONArray;
 import kong.unirest.json.JSONObject;
@@ -50,5 +53,50 @@ public class RepositoriesClientImpl extends ApiClient implements RepositoriesCli
         };
         return ApiClientUtils.sendRequestWithRetry(httpClient, httpRequestHandler, baseUrl + "/v1/Repositories", "GET",
                 null, null, null, null, null, null, new HashMap<String, String>(), false, parseResponse);
+    }
+
+    /**
+     * Returns the repository resource list that current user has access to given the API server base URL. Only available in Laserfiche Self-Hosted.
+     *
+     * @param url API server base URL e.g., https://{APIServerName}/LFRepositoryAPI
+     * @return Get the respository resource list successfully.
+     */
+    public static RepositoryInfo[] getSelfHostedRepositoryList(String url) {
+        Map<String, String> headerKeyValuePairs = new HashMap<>();
+        headerKeyValuePairs.put("accept", "application/json");
+        HttpResponse<Object> httpResponse = null;
+        String responseJson;
+        if (url.endsWith("/")) {
+            url = url.substring(0, url.length() - 1);
+        }
+        String baseUrl = url + "/v1/Repositories";
+        ObjectMapper objectMapper = new TokenClientObjectMapper();
+        UnirestInstance httpClient = Unirest.spawnInstance();
+        httpClient
+                .config()
+                .setObjectMapper(objectMapper);
+        httpResponse = httpClient
+                .get(baseUrl)
+                .headers(headerKeyValuePairs)
+                .asObject(Object.class);
+        Object body = httpResponse.getBody();
+        Map<String, String> headersMap = ApiClientUtils.getHeadersMap(httpResponse.getHeaders());
+        if (httpResponse.getStatus() == 200) {
+            try {
+                responseJson = new JSONArray(((ArrayList) body).toArray()).toString();
+                return objectMapper.readValue(responseJson, RepositoryInfo[].class);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
+            }
+        } else {
+            ProblemDetails problemDetails;
+            try {
+                String jsonString = new JSONObject(body).toString();
+                problemDetails = ProblemDetailsDeserializer.deserialize(objectMapper, jsonString);
+            } catch (Exception e) {
+                throw ApiException.create(httpResponse.getStatus(), headersMap, null, e);
+            }
+            throw ApiClientUtils.createApiException(httpResponse, problemDetails);
+        }
     }
 }

--- a/src/test/java/integration/BaseTest.java
+++ b/src/test/java/integration/BaseTest.java
@@ -38,7 +38,7 @@ public class BaseTest {
     private static final String USERNAME = "APISERVER_USERNAME";
     private static final String PASSWORD = "APISERVER_PASSWORD";
     private static final String BASE_URL = "APISERVER_REPOSITORY_API_BASE_URL";
-    private static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
+    protected static final String AUTHORIZATION_TYPE = "AUTHORIZATION_TYPE";
     protected static AuthorizationType authorizationType;
     private static final boolean IS_NOT_GITHUB_ENVIRONMENT = nullOrEmpty(System.getenv("GITHUB_WORKSPACE"));
     @BeforeAll
@@ -73,7 +73,7 @@ public class BaseTest {
         repositoryApiClient = createClient();
     }
 
-    private static String getEnvironmentVariable(String environmentVariableName) {
+    protected static String getEnvironmentVariable(String environmentVariableName) {
         String environmentVariable = System.getenv(environmentVariableName);
         if (nullOrEmpty(environmentVariable)) {
             environmentVariable = System.getProperty(environmentVariableName);

--- a/src/test/java/integration/RepositoriesApiTest.java
+++ b/src/test/java/integration/RepositoriesApiTest.java
@@ -2,12 +2,12 @@ package integration;
 
 import com.laserfiche.repository.api.RepositoryApiClientImpl;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
-import com.laserfiche.repository.api.clients.impl.RepositoriesClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class RepositoriesApiTest extends BaseTest {
     @Test
@@ -16,13 +16,17 @@ class RepositoriesApiTest extends BaseTest {
         RepositoryInfo[] repositoryInfoList = client.getRepositoryList();
         boolean foundRepo = false;
         assertNotNull(repositoryInfoList);
-        for (RepositoryInfo repositoryInfo : repositoryInfoList){
+        for (RepositoryInfo repositoryInfo : repositoryInfoList) {
             assertNotNull(repositoryInfo.getRepoId());
-            if(!authorizationType.equals(AuthorizationType.API_SERVER_USERNAME_PASSWORD)){
+            if (!authorizationType.equals(AuthorizationType.API_SERVER_USERNAME_PASSWORD)) {
                 assertNotNull(repositoryInfo.getWebclientUrl());
-                assertTrue(repositoryInfo.getWebclientUrl().contains(repositoryInfo.getRepoId()));
+                assertTrue(repositoryInfo
+                        .getWebclientUrl()
+                        .contains(repositoryInfo.getRepoId()));
             }
-            if(repositoryInfo.getRepoId().equalsIgnoreCase(repositoryId)){
+            if (repositoryInfo
+                    .getRepoId()
+                    .equalsIgnoreCase(repositoryId)) {
                 foundRepo = true;
             }
         }
@@ -32,14 +36,18 @@ class RepositoriesApiTest extends BaseTest {
     @Test
     @DisabledIf("isCloudEnvironment")
     void getSelfHostedRepositoryList_WithNoAuthentication_ReturnSuccessful() {
-        RepositoryInfo[] repositoryInfoList = RepositoriesClientImpl.getSelfHostedRepositoryList(baseUrl);
+        RepositoryInfo[] repositoryInfoList = RepositoryApiClientImpl.getSelfHostedRepositoryList(baseUrl);
         assertNotNull(repositoryInfoList);
         boolean foundRepo = false;
-        for (RepositoryInfo repositoryInfo : repositoryInfoList){
+        for (RepositoryInfo repositoryInfo : repositoryInfoList) {
             assertNotNull(repositoryInfo.getRepoId());
             assertNotNull(repositoryInfo.getWebclientUrl());
-            assertTrue(repositoryInfo.getWebclientUrl().contains(repositoryInfo.getRepoId()));
-            if(repositoryInfo.getRepoId().equalsIgnoreCase(repositoryId)){
+            assertTrue(repositoryInfo
+                    .getWebclientUrl()
+                    .contains(repositoryInfo.getRepoId()));
+            if (repositoryInfo
+                    .getRepoId()
+                    .equalsIgnoreCase(repositoryId)) {
                 foundRepo = true;
             }
         }

--- a/src/test/java/integration/RepositoriesApiTest.java
+++ b/src/test/java/integration/RepositoriesApiTest.java
@@ -1,8 +1,11 @@
 package integration;
 
+import com.laserfiche.repository.api.RepositoryApiClientImpl;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
+import com.laserfiche.repository.api.clients.impl.RepositoriesClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIf;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -13,5 +16,20 @@ class RepositoriesApiTest extends BaseTest {
         RepositoryInfo[] repositoryInfoList = client.getRepositoryList();
 
         assertNotNull(repositoryInfoList);
+    }
+
+    @Test
+    @DisabledIf("isCloudEnvironment")
+    void getSelfHostedRepositoryList_WithNoAuthentication_ReturnSuccessful() {
+        RepositoryInfo[] repositoryInfoList = RepositoriesClientImpl.getSelfHostedRepositoryList(baseUrl);
+        assertNotNull(repositoryInfoList);
+    }
+
+    boolean isCloudEnvironment() {
+        AuthorizationType AuthType = AuthorizationType.valueOf(getEnvironmentVariable(AUTHORIZATION_TYPE));
+        if (AuthType == AuthorizationType.API_SERVER_USERNAME_PASSWORD) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/test/java/integration/RepositoriesApiTest.java
+++ b/src/test/java/integration/RepositoriesApiTest.java
@@ -1,7 +1,7 @@
 package integration;
 
-import com.laserfiche.repository.api.RepositoryApiClientImpl;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
+import com.laserfiche.repository.api.clients.impl.RepositoriesClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
@@ -36,15 +36,11 @@ class RepositoriesApiTest extends BaseTest {
     @Test
     @DisabledIf("isCloudEnvironment")
     void getSelfHostedRepositoryList_WithNoAuthentication_ReturnSuccessful() {
-        RepositoryInfo[] repositoryInfoList = RepositoryApiClientImpl.getSelfHostedRepositoryList(baseUrl);
+        RepositoryInfo[] repositoryInfoList = RepositoriesClientImpl.getSelfHostedRepositoryList(baseUrl);
         assertNotNull(repositoryInfoList);
         boolean foundRepo = false;
         for (RepositoryInfo repositoryInfo : repositoryInfoList) {
             assertNotNull(repositoryInfo.getRepoId());
-            assertNotNull(repositoryInfo.getWebclientUrl());
-            assertTrue(repositoryInfo
-                    .getWebclientUrl()
-                    .contains(repositoryInfo.getRepoId()));
             if (repositoryInfo
                     .getRepoId()
                     .equalsIgnoreCase(repositoryId)) {

--- a/src/test/java/integration/RepositoriesApiTest.java
+++ b/src/test/java/integration/RepositoriesApiTest.java
@@ -7,15 +7,26 @@ import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 class RepositoriesApiTest extends BaseTest {
     @Test
     void getRepositoryList_ReturnSuccessful() {
         RepositoriesClient client = repositoryApiClient.getRepositoryClient();
         RepositoryInfo[] repositoryInfoList = client.getRepositoryList();
-
+        boolean foundRepo = false;
         assertNotNull(repositoryInfoList);
+        for (RepositoryInfo repositoryInfo : repositoryInfoList){
+            assertNotNull(repositoryInfo.getRepoId());
+            if(!authorizationType.equals(AuthorizationType.API_SERVER_USERNAME_PASSWORD)){
+                assertNotNull(repositoryInfo.getWebclientUrl());
+                assertTrue(repositoryInfo.getWebclientUrl().contains(repositoryInfo.getRepoId()));
+            }
+            if(repositoryInfo.getRepoId().equalsIgnoreCase(repositoryId)){
+                foundRepo = true;
+            }
+        }
+        assertTrue(foundRepo);
     }
 
     @Test
@@ -23,6 +34,16 @@ class RepositoriesApiTest extends BaseTest {
     void getSelfHostedRepositoryList_WithNoAuthentication_ReturnSuccessful() {
         RepositoryInfo[] repositoryInfoList = RepositoriesClientImpl.getSelfHostedRepositoryList(baseUrl);
         assertNotNull(repositoryInfoList);
+        boolean foundRepo = false;
+        for (RepositoryInfo repositoryInfo : repositoryInfoList){
+            assertNotNull(repositoryInfo.getRepoId());
+            assertNotNull(repositoryInfo.getWebclientUrl());
+            assertTrue(repositoryInfo.getWebclientUrl().contains(repositoryInfo.getRepoId()));
+            if(repositoryInfo.getRepoId().equalsIgnoreCase(repositoryId)){
+                foundRepo = true;
+            }
+        }
+        assertTrue(foundRepo);
     }
 
     boolean isCloudEnvironment() {


### PR DESCRIPTION
- added `getSelfHostedRepoList()` method for self hosted users to get all self hosted repos without any authorization
- added a conditional integration test case for it
- updated version and changelog
- refactor all `getRepoList` test cases
- avoided calling the `getRepositoryList()` since the before and aftersend logic will be applied if calling that we want to keep it as simple as possible 
- decided to not add an encapsulation class for new method (like all the `nextlink` functions) and just keep it simple 