### PR TITLE
V2 restructure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,11 @@ name: lf-repository-api-client-java-CI
 
 on:
   push:
-    branches: [ '\d+.x' ]
+    branches:
+      - v2
   pull_request:
-    branches: [ '\d+.x' ]
+    branches:
+      - v2
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -26,7 +28,7 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
 
-    - name: Build with Maven
+    - name: Build project
       run: mvn -B package -Dmaven.test.skip=true --file pom.xml
 
     - name: Run unit tests
@@ -103,7 +105,7 @@ jobs:
     - name: Move javadoc files to temporary directory
       run: mv ${{ github.workspace }}/target/site/ ${{ github.workspace }}/docs_temp/${{ github.ref_name }}
 
-    - name: Upload a Build Artifact
+    - name: Upload a build artifact
       uses: actions/upload-artifact@v2.3.1
       with:
         name: documentation-artifact
@@ -129,10 +131,10 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
 
-    - name: Build with Maven
+    - name: Build project
       run: mvn -B package -Dmaven.test.skip=true --file pom.xml
 
-    - name: Set up Apache Maven Central
+    - name: Set up OSSRH
       uses: actions/setup-java@v3
       with:
         java-version: '8'
@@ -143,13 +145,13 @@ jobs:
         gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-    - name: Set Java Package Version environment
+    - name: Generate package version
       run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}-preview-${{ github.run_id }}-SNAPSHOT" >> $GITHUB_ENV
 
-    - name: Set Java Package Version
+    - name: Set package version
       run: mvn versions:set -DnewVersion=${{ env.PACKAGE_VERSION }}
 
-    - name: Publish to Sonatype
+    - name: Publish to OSSRH
       run: mvn clean deploy -Dmaven.test.skip=true -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -179,10 +181,10 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
 
-    - name: Build with Maven
+    - name: Build project
       run: mvn -B package -Dmaven.test.skip=true --file pom.xml
 
-    - name: Set up Apache Maven Central
+    - name: Set up OSSRH
       uses: actions/setup-java@v3
       with:
         java-version: '8'
@@ -193,13 +195,13 @@ jobs:
         gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
         gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-    - name: Set Java Package Version environment
+    - name: Generate package version
       run: echo "PACKAGE_VERSION=${{ env.VERSION_PREFIX }}" >> $GITHUB_ENV
 
-    - name: Set Java Package Version
+    - name: Set package version
       run: mvn versions:set -DnewVersion=${{ env.PACKAGE_VERSION }}
 
-    - name: Publish to Maven Central
+    - name: Publish to OSSRH
       run: mvn clean deploy -P release -Dmaven.test.skip=true -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
       env:
         MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
@@ -251,7 +253,7 @@ jobs:
           name: documentation-artifact
           path: ./docs/${{ env.DOCUMENTATION_VERSION }}
 
-      - name: Create Pull Request
+      - name: Create pull request
         uses: peter-evans/create-pull-request@v4.2.3
         with:
           branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,42 +223,37 @@ jobs:
     needs: [ publish-production-package ]
     steps:
       - name: Set DOCUMENTATION_VERSION environment variable
-        run: |
-          if [[ '${{ github.event_name }}' == 'pull_request' ]]; then
-            echo 'DOCUMENTATION_VERSION=${{ github.base_ref }}' >> $GITHUB_ENV
-          elif [[ '${{ github.ref_protected }}' == 'true' && '${{ github.ref_type }}' == 'branch' ]]; then
-            echo 'DOCUMENTATION_VERSION=${{ github.ref_name }}' >> $GITHUB_ENV
-          else
-            echo '::error::Unable to publish documentation for the current branch.'
-            exit 1
-          fi
-
+      run: |
+        version_prefix=${{ env.VERSION_PREFIX }}
+        major_version=${version_prefix%%.*}
+        documentation_version=$major_version.x
+        echo $documentation_version
+        echo DOCUMENTATION_VERSION=$documentation_version >> $GITHUB_ENV
       - name: Print DOCUMENTATION_VERSION environment variable
         run: |
-          echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.DOCUMENTATION_VERSION }}.'
-
+          echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }}.'
       - uses: actions/checkout@v3
         with:
           ref: ${{ env.GITHUB_PAGES_BRANCH }}
 
       - name: Delete documentation directory
-        run: rm -f -r ./docs/${{ env.DOCUMENTATION_VERSION }}
+        run: rm -f -r ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
       - name: Create documentation directory
-        run: mkdir -p ./docs/${{ env.DOCUMENTATION_VERSION }}
+        run: mkdir -p ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
       - name: Download documentation build artifact
         uses: actions/download-artifact@v3.0.0
         with:
           name: documentation-artifact
-          path: ./docs/${{ env.DOCUMENTATION_VERSION }}
+          path: ./docs/${{ env.API_VERSION }}/${{ env.DOCUMENTATION_VERSION }}
 
-      - name: Create pull request
+      - name: Create a pull request
         uses: peter-evans/create-pull-request@v4.2.3
         with:
-          branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.DOCUMENTATION_VERSION }}-patch
+          branch: ${{ env.GITHUB_PAGES_BRANCH }}-${{ env.API_VERSION }}-${{ env.DOCUMENTATION_VERSION }}-patch
           delete-branch: true
