### PR TITLE
Add copyright header

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api;
 
 import com.laserfiche.repository.api.clients.*;

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api;
 
 import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.Attribute;

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.AuditReasonCollectionResponse;

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.FieldDefinition;

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.LinkDefinition;

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.RepositoryCollectionResponse;

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.EntryCollectionResponse;

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.EntryCollectionResponse;

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.TagDefinition;

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.CancelTasksResponse;

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.TemplateDefinition;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.httphandlers.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Attribute.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Attribute.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AttributeCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AttributeCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditEventType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditEventType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReason.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReasonCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReasonCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CancelTaskResult.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CancelTaskResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CancelTasksResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CancelTasksResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CopyEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CopyEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryRequestEntryType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryRequestEntryType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateMultipartUploadUrlsRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateMultipartUploadUrlsRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateMultipartUploadUrlsResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateMultipartUploadUrlsResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestImageFormat.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestImageFormat.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestImageOptions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestImageOptions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestPart.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestPart.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestTextOptions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestTextOptions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestWatermark.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryRequestWatermark.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ExportEntryResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Field.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Field.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldDefinitionCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldDefinitionCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldFormat.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldFormat.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldToUpdate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FuzzyType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FuzzyType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/GeneratePagesImageType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/GeneratePagesImageType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetEntryByPathResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetEntryByPathResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequestMetadata.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequestMetadata.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequestPdfOptions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportEntryRequestPdfOptions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LFColor.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LFColor.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Link.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Link.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkDefinitionCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkDefinitionCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ListDynamicFieldValuesRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ListDynamicFieldValuesRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/RecordSeries.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/RecordSeries.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Repository.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Repository.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/RepositoryCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/RepositoryCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Rule.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Rule.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchContextHit.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchContextHit.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchContextHitCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchContextHitCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SearchEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetFieldsRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetFieldsRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetLinksRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetLinksRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTagsRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTagsRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTemplateRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTemplateRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Shortcut.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Shortcut.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartCopyEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartCopyEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartDeleteEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartDeleteEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartExportEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartExportEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartImportUploadedPartsRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartImportUploadedPartsRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartSearchEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartSearchEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartTaskResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/StartTaskResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Tag.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Tag.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinitionCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinitionCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinitionWatermark.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TagDefinitionWatermark.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskProgress.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskProgress.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskResult.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskStatus.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskStatus.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TaskType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateDefinitionCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateDefinitionCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldDefinitionCollectionResponse.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldDefinitionCollectionResponse.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/UpdateEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/UpdateEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonInclude;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WatermarkPosition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WatermarkPosition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;

--- a/src/main/java/com/laserfiche/repository/api/clients/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides interfaces for each Laserfiche Repository API set.
  */

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelTasks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelTasks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.CopyEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.CreateEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateMultipartUploadUrls.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateMultipartUploadUrls.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.CreateMultipartUploadUrlsRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteElectronicDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteElectronicDocument.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.ExportEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAttribute.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAttribute.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.ImportEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListAttributes.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListAttributes.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListAuditReasons.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListAuditReasons.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListDynamicFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListDynamicFieldValues.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.ListDynamicFieldValuesRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListEntries.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListEntries.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListFieldDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListFields.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListFields.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListLinkDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListLinkDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListLinks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListSearchContextHits.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListSearchContextHits.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListSearchResults.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListSearchResults.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTagDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTagDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTags.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTasks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTasks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateFieldDefinitionsByTemplateId.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateFieldDefinitionsByTemplateId.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateFieldDefinitionsByTemplateName.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForListTemplateFieldDefinitionsByTemplateName.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRemoveTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRemoveTemplate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 /**

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSearchEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSearchEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.SearchEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetFields.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetFields.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.SetFieldsRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetLinks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.SetLinksRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetTags.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.SetTagsRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForSetTemplate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.SetTemplateRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartCopyEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartCopyEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.StartCopyEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartDeleteEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartDeleteEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.StartDeleteEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartExportEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartExportEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.StartExportEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartImportUploadedParts.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartImportUploadedParts.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.StartImportUploadedPartsRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartSearchEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForStartSearchEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.StartSearchEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForUpdateEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForUpdateEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.UpdateEntryRequest;

--- a/src/main/java/com/laserfiche/repository/api/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes for the Laserfiche Repository API client.
  */

--- a/src/test/java/com/laserfiche/repository/api/integration/AttributesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/AttributesClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.AttributesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/AuditReasonsClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/AuditReasonsClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.AuditReasonsClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/repository/api/integration/ErrorSource.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ErrorSource.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 public enum ErrorSource {

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.FieldDefinitionsClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportUploadedPartsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportUploadedPartsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/LinkDefinitionsClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/LinkDefinitionsClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.LinkDefinitionsClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/RepositoriesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/RepositoriesClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.RepositoriesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/RepositoryApiClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/RepositoryApiClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/repository/api/integration/SearchesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SearchesClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.SearchesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/repository/api/integration/StartExportEntryApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/StartExportEntryApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.EntriesClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.TagDefinitionsClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/TasksClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TasksClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.TasksClient;

--- a/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.repository.api.clients.TemplateDefinitionsClient;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import com.laserfiche.repository.api.clients.impl.ApiClientUtils;


### PR DESCRIPTION
Insert the following copyright header at the top of all `*.java` files.
```
// Copyright (c) Laserfiche.
// Licensed under the MIT License. See LICENSE in the project root for license information.
```