### PR TITLE
added test case conditions and conditional method

### DIFF
--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -1,15 +1,21 @@
 package com.laserfiche.repository.api.integration;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.repository.api.clients.AuditReasonsClient;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
-import com.laserfiche.repository.api.clients.params.*;
+import com.laserfiche.repository.api.clients.params.ParametersForExportDocument;
+import com.laserfiche.repository.api.clients.params.ParametersForExportDocumentWithAuditReason;
+import com.laserfiche.repository.api.clients.params.ParametersForGetAuditReasons;
+import com.laserfiche.repository.api.clients.params.ParametersForImportDocument;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
+
 import java.io.*;
 import java.util.function.Consumer;
-import org.junit.jupiter.api.*;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExportDocumentApiTest extends BaseTest {
     private EntriesClient client;
@@ -51,7 +57,9 @@ public class ExportDocumentApiTest extends BaseTest {
                             .setRequestBody(new PostEntryWithEdocMetadataRequest()));
 
             CreateEntryOperations operations = result.getOperations();
-            testEntryId = operations.getEntryCreate().getEntryId();
+            testEntryId = operations
+                    .getEntryCreate()
+                    .getEntryId();
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -63,6 +71,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @EnabledIf("doAuditReasonsNotExist")
     void exportDocument_Returns_Exported_File() {
         final String FILE_NAME = "exportDocument_temp_file.txt";
         Consumer<InputStream> consumer = inputStream -> {
@@ -92,6 +101,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @DisabledIf("doAuditReasonsNotExist")
     void exportDocumentWithAuditReason_Returns_Exported_File() {
         AuditReasons auditReasons =
                 auditReasonsClient.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repositoryId));
@@ -113,8 +123,14 @@ public class ExportDocumentApiTest extends BaseTest {
             }
         };
         GetEdocWithAuditReasonRequest requestBody = new GetEdocWithAuditReasonRequest();
-        requestBody.setAuditReasonId(auditReasons.getExportDocument().get(0).getId());
-        requestBody.setComment(auditReasons.getExportDocument().get(0).getName());
+        requestBody.setAuditReasonId(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getId());
+        requestBody.setComment(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getName());
         client.exportDocumentWithAuditReason(new ParametersForExportDocumentWithAuditReason()
                 .setRepoId(repositoryId)
                 .setEntryId(testEntryId)
@@ -126,6 +142,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @EnabledIf("doAuditReasonsNotExist")
     void exportDocumentAsStream_Returns_Exported_File() throws IOException {
         final String FILE_NAME = "exportDocument_temp_file.txt";
         Consumer<InputStream> consumer = inputStream -> {
@@ -149,7 +166,9 @@ public class ExportDocumentApiTest extends BaseTest {
                 .setEntryId(testEntryId)
                 .setInputStreamConsumer(consumer);
         InputStream inputStream = client.exportDocumentAsStream(input);
-        input.getInputStreamConsumer().accept(inputStream);
+        input
+                .getInputStreamConsumer()
+                .accept(inputStream);
         inputStream.close();
         exportedFile = new File(FILE_NAME);
         assertTrue(exportedFile.exists());
@@ -157,6 +176,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @DisabledIf("doAuditReasonsNotExist")
     void exportDocumentWithAuditReasonAsStream_Returns_Exported_File() throws IOException {
         AuditReasons auditReasons =
                 auditReasonsClient.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repositoryId));
@@ -178,15 +198,23 @@ public class ExportDocumentApiTest extends BaseTest {
             }
         };
         GetEdocWithAuditReasonRequest requestBody = new GetEdocWithAuditReasonRequest();
-        requestBody.setAuditReasonId(auditReasons.getExportDocument().get(0).getId());
-        requestBody.setComment(auditReasons.getExportDocument().get(0).getName());
+        requestBody.setAuditReasonId(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getId());
+        requestBody.setComment(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getName());
         ParametersForExportDocumentWithAuditReason input = new ParametersForExportDocumentWithAuditReason()
                 .setRepoId(repositoryId)
                 .setEntryId(testEntryId)
                 .setInputStreamConsumer(consumer)
                 .setRequestBody(requestBody);
         InputStream inputStream = client.exportDocumentWithAuditReasonAsStream(input);
-        input.getInputStreamConsumer().accept(inputStream);
+        input
+                .getInputStreamConsumer()
+                .accept(inputStream);
         inputStream.close();
         exportedFile = new File(FILE_NAME);
         assertTrue(exportedFile.exists());
@@ -213,6 +241,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @DisabledIf("doAuditReasonsNotExist")
     void exportDocumentWithAuditReason_Returns_Error_For_Invalid_EntryId() {
         AuditReasons auditReasons =
                 auditReasonsClient.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repositoryId));
@@ -221,8 +250,14 @@ public class ExportDocumentApiTest extends BaseTest {
             assertTrue(false, "Consumer should not have been called.");
         };
         GetEdocWithAuditReasonRequest requestBody = new GetEdocWithAuditReasonRequest();
-        requestBody.setAuditReasonId(auditReasons.getExportDocument().get(0).getId());
-        requestBody.setComment(auditReasons.getExportDocument().get(0).getName());
+        requestBody.setAuditReasonId(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getId());
+        requestBody.setComment(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getName());
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocumentWithAuditReason(new ParametersForExportDocumentWithAuditReason()
                     .setRepoId(repositoryId)
@@ -257,6 +292,7 @@ public class ExportDocumentApiTest extends BaseTest {
     }
 
     @Test
+    @DisabledIf("doAuditReasonsNotExist")
     void exportDocumentWithAuditReasonAsStream_Returns_Error_For_Invalid_EntryId() {
         AuditReasons auditReasons =
                 auditReasonsClient.getAuditReasons(new ParametersForGetAuditReasons().setRepoId(repositoryId));
@@ -265,8 +301,14 @@ public class ExportDocumentApiTest extends BaseTest {
             assertTrue(false, "Consumer should not have been called.");
         };
         GetEdocWithAuditReasonRequest requestBody = new GetEdocWithAuditReasonRequest();
-        requestBody.setAuditReasonId(auditReasons.getExportDocument().get(0).getId());
-        requestBody.setComment(auditReasons.getExportDocument().get(0).getName());
+        requestBody.setAuditReasonId(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getId());
+        requestBody.setComment(auditReasons
+                .getExportDocument()
+                .get(0)
+                .getName());
         Exception thrown = Assertions.assertThrows(ApiException.class, () -> {
             client.exportDocumentWithAuditReasonAsStream(new ParametersForExportDocumentWithAuditReason()
                     .setRepoId(repositoryId)
@@ -279,5 +321,18 @@ public class ExportDocumentApiTest extends BaseTest {
         File exportedFile = new File(FILE_NAME);
         assertNotNull(exportedFile);
         assertFalse(exportedFile.exists());
+    }
+
+    boolean doAuditReasonsNotExist() {
+        try {
+            AuditReasons auditReasons = repositoryApiClient.getAuditReasonsClient().getAuditReasons(
+                    new ParametersForGetAuditReasons().setRepoId(repositoryId));
+            if(auditReasons.getExportDocument().size() == 0){
+                return true;
+            }
+        } catch (Exception e) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -324,9 +324,13 @@ public class ExportDocumentApiTest extends BaseTest {
 
     boolean doAuditReasonsNotExist() {
         try {
-            AuditReasons auditReasons = repositoryApiClient.getAuditReasonsClient().getAuditReasons(
-                    new ParametersForGetAuditReasons().setRepoId(repositoryId));
-            if(auditReasons.getExportDocument().size() == 0){
+            AuditReasons auditReasons = repositoryApiClient
+                    .getAuditReasonsClient()
+                    .getAuditReasons(
+                            new ParametersForGetAuditReasons().setRepoId(repositoryId));
+            if (auditReasons
+                    .getExportDocument()
+                    .size() == 0) {
                 return true;
             }
         } catch (Exception e) {


### PR DESCRIPTION
Added a conditional method to check if audit reasons exists
- added `doAuditReasonsNotExist()` conditional method which will return `true` if no audit reasons exists or when an exception gets thrown and return `false` if at least one audit reason exists
- if there are audit reasons, then run some certain test cases (i.e. all happy path `exportDocument_WithAuditReasons` test cases) and skip some other ones (i.e. all happy path `exportDocument` test cases)
- if there are no audit reasons, then run all happy path `exportDocument` test cases and skip all happy path `exportDocument_WithAuditReasons` test cases