-          title: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-          commit-message: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
-          body: "Automated documentation update for ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          title: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          commit-message: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
+          body: "Automated documentation update for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }} by action ${{ github.run_id }}"
           assignees: ${{ github.actor }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   API_VERSION: 'v2'
-  VERSION_PREFIX: '2.0.3'
+  VERSION_PREFIX: '1.0.0'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,19 +217,18 @@ jobs:
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   publish-documentation:
-
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment: github-pages
     needs: [ publish-production-package ]
     steps:
       - name: Set DOCUMENTATION_VERSION environment variable
-      run: |
-        version_prefix=${{ env.VERSION_PREFIX }}
-        major_version=${version_prefix%%.*}
-        documentation_version=$major_version.x
-        echo $documentation_version
-        echo DOCUMENTATION_VERSION=$documentation_version >> $GITHUB_ENV
+        run: |
+          version_prefix=${{ env.VERSION_PREFIX }}
+          major_version=${version_prefix%%.*}
+          documentation_version=$major_version.x
+          echo $documentation_version
+          echo DOCUMENTATION_VERSION=$documentation_version >> $GITHUB_ENV
       - name: Print DOCUMENTATION_VERSION environment variable
         run: |
           echo 'Publishing documentation to ${{ env.GITHUB_PAGES_BRANCH }} for ${{ env.API_VERSION }} ${{ env.DOCUMENTATION_VERSION }}.'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: ${{ env.PACKAGE_VERSION }}
+        tag: ${{ env.API_VERSION }}-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
@@ -212,7 +212,7 @@ jobs:
     - name: Tag commit
       uses: rickstaa/action-create-tag@v1
       with:
-        tag: ${{ env.PACKAGE_VERSION }}
+        tag: ${{ env.API_VERSION }}-${{ env.PACKAGE_VERSION }}
         commit_sha: ${{ github.sha }}
         message: Workflow run ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ on:
   workflow_dispatch:
 
 env:
+  API_VERSION: 'v2'
   VERSION_PREFIX: '2.0.3'
   GITHUB_PAGES_BRANCH: 'gh-pages'
 

--- a/.github/workflows/veracode-scan.yml
+++ b/.github/workflows/veracode-scan.yml
@@ -1,4 +1,4 @@
-name: Veracode scan
+name: veracode-scan
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -19,10 +19,10 @@ jobs:
         java-version: '8'
         distribution: 'temurin'
 
-    - name: Build with Maven
+    - name: Build project
       run: mvn -B package -Dmaven.test.skip=true --file pom.xml
 
-    - name: Veracode Upload And Scan (Static Application Security Testing)
+    - name: Veracode static application security testing (SAST)
       uses: veracode/veracode-uploadandscan-action@0.2.6
       with:
         appname: 'lf-repository-api-client-java'
@@ -31,7 +31,7 @@ jobs:
         vid: '${{ secrets.VERACODE_API_ID }}'
         vkey: '${{ secrets.VERACODE_API_KEY }}'
 
-    - name: Run Veracode Software Composition Analysis (SCA)
+    - name: Run Veracode software composition analysis (SCA)
       env:
         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
       uses: veracode/veracode-sca@v2.1.6

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 ## Documentation
 
 - [Laserfiche Developer Center](https://developer.laserfiche.com/)
-- [Java Doc for Laserfiche Repository API Client](https://laserfiche.github.io/lf-repository-api-client-java/docs/2.x/index.html)
+- [Java Doc for Laserfiche Repository API Client](https://laserfiche.github.io/lf-repository-api-client-java/docs/v2)
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use the Laserfiche Repository API to access data in a Laserfiche repository. Imp
 - [Laserfiche Developer Center](https://developer.laserfiche.com/)
 - [Java Doc for Laserfiche Repository API Client](https://laserfiche.github.io/lf-repository-api-client-java/docs/2.x/index.html)
 
-## Change Log
+## Changelog
 
 See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-java/blob/HEAD/CHANGELOG.md).
 
@@ -15,6 +15,9 @@ See CHANGELOG [here](https://github.com/Laserfiche/lf-repository-api-client-java
 
 To install, [see here](https://central.sonatype.com/artifact/com.laserfiche/lf-repository-api-client/)
 
-### Build, Test, and Package
+### Build, test, and package
 
 See the [.github/workflows/main.yml](https://github.com/Laserfiche/lf-repository-api-client-java/blob/HEAD/.github/workflows/main.yml).
+
+#### Branches
+The v1 branch stores client code for the Laserfiche Repository API v1; the v2 branch stores client code for the Laserfiche Repository API v2.

--- a/pom.xml
+++ b/pom.xml
@@ -7,8 +7,7 @@
   <name>Laserfiche Repository API Client V2</name>
   <version>1.0.0</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
-  <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
-    Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>
+  <description>The Java Laserfiche Repository API Client library for accessing the v2 Laserfiche Repository APIs.</description>
   <scm>
     <connection>scm:git:git://github.com/Laserfiche/lf-repository-api-client-java.git</connection>
     <developerConnection>scm:git:ssh://github.com:Laserfiche/lf-repository-api-client-java.git</developerConnection>

--- a/pom.xml
+++ b/pom.xml
@@ -2,10 +2,10 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.laserfiche</groupId>
-  <artifactId>lf-repository-api-client</artifactId>
+  <artifactId>lf-repository-api-client-v2</artifactId>
   <packaging>jar</packaging>
-  <name>Laserfiche Repository API Client</name>
-  <version>2.0.3</version>
+  <name>Laserfiche Repository API Client V2</name>
+  <version>1.0.0</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>Java implementation of various foundational APIs for Laserfiche, including Repository APIs such as
     Entry API flows for secure and easy access to Laserfiche Repository Entries.</description>


### PR DESCRIPTION
1. Normalize CI naming
2. Update CI branch matching
3. Update tag name to include API version (to avoid confusion)
4. Update project description to include branching information
5. Update project name (suffix v2, that's common in Maven)
6. Reset version number to 1.0.0 since we are publishing a new project
7. Update documentation publishing CI
8. Update documentation link