### PR TITLE
Fix and enable all integration tests 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,7 @@ jobs:
       run: mvn -B package -Dmaven.test.skip=true --file pom.xml
 
     - name: Run unit tests
-      run: mvn -Dtest=com.laserfiche.repository.api.unit.*Test test
+      run: mvn -Dtest=com.laserfiche.repository.api.unit.** test
 
     - name: Publish unit test results
       uses: EnricoMi/publish-unit-test-result-action@v1
@@ -50,7 +50,7 @@ jobs:
         REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
         AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
         TEST_HEADER: ${{ secrets.TEST_HEADER }}
-      run: mvn -Dtest=com.laserfiche.repository.api.integration.*Test test
+      run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
     - name: Publish cloud test results
       uses: EnricoMi/publish-unit-test-result-action@v1
@@ -71,7 +71,7 @@ jobs:
         APISERVER_PASSWORD: ${{ secrets.APISERVER_PASSWORD }}
         APISERVER_REPOSITORY_API_BASE_URL: ${{ secrets.APISERVER_REPOSITORY_API_BASE_URL }}
         AUTHORIZATION_TYPE: ${{ secrets.APISERVER_AUTHORIZATION_TYPE }}
-      run: mvn -Dtest=com.laserfiche.repository.api.integration.*Test test
+      run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
     - name: Publish self-hosted test results
       uses: EnricoMi/publish-unit-test-result-action@v1

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -148,7 +148,7 @@ public class ApiClientUtils {
         return headers
                 .all()
                 .stream()
-                .collect(Collectors.toMap(Header::getName, Header::getValue));
+                .collect(Collectors.toMap(Header::getName, Header::getValue, (value1, value2) -> String.format("%s, %s", value1, value2)));
     }
 
     /**

--- a/src/test/java/com/laserfiche/repository/api/integration/AttributesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/AttributesApiTest.java
@@ -81,7 +81,7 @@ class AttributesApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 3;
         Function<ODataValueContextOfListOfAttribute, Boolean> callback = attributes -> {
-            if (attributes.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && attributes.getOdataNextLink() != null) {
                 assertNotEquals(0, attributes
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -1,7 +1,6 @@
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.AccessKey;
-import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.RepositoryApiClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.*;
@@ -14,7 +13,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -127,7 +125,7 @@ public class BaseTest {
                         .setAutoRename(autoRename));
     }
 
-    public static Boolean allFalse(List<TemplateFieldInfo> arr) {
+    public static Boolean noTemplateFieldDefinitionsRequired(List<TemplateFieldInfo> arr) {
         for (TemplateFieldInfo templateFieldInfo : arr) {
             if (templateFieldInfo.isRequired()) {
                 return false;

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -125,7 +125,7 @@ public class BaseTest {
                         .setAutoRename(autoRename));
     }
 
-    public static Boolean noTemplateFieldDefinitionsRequired(List<TemplateFieldInfo> arr) {
+    public static Boolean noRequiredFieldDefinitionsInTemplate(List<TemplateFieldInfo> arr) {
         for (TemplateFieldInfo templateFieldInfo : arr) {
             if (templateFieldInfo.isRequired()) {
                 return false;

--- a/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
@@ -66,17 +66,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
         Integer parentEntryId = 1;
 
-        PostEntryChildrenRequest request = new PostEntryChildrenRequest();
-        request.setEntryType(PostEntryChildrenEntryType.FOLDER);
-        request.setName(newEntryName);
-
-        Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
-                        .setRequestBody(request)
-                        .setAutoRename(true));
-
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, 1, true);
         assertNotNull(targetEntry);
         createdEntries.add(targetEntry);
 
@@ -84,7 +74,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
         newEntryName = "RepositoryApiClientIntegrationTest Java CreateShortcut";
-        request = new PostEntryChildrenRequest();
+        PostEntryChildrenRequest request = new PostEntryChildrenRequest();
         request.setEntryType(PostEntryChildrenEntryType.SHORTCUT);
         request.setName(newEntryName);
         request.setTargetId(targetEntry.getId());
@@ -106,26 +96,15 @@ public class CreateCopyEntryApiTest extends BaseTest {
     }
 
     @Test
-    void createCopyEntry_CopyEntry() throws InterruptedException {
+    void copyEntryAsync_CopyEntry() throws InterruptedException {
         String testFolderName = "RepositoryApiClientIntegrationTest Java CreateCopyEntry_CopyEntry_test_folder";
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
 
         Entry testFolder = createEntry(createEntryClient, testFolderName, 1, true);
+        createdEntries.add(testFolder);
 
-        PostEntryChildrenRequest request = new PostEntryChildrenRequest();
-        request.setEntryType(PostEntryChildrenEntryType.FOLDER);
-        request.setName(newEntryName);
-
-        Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repositoryId)
-                        .setEntryId(testFolder.getId())
-                        .setRequestBody(request)
-                        .setAutoRename(true));
-
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, testFolder.getId(), true);
         assertNotNull(targetEntry);
-        createdEntries.add(targetEntry);
-
         assertEquals(targetEntry.getParentId(), testFolder.getId());
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
@@ -149,16 +128,6 @@ public class CreateCopyEntryApiTest extends BaseTest {
                         .setOperationToken(opToken));
 
         assertEquals(getOperationStatusAndProgressResponse.getStatus(), OperationStatus.COMPLETED);
-
-        DeleteEntryWithAuditReason deleteEntryWithAuditReason = new DeleteEntryWithAuditReason();
-        AcceptedOperation deleteEntryResponse = client
-                .deleteEntryInfo(new ParametersForDeleteEntryInfo()
-                        .setRepoId(repositoryId)
-                        .setEntryId(testFolder.getId())
-                        .setRequestBody(deleteEntryWithAuditReason));
-        WaitUntilTaskEnds(deleteEntryResponse, Duration.ofMillis(100), Duration.ofSeconds(30));
-
-        assertNotNull(deleteEntryResponse);
     }
 
     @Test
@@ -166,17 +135,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
         Integer parentEntryId = 1;
 
-        PostEntryChildrenRequest request = new PostEntryChildrenRequest();
-        request.setEntryType(PostEntryChildrenEntryType.FOLDER);
-        request.setName(newEntryName);
-
-        Entry targetEntry = client
-                .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
-                        .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
-                        .setRequestBody(request)
-                        .setAutoRename(true));
-
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, parentEntryId, true);
         assertNotNull(targetEntry);
 
         createdEntries.add(targetEntry);
@@ -185,8 +144,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
         newEntryName = "RepositoryApiClientIntegrationTest Java CreateShortcut";
-
-        request = new PostEntryChildrenRequest();
+        PostEntryChildrenRequest request = new PostEntryChildrenRequest();
         request.setEntryType(PostEntryChildrenEntryType.SHORTCUT);
         request.setName(newEntryName);
         request.setTargetId(targetEntry.getId());

--- a/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
@@ -6,21 +6,15 @@ import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.*;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class CreateCopyEntryApiTest extends BaseTest {
-    List<Entry> createdEntries = new ArrayList<>();
+    static Entry testClassParentFolder;
     EntriesClient client;
     RepositoryApiClient createEntryClient;
 
@@ -30,15 +24,20 @@ public class CreateCopyEntryApiTest extends BaseTest {
         createEntryClient = repositoryApiClient;
     }
 
-    @AfterEach
-    void perTestCleanUp() throws InterruptedException {
-        deleteEntries(createdEntries);
+    @BeforeAll
+    static void classSetup() {
+        String name = "RepositoryApiClientIntegrationTest Java ParentFolder";
+        testClassParentFolder = createEntry(repositoryApiClient, name, 1, true);
+    }
+
+    @AfterAll
+    static void classCleanUp() throws InterruptedException {
+        deleteEntry(testClassParentFolder.getId());
     }
 
     @Test
     void createCopyEntry_CreateFolder() {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
-        Integer parentEntryId = 1;
 
         PostEntryChildrenRequest request = new PostEntryChildrenRequest();
         request.setEntryType(PostEntryChildrenEntryType.FOLDER);
@@ -47,14 +46,13 @@ public class CreateCopyEntryApiTest extends BaseTest {
         Entry createdEntry = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
                         .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
+                        .setEntryId(testClassParentFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
 
         assertNotNull(createdEntry);
-        createdEntries.add(createdEntry);
 
-        assertEquals(parentEntryId, createdEntry.getParentId());
+        assertEquals(testClassParentFolder.getId(), createdEntry.getParentId());
         assertEquals(createdEntry.getEntryType(), EntryType.FOLDER);
         assertEquals(Folder.class.getName(), createdEntry
                 .getClass()
@@ -64,13 +62,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
     @Test
     void createCopyEntry_CreateShortcut() {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
-        Integer parentEntryId = 1;
 
-        Entry targetEntry = createEntry(createEntryClient, newEntryName, 1, true);
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, testClassParentFolder.getId(), true);
         assertNotNull(targetEntry);
-        createdEntries.add(targetEntry);
 
-        assertEquals(targetEntry.getParentId(), parentEntryId);
+        assertEquals(targetEntry.getParentId(), testClassParentFolder.getId());
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
         newEntryName = "RepositoryApiClientIntegrationTest Java CreateShortcut";
@@ -82,13 +78,12 @@ public class CreateCopyEntryApiTest extends BaseTest {
         Entry shortCut = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
                         .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
+                        .setEntryId(testClassParentFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
 
         assertNotNull(shortCut);
-        createdEntries.add(shortCut);
-        assertEquals(parentEntryId, shortCut.getParentId());
+        assertEquals(testClassParentFolder.getId(), shortCut.getParentId());
         assertEquals(EntryType.SHORTCUT, shortCut.getEntryType());
         assertEquals(shortCut
                 .getClass()
@@ -97,15 +92,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
     @Test
     void copyEntryAsync_CopyEntry() throws InterruptedException {
-        String testFolderName = "RepositoryApiClientIntegrationTest Java CreateCopyEntry_CopyEntry_test_folder";
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
 
-        Entry testFolder = createEntry(createEntryClient, testFolderName, 1, true);
-        createdEntries.add(testFolder);
-
-        Entry targetEntry = createEntry(createEntryClient, newEntryName, testFolder.getId(), true);
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, testClassParentFolder.getId(), true);
         assertNotNull(targetEntry);
-        assertEquals(targetEntry.getParentId(), testFolder.getId());
+        assertEquals(targetEntry.getParentId(), testClassParentFolder.getId());
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
         CopyAsyncRequest copyAsyncRequest = new CopyAsyncRequest();
@@ -114,7 +105,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
         AcceptedOperation copyEntryResponse = client.copyEntryAsync(new ParametersForCopyEntryAsync()
                 .setRepoId(repositoryId)
-                .setEntryId(testFolder.getId())
+                .setEntryId(testClassParentFolder.getId())
                 .setRequestBody(copyAsyncRequest)
                 .setAutoRename(true));
         String opToken = copyEntryResponse
@@ -133,14 +124,10 @@ public class CreateCopyEntryApiTest extends BaseTest {
     @Test
     void createCopyEntry_CopyShortCut() {
         String newEntryName = "RepositoryApiClientIntegrationTest Java CreateFolder";
-        Integer parentEntryId = 1;
 
-        Entry targetEntry = createEntry(createEntryClient, newEntryName, parentEntryId, true);
+        Entry targetEntry = createEntry(createEntryClient, newEntryName, testClassParentFolder.getId(), true);
         assertNotNull(targetEntry);
-
-        createdEntries.add(targetEntry);
-
-        assertEquals(targetEntry.getParentId(), parentEntryId);
+        assertEquals(targetEntry.getParentId(), testClassParentFolder.getId());
         assertEquals(targetEntry.getEntryType(), EntryType.FOLDER);
 
         newEntryName = "RepositoryApiClientIntegrationTest Java CreateShortcut";
@@ -152,15 +139,12 @@ public class CreateCopyEntryApiTest extends BaseTest {
         Entry createOrCopyEntryResponse = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
                         .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
+                        .setEntryId(testClassParentFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
 
         assertNotNull(createOrCopyEntryResponse);
-
-        createdEntries.add(createOrCopyEntryResponse);
-
-        assertEquals(parentEntryId, createOrCopyEntryResponse.getParentId());
+        assertEquals(testClassParentFolder.getId(), createOrCopyEntryResponse.getParentId());
         assertEquals(createOrCopyEntryResponse.getEntryType(), EntryType.SHORTCUT);
 
         request = new PostEntryChildrenRequest();
@@ -170,27 +154,21 @@ public class CreateCopyEntryApiTest extends BaseTest {
         Entry newEntryResponse = client
                 .createOrCopyEntry(new ParametersForCreateOrCopyEntry()
                         .setRepoId(repositoryId)
-                        .setEntryId(parentEntryId)
+                        .setEntryId(testClassParentFolder.getId())
                         .setRequestBody(request)
                         .setAutoRename(true));
 
-        createdEntries.add(newEntryResponse);
-
-        assertEquals(newEntryResponse.getParentId(), parentEntryId);
+        assertEquals(newEntryResponse.getParentId(), testClassParentFolder.getId());
         assertEquals(newEntryResponse.getEntryType(), createOrCopyEntryResponse.getEntryType());
     }
 
     @Test
     void moveAndRenameEntry_ReturnEntry() {
-        Entry parentFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ParentFolder", 1,
+        Entry parentFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ParentFolder", testClassParentFolder.getId(),
                 true);
 
-        createdEntries.add(parentFolder);
-
-        Entry childFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ChildFolder", 1,
+        Entry childFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ChildFolder", testClassParentFolder.getId(),
                 true);
-
-        createdEntries.add(childFolder);
 
         PatchEntryRequest request = new PatchEntryRequest();
         request.setParentId(parentFolder.getId());
@@ -211,15 +189,11 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
     @Test
     void moveAndRenameEntry_ReturnsCorrectErrorMessage_For_InvalidRepoId() {
-        Entry parentFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ParentFolder", 1,
+        Entry parentFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ParentFolder", testClassParentFolder.getId(),
                 true);
 
-        createdEntries.add(parentFolder);
-
-        Entry childFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ChildFolder", 1,
+        Entry childFolder = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java ChildFolder", testClassParentFolder.getId(),
                 true);
-
-        createdEntries.add(childFolder);
 
         PatchEntryRequest request = new PatchEntryRequest();
         request.setParentId(parentFolder.getId());

--- a/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
@@ -26,7 +26,7 @@ public class CreateCopyEntryApiTest extends BaseTest {
 
     @BeforeAll
     static void classSetup() {
-        String name = "RepositoryApiClientIntegrationTest Java ParentFolder";
+        String name = "RepositoryApiClientIntegrationTest Java TestClassParentFolder";
         testClassParentFolder = createEntry(repositoryApiClient, name, 1, true);
     }
 

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -125,7 +125,7 @@ class EntriesApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 3;
         Function<ODataValueContextOfIListOfEntry, Boolean> callback = entries -> {
-            if (entries.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && entries.getOdataNextLink() != null) {
                 assertNotEquals(0, entries
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -197,7 +197,7 @@ class EntriesApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         Function<ODataValueContextOfIListOfFieldValue, Boolean> callback = fieldValues -> {
-            if (fieldValues.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && fieldValues.getOdataNextLink() != null) {
                 assertNotEquals(0, fieldValues
                         .getValue()
                         .size());
@@ -253,7 +253,7 @@ class EntriesApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback = entryLinkIntoList -> {
-            if (entryLinkIntoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && entryLinkIntoList.getOdataNextLink() != null) {
                 assertNotEquals(0, entryLinkIntoList
                         .getValue()
                         .size());
@@ -325,7 +325,7 @@ class EntriesApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback = tagInfoList -> {
-            if (tagInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && tagInfoList.getOdataNextLink() != null) {
                 assertNotEquals(0, tagInfoList
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -9,7 +9,6 @@ import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -19,12 +18,11 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Disabled("Rate limiting issue")
 class EntriesApiTest extends BaseTest {
     EntriesClient client;
     RepositoryApiClient createEntryClient;
@@ -123,9 +121,11 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getEntryListing_ForEach() {
-        int maxPageSize = 10;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 3;
         Function<ODataValueContextOfIListOfEntry, Boolean> callback = entries -> {
-            if (entries.getOdataNextLink() != null) {
+            if (entries.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, entries
                         .getValue()
                         .size());
@@ -141,6 +141,7 @@ class EntriesApiTest extends BaseTest {
                 new ParametersForGetEntryListing()
                         .setRepoId(repositoryId)
                         .setEntryId(1));
+        assertTrue(pageCount.get() > 1);
     }
 
     @Test
@@ -192,9 +193,11 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getFieldValues_ForEach() {
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 1;
         Function<ODataValueContextOfIListOfFieldValue, Boolean> callback = fieldValues -> {
-            if (fieldValues.getOdataNextLink() != null) {
+            if (fieldValues.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, fieldValues
                         .getValue()
                         .size());
@@ -246,9 +249,11 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getLinkValuesFromEntry_ForEach() {
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWEntryLinkInfo, Boolean> callback = entryLinkIntoList -> {
-            if (entryLinkIntoList.getOdataNextLink() != null) {
+            if (entryLinkIntoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, entryLinkIntoList
                         .getValue()
                         .size());
@@ -316,9 +321,11 @@ class EntriesApiTest extends BaseTest {
 
     @Test
     void getTagsAssignedToEntry_ForEach() {
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback = tagInfoList -> {
-            if (tagInfoList.getOdataNextLink() != null) {
+            if (tagInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, tagInfoList
                         .getValue()
                         .size());
@@ -453,30 +460,6 @@ class EntriesApiTest extends BaseTest {
         assertNotNull(problemDetails.getType());
         assertNotNull(problemDetails.getInstance());
         assertNotNull(problemDetails.getStatus());
-    }
-
-    @Test
-    void getEntryListing_WithOneField_ReturnEntries() {
-        String[] fieldNames = {"Sender"};
-        ODataValueContextOfIListOfEntry entries = client
-                .getEntryListing(new ParametersForGetEntryListing()
-                        .setRepoId(repositoryId)
-                        .setEntryId(1)
-                        .setFields(fieldNames)
-                        .setPrefer("maxpagesize=5"));
-        assertNotNull(entries);
-        for (Entry entry : entries.getValue()) {
-            int numberOfReturnedFields = (int) entry
-                    .getFields()
-                    .stream()
-                    .filter(entryFieldValue -> entryFieldValue
-                            .getFieldName()
-                            .equalsIgnoreCase(fieldNames[0]) || entryFieldValue
-                            .getFieldName()
-                            .equalsIgnoreCase(fieldNames[1]))
-                    .count();
-            assertEquals(fieldNames.length, numberOfReturnedFields);
-        }
     }
 
     @Test

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -23,19 +23,20 @@ public class ExportDocumentApiTest extends BaseTest {
     public void perTestSetup() {
         client = repositoryApiClient.getEntriesClient();
         auditReasonsClient = repositoryApiClient.getAuditReasonsClient();
+        exportedFile = null;
     }
 
     @AfterEach
     void perTestCleanUp() throws InterruptedException {
         if (exportedFile != null){
             exportedFile.delete();
-            exportedFile = null;
         }
     }
 
     @BeforeAll
     static void classSetup() {
         try {
+            // Import a document that will be exported by tests in this class
             String fileName = "RepositoryApiClientIntegrationTest Java ExportDocumentApiTest";
             String filePath = "src/test/java/com/laserfiche/repository/api/integration/test.pdf";
             File fileToImport = new File(filePath);

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -11,8 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.*;
-import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -26,7 +24,6 @@ public class ExportDocumentApiTest extends BaseTest {
     public void perTestSetup() {
         client = repositoryApiClient.getEntriesClient();
         auditReasonsClient = repositoryApiClient.getAuditReasonsClient();
-        createEmptyDocument();
     }
 
     @AfterEach
@@ -36,6 +33,8 @@ public class ExportDocumentApiTest extends BaseTest {
 
     @Test
     void exportDocument_Returns_Exported_File() {
+        createEmptyDocument();
+
         final String FILE_NAME = "exportDocument_temp_file.txt";
         Consumer<InputStream> consumer = inputStream -> {
             File exportedFile = new File(FILE_NAME);
@@ -67,6 +66,8 @@ public class ExportDocumentApiTest extends BaseTest {
 
     @Test
     void exportDocumentWithAuditReason_Returns_Exported_File() {
+        createEmptyDocument();
+
         AuditReasons auditReasons = auditReasonsClient.getAuditReasons(
                 new ParametersForGetAuditReasons().setRepoId(repositoryId));
         final String FILE_NAME = "exportDocument_temp_file.txt";
@@ -109,6 +110,8 @@ public class ExportDocumentApiTest extends BaseTest {
 
     @Test
     void exportDocumentAsStream_Returns_Exported_File() throws IOException {
+        createEmptyDocument();
+
         final String FILE_NAME = "exportDocument_temp_file.txt";
         Consumer<InputStream> consumer = inputStream -> {
             File exportedFile = new File(FILE_NAME);
@@ -144,6 +147,8 @@ public class ExportDocumentApiTest extends BaseTest {
 
     @Test
     void exportDocumentWithAuditReasonAsStream_Returns_Exported_File() throws IOException {
+        createEmptyDocument();
+
         AuditReasons auditReasons = auditReasonsClient.getAuditReasons(
                 new ParametersForGetAuditReasons().setRepoId(repositoryId));
         final String FILE_NAME = "exportDocument_temp_file.txt";
@@ -198,7 +203,7 @@ public class ExportDocumentApiTest extends BaseTest {
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocument(new ParametersForExportDocument()
                     .setRepoId(repositoryId)
-                    .setEntryId(-createdEntryId)
+                    .setEntryId(-1)
                     .setInputStreamConsumer(consumer));
         });
         Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')",
@@ -228,7 +233,7 @@ public class ExportDocumentApiTest extends BaseTest {
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocumentWithAuditReason(new ParametersForExportDocumentWithAuditReason()
                     .setRepoId(repositoryId)
-                    .setEntryId(-createdEntryId)
+                    .setEntryId(-1)
                     .setInputStreamConsumer(consumer)
                     .setRequestBody(requestBody));
         });
@@ -248,7 +253,7 @@ public class ExportDocumentApiTest extends BaseTest {
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocumentAsStream(new ParametersForExportDocument()
                     .setRepoId(repositoryId)
-                    .setEntryId(-createdEntryId)
+                    .setEntryId(-1)
                     .setInputStreamConsumer(consumer));
         });
         Assertions.assertEquals("Specified argument was out of the range of valid values. (Parameter 'entryId')",
@@ -278,7 +283,7 @@ public class ExportDocumentApiTest extends BaseTest {
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocumentWithAuditReasonAsStream(new ParametersForExportDocumentWithAuditReason()
                     .setRepoId(repositoryId)
-                    .setEntryId(-createdEntryId)
+                    .setEntryId(-1)
                     .setInputStreamConsumer(consumer)
                     .setRequestBody(requestBody));
         });
@@ -291,7 +296,7 @@ public class ExportDocumentApiTest extends BaseTest {
 
     private void createEmptyDocument() {
         try {
-            String fileName = "JavaClientLibrary_ExportDocumentApiTest";
+            String fileName = "RepositoryApiClientIntegrationTest Java ExportDocumentApiTest";
             File toUpload = File.createTempFile(fileName, "txt");
             CreateEntryResult result = client
                     .importDocument(new ParametersForImportDocument()

--- a/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
@@ -8,7 +8,7 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetFieldDefinit
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -41,7 +41,7 @@ class FieldDefinitionsApiTest extends BaseTest {
 
     @Test
     void getFieldDefinitions_NextLink() throws InterruptedException {
-        int maxPageSize = 10;
+        int maxPageSize = 3;
         ODataValueContextOfIListOfWFieldInfo fieldInfoList = client
                 .getFieldDefinitions(new ParametersForGetFieldDefinitions()
                         .setRepoId(repositoryId)
@@ -66,9 +66,11 @@ class FieldDefinitionsApiTest extends BaseTest {
 
     @Test
     void getFieldDefinitions_ForEach() {
-        int maxPageSize = 10;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 3;
         Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback = fieldInfoList -> {
-            if (fieldInfoList.getOdataNextLink() != null) {
+            if (fieldInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, fieldInfoList
                         .getValue()
                         .size());
@@ -82,5 +84,6 @@ class FieldDefinitionsApiTest extends BaseTest {
         };
         client.getFieldDefinitionsForEach(callback, maxPageSize,
                 new ParametersForGetFieldDefinitions().setRepoId(repositoryId));
+        assertTrue(pageCount.get() > 1);
     }
 }

--- a/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
@@ -70,7 +70,7 @@ class FieldDefinitionsApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 3;
         Function<ODataValueContextOfIListOfWFieldInfo, Boolean> callback = fieldInfoList -> {
-            if (fieldInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && fieldInfoList.getOdataNextLink() != null) {
                 assertNotEquals(0, fieldInfoList
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
@@ -52,7 +52,7 @@ public class ImportDocumentApiTest extends BaseTest {
                     .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
-            if (templateDefinitionFieldsResult.getValue() != null && noTemplateFieldDefinitionsRequired(
+            if (templateDefinitionFieldsResult.getValue() != null && noRequiredFieldDefinitionsInTemplate(
                     templateDefinitionFieldsResult.getValue())) {
                 template = templateDefinition;
                 break;

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
@@ -6,10 +6,7 @@ import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
 import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
 import com.laserfiche.repository.api.clients.params.ParametersForImportDocument;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 
 import java.io.*;
 import java.net.HttpURLConnection;
@@ -20,19 +17,24 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class ImportDocumentApiTest extends BaseTest {
-    EntriesClient client;
+    static Entry testClassParentFolder;
 
-    int createdEntryId;
+    EntriesClient client;
 
     @BeforeEach
     public void perTestSetup() {
         client = repositoryApiClient.getEntriesClient();
-        createdEntryId = 0;
     }
 
-    @AfterEach
-    void perTestCleanUp() throws InterruptedException {
-        deleteEntry(createdEntryId);
+    @BeforeAll
+    static void classSetup() {
+        String name = "RepositoryApiClientIntegrationTest Java TestClassParentFolder";
+        testClassParentFolder = createEntry(repositoryApiClient, name, 1, true);
+    }
+
+    @AfterAll
+    static void classCleanUp() throws InterruptedException {
+        deleteEntry(testClassParentFolder.getId());
     }
 
     @Test
@@ -58,7 +60,6 @@ public class ImportDocumentApiTest extends BaseTest {
         }
         assertNotNull(template);
 
-        int parentEntryId = 1;
         String fileName = "myFile";
         File toUpload = null;
         try {
@@ -73,7 +74,7 @@ public class ImportDocumentApiTest extends BaseTest {
         CreateEntryResult result = client
                 .importDocument(new ParametersForImportDocument()
                         .setRepoId(repositoryId)
-                        .setParentEntryId(parentEntryId)
+                        .setParentEntryId(testClassParentFolder.getId())
                         .setFileName(fileName)
                         .setAutoRename(true)
                         .setInputStream(new FileInputStream(toUpload))
@@ -86,7 +87,7 @@ public class ImportDocumentApiTest extends BaseTest {
                 .getEntryCreate()
                 .getExceptions()
                 .size());
-        createdEntryId = operations
+        int createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
         assertTrue(createdEntryId > 0);
@@ -115,7 +116,7 @@ public class ImportDocumentApiTest extends BaseTest {
         result = client
                 .importDocument(new ParametersForImportDocument()
                         .setRepoId(repositoryId)
-                        .setParentEntryId(1)
+                        .setParentEntryId(testClassParentFolder.getId())
                         .setFileName(fileName)
                         .setAutoRename(true)
                         .setInputStream(inputStream)
@@ -126,7 +127,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        createdEntryId = operations
+        int createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
         assertTrue(createdEntryId > 0);
@@ -151,7 +152,7 @@ public class ImportDocumentApiTest extends BaseTest {
         result = client
                 .importDocument(new ParametersForImportDocument()
                         .setRepoId(repositoryId)
-                        .setParentEntryId(1)
+                        .setParentEntryId(testClassParentFolder.getId())
                         .setFileName(fileName)
                         .setAutoRename(true)
                         .setInputStream(inputStream)
@@ -162,7 +163,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        createdEntryId = operations
+        int createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
         assertTrue(createdEntryId > 0);
@@ -188,7 +189,7 @@ public class ImportDocumentApiTest extends BaseTest {
         ApiException apiException = assertThrows(ApiException.class, () -> client
                 .importDocument(new ParametersForImportDocument()
                         .setRepoId(repositoryId)
-                        .setParentEntryId(1)
+                        .setParentEntryId(testClassParentFolder.getId())
                         .setFileName(fileName)
                         .setAutoRename(true)
                         .setInputStream(inputStream)
@@ -208,7 +209,7 @@ public class ImportDocumentApiTest extends BaseTest {
 
         assertNotNull(operations);
         assertNotNull(result.getDocumentLink());
-        createdEntryId = operations
+        int createdEntryId = operations
                 .getEntryCreate()
                 .getEntryId();
         assertTrue(createdEntryId > 0);

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
@@ -3,7 +3,6 @@ package com.laserfiche.repository.api.integration;
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
-import com.laserfiche.repository.api.clients.params.ParametersForDeleteEntryInfo;
 import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateDefinitions;
 import com.laserfiche.repository.api.clients.params.ParametersForGetTemplateFieldDefinitions;
 import com.laserfiche.repository.api.clients.params.ParametersForImportDocument;
@@ -15,10 +14,8 @@ import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -39,46 +36,6 @@ public class ImportDocumentApiTest extends BaseTest {
     }
 
     @Test
-    void importDocument_DocumentCreated_FromFile() throws FileNotFoundException {
-        String fileName = "myFile";
-        File toUpload = null;
-        try {
-            toUpload = File.createTempFile(fileName, "txt");
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        assertNotNull(toUpload);
-
-        CreateEntryResult result = client
-                .importDocument(new ParametersForImportDocument()
-                        .setRepoId(repositoryId)
-                        .setParentEntryId(1)
-                        .setFileName(fileName)
-                        .setAutoRename(true)
-                        .setInputStream(new FileInputStream(toUpload))
-                        .setRequestBody(new PostEntryWithEdocMetadataRequest()));
-
-        assertNotNull(result);
-        CreateEntryOperations operations = result.getOperations();
-
-        assertNotNull(operations);
-        assertNotNull(result.getDocumentLink());
-        createdEntryId = operations
-                .getEntryCreate()
-                .getEntryId();
-        assertTrue(createdEntryId > 0);
-        assertEquals(0, operations
-                .getEntryCreate()
-                .getExceptions()
-                .size());
-        assertEquals(0, operations
-                .getSetEdoc()
-                .getExceptions()
-                .size());
-    }
-
-    @Test
     void importDocument_DocumentCreated_FromFile_WithTemplate() throws ExecutionException, InterruptedException, FileNotFoundException {
         WTemplateInfo template = null;
         ODataValueContextOfIListOfWTemplateInfo templateDefinitionResult = repositoryApiClient
@@ -93,7 +50,7 @@ public class ImportDocumentApiTest extends BaseTest {
                     .getTemplateFieldDefinitions(new ParametersForGetTemplateFieldDefinitions()
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
-            if (templateDefinitionFieldsResult.getValue() != null && allFalse(
+            if (templateDefinitionFieldsResult.getValue() != null && noTemplateFieldDefinitionsRequired(
                     templateDefinitionFieldsResult.getValue())) {
                 template = templateDefinition;
                 break;

--- a/src/test/java/com/laserfiche/repository/api/integration/RepositoriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/RepositoriesApiTest.java
@@ -3,17 +3,14 @@ package com.laserfiche.repository.api.integration;
 import com.laserfiche.repository.api.clients.RepositoriesClient;
 import com.laserfiche.repository.api.clients.impl.RepositoriesClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.RepositoryInfo;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled("Skipped failed test for now")
 class RepositoriesApiTest extends BaseTest {
     @Test
-    @Disabled("To be updated for payload compression")
     void getRepositoryList_ReturnSuccessful() {
         RepositoriesClient client = repositoryApiClient.getRepositoryClient();
         RepositoryInfo[] repositoryInfoList = client.getRepositoryList();

--- a/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
@@ -35,7 +35,7 @@ public class SearchApiTest extends BaseTest {
     @Test
     void getSearchContextHits_ReturnContextHits() throws InterruptedException {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"DLT\"})");
+        request.setSearchCommand("{LF:Basic ~= \"Laserfiche\", option=\"DLT\"} & {LF:name=\"Laserfiche Cloud Overview\", Type=\"DFS\"}");
 
         AcceptedOperation searchResponse = client
                 .createSearchOperation(new ParametersForCreateSearchOperation()
@@ -188,7 +188,7 @@ public class SearchApiTest extends BaseTest {
         WaitUntilSearchEnds(searchResponse);
 
         Function<ODataValueContextOfIListOfEntry, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && data.getOdataNextLink() != null) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());
@@ -210,8 +210,7 @@ public class SearchApiTest extends BaseTest {
     void getSearchContextHits_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"ALT\"})");
-        request.setFuzzyFactor(2);
+        request.setSearchCommand("{LF:Basic ~= \"Laserfiche\", option=\"DLT\"} & {LF:name=\"Laserfiche Cloud Overview\", Type=\"DFS\"}");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
@@ -268,8 +267,7 @@ public class SearchApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"ALT\"})");
-        request.setFuzzyFactor(2);
+        request.setSearchCommand("{LF:Basic ~= \"Laserfiche\", option=\"DLT\"} & {LF:name=\"Laserfiche Cloud Overview\", Type=\"DFS\"}");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
@@ -296,7 +294,7 @@ public class SearchApiTest extends BaseTest {
                 .getRowNumber();
 
         Function<ODataValueContextOfIListOfContextHit, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && data.getOdataNextLink() != null) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
@@ -5,15 +5,14 @@ import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-@Disabled("Rate limiting issue")
 public class SearchApiTest extends BaseTest {
     SearchesClient client;
     private String searchToken = "";
@@ -36,8 +35,7 @@ public class SearchApiTest extends BaseTest {
     @Test
     void getSearchContextHits_ReturnContextHits() throws InterruptedException {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
-        request.setFuzzyFactor(2);
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"DLT\"})");
 
         AcceptedOperation searchResponse = client
                 .createSearchOperation(new ParametersForCreateSearchOperation()
@@ -49,33 +47,18 @@ public class SearchApiTest extends BaseTest {
 
         WaitUntilSearchEnds(searchResponse);
 
-        ODataValueContextOfIListOfEntry searchResults = client.getSearchResults(new ParametersForGetSearchResults()
-                .setRepoId(repositoryId)
-                .setSearchToken(searchToken));
-
-        assertNotNull(searchResults);
-        assertTrue(searchResults
-                .getValue()
-                .size() > 0);
-
-        int rowNum = searchResults
-                .getValue()
-                .get(0)
-                .getRowNumber();
-
         ODataValueContextOfIListOfContextHit contextHitResponse = client
                 .getSearchContextHits(new ParametersForGetSearchContextHits()
                         .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
-                        .setRowNumber(rowNum));
-
+                        .setRowNumber(1));
         assertNotNull(contextHitResponse);
     }
 
     @Test
     void getSearchResults_ReturnSearchResults() throws InterruptedException {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
@@ -97,7 +80,7 @@ public class SearchApiTest extends BaseTest {
     @Test
     void getSearchStatus_ReturnSearchStatus() throws InterruptedException {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
@@ -118,7 +101,7 @@ public class SearchApiTest extends BaseTest {
     @Test
     void closeSearchOperations_CloseSearch() throws InterruptedException {
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         AcceptedOperation searchOperationResponse = client
                 .createSearchOperation(new ParametersForCreateSearchOperation()
@@ -144,7 +127,7 @@ public class SearchApiTest extends BaseTest {
         int maxPageSize = 1;
 
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
@@ -186,10 +169,11 @@ public class SearchApiTest extends BaseTest {
 
     @Test
     void getSearchResults_ForEach() throws InterruptedException {
-        int maxPageSize = 1;
-
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 3;
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"search text\", option=\"NLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         AcceptedOperation searchResponse = client.createSearchOperation(
                 new ParametersForCreateSearchOperation()
@@ -204,7 +188,7 @@ public class SearchApiTest extends BaseTest {
         WaitUntilSearchEnds(searchResponse);
 
         Function<ODataValueContextOfIListOfEntry, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null) {
+            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());
@@ -219,13 +203,14 @@ public class SearchApiTest extends BaseTest {
         client.getSearchResultsForEach(callback, maxPageSize, new ParametersForGetSearchResults()
                 .setRepoId(repositoryId)
                 .setSearchToken(searchToken));
+        assertTrue(pageCount.get() > 1);
     }
 
     @Test
     void getSearchContextHits_NextLink() throws InterruptedException {
         int maxPageSize = 1;
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"ALT\"})");
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
@@ -257,13 +242,14 @@ public class SearchApiTest extends BaseTest {
                 .getSearchContextHits(new ParametersForGetSearchContextHits()
                         .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
-                        .setRowNumber(rowNum));
+                        .setRowNumber(rowNum)
+                        .setPrefer(String.format("maxpagesize=%d", maxPageSize)));
 
         assertNotNull(contextHitResponse);
 
-        String nextLink = searchResults.getOdataNextLink();
+        String nextLink = contextHitResponse.getOdataNextLink();
         assertNotNull(nextLink);
-        assertTrue(searchResults
+        assertTrue(contextHitResponse
                 .getValue()
                 .size() <= maxPageSize);
 
@@ -278,16 +264,17 @@ public class SearchApiTest extends BaseTest {
 
     @Test
     void getSearchContextHits_ForEach() throws InterruptedException {
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
         int maxPageSize = 1;
         AdvancedSearchRequest request = new AdvancedSearchRequest();
-        request.setSearchCommand("({LF:Basic ~= \"*\", option=\"DFANLT\"})");
+        request.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"ALT\"})");
         request.setFuzzyFactor(2);
 
         AcceptedOperation searchResponse = client.createSearchOperation(new ParametersForCreateSearchOperation()
                 .setRepoId(repositoryId)
                 .setRequestBody(request));
         searchToken = searchResponse.getToken();
-
         assertNotNull(searchToken);
 
         WaitUntilSearchEnds(searchResponse);
@@ -308,16 +295,8 @@ public class SearchApiTest extends BaseTest {
                 .get(0)
                 .getRowNumber();
 
-        ODataValueContextOfIListOfContextHit contextHitResponse = client
-                .getSearchContextHits(new ParametersForGetSearchContextHits()
-                        .setRepoId(repositoryId)
-                        .setSearchToken(searchToken)
-                        .setRowNumber(rowNum));
-
-        assertNotNull(contextHitResponse);
-
         Function<ODataValueContextOfIListOfContextHit, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null) {
+            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());
@@ -333,6 +312,7 @@ public class SearchApiTest extends BaseTest {
                 new ParametersForGetSearchContextHits()
                         .setRepoId(repositoryId)
                         .setSearchToken(searchToken)
-                        .setRowNumber(1));
+                        .setRowNumber(rowNum));
+        assertTrue(pageCount.get() > 1);
     }
 }

--- a/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
@@ -3,7 +3,8 @@ package com.laserfiche.repository.api.integration;
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.*;
-import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -15,13 +16,19 @@ import java.util.concurrent.ExecutionException;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SetEntriesApiTest extends BaseTest {
+    static Entry testClassParentFolder;
+
     RepositoryApiClient client = repositoryApiClient;
 
-    Entry entry;
+    @BeforeAll
+    static void classSetup() {
+        String name = "RepositoryApiClientIntegrationTest Java TestClassParentFolder";
+        testClassParentFolder = createEntry(repositoryApiClient, name, 1, true);
+    }
 
-    @AfterEach
-    void perTestCleanUp() throws InterruptedException {
-        deleteEntry(entry.getId());
+    @AfterAll
+    static void classCleanUp() throws InterruptedException {
+        deleteEntry(testClassParentFolder.getId());
     }
 
     @Test
@@ -42,7 +49,7 @@ public class SetEntriesApiTest extends BaseTest {
         request
                 .getTags()
                 .add(tag);
-        entry = createEntry(client, "RepositoryApiClientIntegrationTest Java SetTags", 1, true);
+        Entry entry = createEntry(client, "RepositoryApiClientIntegrationTest Java SetTags", testClassParentFolder.getId(), true);
         Integer num = entry.getId();
 
         ODataValueOfIListOfWTagInfo assignTagsResponse = repositoryApiClient
@@ -87,7 +94,7 @@ public class SetEntriesApiTest extends BaseTest {
 
         PutTemplateRequest request = new PutTemplateRequest();
         request.setTemplateName(template.getName());
-        entry = createEntry(client, "RepositoryApiClientIntegrationTest Java DeleteTemplate", 1, true);
+        Entry entry = createEntry(client, "RepositoryApiClientIntegrationTest Java DeleteTemplate", testClassParentFolder.getId(), true);
 
         Entry setTemplateResponse = repositoryApiClient
                 .getEntriesClient()
@@ -141,7 +148,7 @@ public class SetEntriesApiTest extends BaseTest {
         valueToUpdate.setPosition(1);
         valueToUpdate.setValue(fieldValue);
 
-        entry = createEntry(client, "RepositoryApiClientIntegrationTest Java SetFields", 1, true);
+        Entry entry = createEntry(client, "RepositoryApiClientIntegrationTest Java SetFields", testClassParentFolder.getId(), true);
         Integer entryId = entry
                 .getId();
 
@@ -192,7 +199,7 @@ public class SetEntriesApiTest extends BaseTest {
         PutTemplateRequest request = new PutTemplateRequest();
         request.setTemplateName(template.getName());
 
-        entry = createEntry(client, "RepositoryApiClientIntegrationTest Java DeleteTemplate", 1, true);
+        Entry entry = createEntry(client, "RepositoryApiClientIntegrationTest Java DeleteTemplate", testClassParentFolder.getId(), true);
 
         Entry writeTemplateValueToEntryResponse = client
                 .getEntriesClient()

--- a/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
@@ -84,7 +84,7 @@ public class SetEntriesApiTest extends BaseTest {
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
-                    .getValue() != null && noTemplateFieldDefinitionsRequired(templateDefinitionsFieldsResponse.getValue())) {
+                    .getValue() != null && noRequiredFieldDefinitionsInTemplate(templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
                 break;
             }
@@ -187,7 +187,7 @@ public class SetEntriesApiTest extends BaseTest {
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
-                    .getValue() != null && noTemplateFieldDefinitionsRequired(
+                    .getValue() != null && noRequiredFieldDefinitionsInTemplate(
                     templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
                 break;

--- a/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
@@ -6,20 +6,16 @@ import com.laserfiche.repository.api.clients.params.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class SetEntriesApiTest extends BaseTest {
     RepositoryApiClient client = repositoryApiClient;
-
-    RepositoryApiClient createEntryClient = repositoryApiClient;
 
     Entry entry;
 
@@ -81,7 +77,7 @@ public class SetEntriesApiTest extends BaseTest {
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
-                    .getValue() != null && allFalse(templateDefinitionsFieldsResponse.getValue())) {
+                    .getValue() != null && noTemplateFieldDefinitionsRequired(templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
                 break;
             }
@@ -111,7 +107,7 @@ public class SetEntriesApiTest extends BaseTest {
         WFieldInfo field = null;
         String fieldValue = "a";
 
-        // Find a field definition that accepts String and has constraint.
+        // Find a field definition that accepts String and has no constraint.
         ODataValueContextOfIListOfWFieldInfo fieldDefinitionsResponse = repositoryApiClient
                 .getFieldDefinitionsClient()
                 .getFieldDefinitions(new ParametersForGetFieldDefinitions().setRepoId(repositoryId));
@@ -184,7 +180,7 @@ public class SetEntriesApiTest extends BaseTest {
                             .setRepoId(repositoryId)
                             .setTemplateId(templateDefinition.getId()));
             if (templateDefinitionsFieldsResponse
-                    .getValue() != null && allFalse(
+                    .getValue() != null && noTemplateFieldDefinitionsRequired(
                     templateDefinitionsFieldsResponse.getValue())) {
                 template = templateDefinition;
                 break;
@@ -196,7 +192,7 @@ public class SetEntriesApiTest extends BaseTest {
         PutTemplateRequest request = new PutTemplateRequest();
         request.setTemplateName(template.getName());
 
-        entry = createEntry(createEntryClient, "RepositoryApiClientIntegrationTest Java DeleteTemplate", 1, true);
+        entry = createEntry(client, "RepositoryApiClientIntegrationTest Java DeleteTemplate", 1, true);
 
         Entry writeTemplateValueToEntryResponse = client
                 .getEntriesClient()

--- a/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesApiTest.java
@@ -14,7 +14,7 @@ class SimpleSearchesApiTest extends BaseTest {
         SimpleSearchesClient client = repositoryApiClient.getSimpleSearchesClient();
 
         SimpleSearchRequest searchRequest = new SimpleSearchRequest();
-        searchRequest.setSearchCommand("({LF:Basic ~= \"search text\", option=\"DFANLT\"})");
+        searchRequest.setSearchCommand("({LF:Basic ~= \"Laserfiche\", option=\"NLT\"})");
 
         ODataValueOfIListOfEntry entryList = client
                 .createSimpleSearchOperation(new ParametersForCreateSimpleSearchOperation()

--- a/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
@@ -60,7 +60,7 @@ class TagDefinitionsApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && data.getOdataNextLink() != null) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
@@ -8,7 +8,7 @@ import com.laserfiche.repository.api.clients.params.ParametersForGetTagDefinitio
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -56,14 +56,11 @@ class TagDefinitionsApiTest extends BaseTest {
 
     @Test
     void getTagDefinitions_ForEach() throws InterruptedException {
-        ODataValueContextOfIListOfWTagInfo tagInfoList = client
-                .getTagDefinitions(new ParametersForGetTagDefinitions().setRepoId(repositoryId));
-
-        assertNotNull(tagInfoList);
-
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 1;
         Function<ODataValueContextOfIListOfWTagInfo, Boolean> callback = data -> {
-            if (data.getOdataNextLink() != null) {
+            if (data.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, data
                         .getValue()
                         .size());
@@ -77,6 +74,7 @@ class TagDefinitionsApiTest extends BaseTest {
         };
         client.getTagDefinitionsForEach(callback, maxPageSize, new ParametersForGetTagDefinitions().setRepoId(
                 repositoryId));
+        assertTrue(pageCount.get() > 1);
     }
 
     @Test

--- a/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
@@ -87,7 +87,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 3;
         Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback = listOfWTemplateInfo -> {
-            if (listOfWTemplateInfo.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && listOfWTemplateInfo.getOdataNextLink() != null) {
                 assertNotEquals(0, listOfWTemplateInfo
                         .getValue()
                         .size());
@@ -160,7 +160,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         int maxPages = 2;
         int maxPageSize = 1;
         Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback = fieldInfoList -> {
-            if (fieldInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
+            if (pageCount.incrementAndGet() <= maxPages && fieldInfoList.getOdataNextLink() != null) {
                 assertNotEquals(0, fieldInfoList
                         .getValue()
                         .size());

--- a/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -39,12 +39,10 @@ class TemplateDefinitionsApiTest extends BaseTest {
     void getTemplateDefinitionsFields_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
-
+        assertNotNull(templateInfoList);
         WTemplateInfo tempDef = templateInfoList
                 .getValue()
                 .get(0);
-
-        assertNotNull(templateInfoList);
 
         ODataValueContextOfIListOfTemplateFieldInfo result = client
                 .getTemplateFieldDefinitions(
@@ -85,14 +83,11 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
     @Test
     void getTemplateDefinitions_ForEach() throws InterruptedException {
-        ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
-                .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
-
-        assertNotNull(templateInfoList);
-
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 3;
         Function<ODataValueContextOfIListOfWTemplateInfo, Boolean> callback = listOfWTemplateInfo -> {
-            if (listOfWTemplateInfo.getOdataNextLink() != null) {
+            if (listOfWTemplateInfo.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, listOfWTemplateInfo
                         .getValue()
                         .size());
@@ -106,6 +101,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
         };
         client.getTemplateDefinitionsForEach(callback, maxPageSize,
                 new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
+        assertTrue(pageCount.get() > 1);
     }
 
     @Test
@@ -160,20 +156,11 @@ class TemplateDefinitionsApiTest extends BaseTest {
 
         assertNotNull(templateInfoList);
 
-        ODataValueContextOfIListOfTemplateFieldInfo result = client
-                .getTemplateFieldDefinitions(
-                        new ParametersForGetTemplateFieldDefinitions()
-                                .setRepoId(repositoryId)
-                                .setTemplateId(tempDef.getId()));
-
-        assertNotNull(result);
-        Assertions.assertSame(result
-                .getValue()
-                .size(), tempDef.getFieldCount());
-
-        int maxPageSize = 90;
+        AtomicInteger pageCount = new AtomicInteger();
+        int maxPages = 2;
+        int maxPageSize = 1;
         Function<ODataValueContextOfIListOfTemplateFieldInfo, Boolean> callback = fieldInfoList -> {
-            if (fieldInfoList.getOdataNextLink() != null) {
+            if (fieldInfoList.getOdataNextLink() != null && pageCount.incrementAndGet() <= maxPages) {
                 assertNotEquals(0, fieldInfoList
                         .getValue()
                         .size());
@@ -189,10 +176,11 @@ class TemplateDefinitionsApiTest extends BaseTest {
                 new ParametersForGetTemplateFieldDefinitions()
                         .setRepoId(repositoryId)
                         .setTemplateId(tempDef.getId()));
+        assertTrue(pageCount.get() > 1);
     }
 
     @Test
-    void getTemplateDefinitionsFieldsById_ReturnTemplate() {
+    void getTemplateDefinitionById_ReturnTemplate() {
         ODataValueContextOfIListOfWTemplateInfo templateInfoList = client
                 .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
 
@@ -231,7 +219,7 @@ class TemplateDefinitionsApiTest extends BaseTest {
     }
 
     @Test
-    void getTemplateDefinitionsByTemplateName_ReturnTemplateFields() {
+    void getTemplateDefinitionsFieldByTemplateName_ReturnTemplateFields() {
         ODataValueContextOfIListOfWTemplateInfo allTemplateDefinitionsFuture = client
                 .getTemplateDefinitions(new ParametersForGetTemplateDefinitions().setRepoId(repositoryId));
         WTemplateInfo firstTemplateDefinitions = allTemplateDefinitionsFuture

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetCreateEntryResultSumaryTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetCreateEntryResultSumaryTest.java
@@ -1,4 +1,4 @@
-package com.laserfiche.repository.api.unit;
+package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
@@ -1,4 +1,4 @@
-package com.laserfiche.repository.api.unit;
+package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;
 import kong.unirest.Headers;
@@ -52,6 +52,18 @@ public class GetHeadersTest {
         Map<String, String> result = ApiClientUtils.getHeadersMap(header);
         assertNotNull(headerParametersWithStringTypeValue);
         assertEquals(result, headerParametersWithStringTypeValue);
+    }
+
+    @Test
+    void getHeadersMap_DuplicateKeys() {
+        String headerKey = "test";
+        String expectedValue = "0, 1, 2, 3, 4";
+        for (int i = 0; i < 5; i++) {
+            header.add(headerKey, Integer.toString(i));
+        }
+        Map<String, String> result = ApiClientUtils.getHeadersMap(header);
+        assertNotNull(headerParametersWithStringTypeValue);
+        assertEquals(expectedValue, result.get(headerKey));
     }
 
     @Test

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
@@ -1,4 +1,4 @@
-package com.laserfiche.repository.api.unit;
+package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;
 import kong.unirest.HttpMethod;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
@@ -1,4 +1,4 @@
-package com.laserfiche.repository.api.unit;
+package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
- Merge response headers with same key by comma concatenating into single response header. See the RFC specs on this for more information https://www.rfc-editor.org/rfc/rfc9110.html#name-field-order   
- Enable all integration tests
- Reduce the number of delete entry calls when cleaning up each tests. A folder is created before running a test class and all new entries will be created in the folder. After the test class is finished, the folder containing all test files are deleted in one delete entry call. 
- Set a max limit of times to page through results