### PR TITLE
Add copyright header

### DIFF
--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api;
 
 import com.laserfiche.repository.api.clients.*;

--- a/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/RepositoryApiClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api;
 
 import com.laserfiche.api.client.deserialization.TokenClientObjectMapper;

--- a/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AttributesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/AuditReasonsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/EntriesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/FieldDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/LinkDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/RepositoriesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SearchesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/ServerSessionClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/SimpleSearchesClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TagDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TasksClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/TemplateDefinitionsClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClient.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.httphandlers.HttpRequestHandler;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.httphandlers.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AttributesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/AuditReasonsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/EntriesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/FieldDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/LinkDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/RepositoriesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SearchesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ServerSessionClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/SimpleSearchesClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TagDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TasksClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/TemplateDefinitionsClientImpl.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl;
 
 import com.laserfiche.api.client.deserialization.ProblemDetailsDeserializer;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/APIServerException.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/APIServerException.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AcceptedOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AcceptedOperation.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AdvancedSearchRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AdvancedSearchRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Attribute.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Attribute.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReasons.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/AuditReasons.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ContextHit.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ContextHit.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CopyAsyncRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CopyAsyncRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryOperations.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryOperations.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryResult.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/CreateEntryResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/DeleteEntryWithAuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/DeleteEntryWithAuditReason.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Document.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Edoc.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Edoc.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Entry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryCreate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryCreate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryFieldValue.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryFieldValue.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryLinkTypeInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryLinkTypeInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/EntryType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldToUpdate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldValue.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FieldValue.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FindEntryResult.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FindEntryResult.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Folder.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/FuzzyType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/FuzzyType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetDynamicFieldLogicValueRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetDynamicFieldLogicValueRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetEdocWithAuditReasonRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/GetEdocWithAuditReasonRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/HitType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportAsyncMetadata.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ImportAsyncMetadata.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LFColor.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LFColor.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/LinkToUpdate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfContextHit.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfContextHit.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfEntryLinkTypeInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfEntryLinkTypeInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfFieldValue.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfFieldValue.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfTemplateFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfTemplateFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWEntryLinkInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWEntryLinkInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWTagInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWTagInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWTemplateInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfIListOfWTemplateInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfListOfAttribute.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueContextOfListOfAttribute.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfBoolean.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfBoolean.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfDateTime.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfDateTime.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfContextHit.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfContextHit.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfEntryLinkTypeInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfEntryLinkTypeInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfFieldValue.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfFieldValue.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfTemplateFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfTemplateFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWEntryLinkInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWEntryLinkInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWTagInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWTagInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWTemplateInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfIListOfWTemplateInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfListOfAttribute.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ODataValueOfListOfAttribute.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationErrorItem.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationErrorItem.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationProgress.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationProgress.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationStatus.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/OperationStatus.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ParentEntryIdFileNameBody.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ParentEntryIdFileNameBody.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PatchEntryRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PatchEntryRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryChildrenEntryType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryChildrenEntryType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryChildrenRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryChildrenRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryWithEdocMetadataRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PostEntryWithEdocMetadataRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutFieldValsRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutFieldValsRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutLinksRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutLinksRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutTagRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutTagRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutTemplateRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/PutTemplateRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/RecordSeries.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/RecordSeries.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/RepositoryInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/RepositoryInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Rule.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Rule.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetEdoc.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetEdoc.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetFields.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetFields.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetLinks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTags.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SetTemplate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Shortcut.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Shortcut.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/SimpleSearchRequest.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/SimpleSearchRequest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/TemplateFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/ValueToUpdate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/ValueToUpdate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WAuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WAuditReason.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WEntryLinkInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WEntryLinkInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldFormat.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldFormat.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WFieldType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTagInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTagInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTemplateInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WTemplateInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/Watermark.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/Watermark.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/WatermarkPosition.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/WatermarkPosition.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.impl.model;
 
 import com.fasterxml.jackson.annotation.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/model/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/model/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides model classes for the Laserfiche Repository API.
  */

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes for each Laserfiche Repository API set.
  */

--- a/src/main/java/com/laserfiche/repository/api/clients/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides interfaces for each Laserfiche Repository API set.
  */

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignEntryLinks.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignFieldValues.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForAssignTags.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOperation.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCancelOrCloseSearch.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCopyEntryAsync.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateOrCopyEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSearchOperation.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateServerSession.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForCreateSimpleSearchOperation.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteAssignedTemplate.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteDocument.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeleteEntryInfo.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForDeletePages.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocument.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForExportDocumentWithAuditReason.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetAuditReasons.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDocumentContentType.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetDynamicFieldValues.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryByPath.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetEntryListing.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitionById.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetFieldValues.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitionById.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetLinkValuesFromEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetOperationStatusAndProgress.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchContextHits.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchResults.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetSearchStatus.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitionById.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTagsAssignedToEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitionById.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitions.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTemplateFieldDefinitionsByTemplateName.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeKeyValuePairs.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForGetTrusteeAttributeValueByKey.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForImportDocument.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForInvalidateServerSession.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForMoveOrRenameEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForRefreshServerSession.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/ParametersForWriteTemplateValueToEntry.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.clients.params;
 
 import com.laserfiche.repository.api.clients.impl.model.*;

--- a/src/main/java/com/laserfiche/repository/api/clients/params/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/params/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides request parameter classes for each Laserfiche Repository API.
  */

--- a/src/main/java/com/laserfiche/repository/api/package-info.java
+++ b/src/main/java/com/laserfiche/repository/api/package-info.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 /**
  * Provides classes for the Laserfiche Repository API client.
  */

--- a/src/test/java/com/laserfiche/repository/api/integration/AttributesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/AttributesApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/AuditReasonsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/AuditReasonsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.AccessKey;

--- a/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/CreateCopyEntryApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/ErrorSource.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ErrorSource.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 public enum ErrorSource {

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.ApiException;

--- a/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/FieldDefinitionsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportDocumentApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/LinkDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/LinkDefinitionsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/laserfiche/repository/api/integration/RepositoriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/RepositoriesApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/laserfiche/repository/api/integration/RepositoryApiClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/RepositoryApiClientTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SearchApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SetEntriesApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/SetLinksApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SetLinksApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/SimpleSearchesApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TagDefinitionsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/integration/TasksApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TasksApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TemplateDefinitionsApiTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
 import static org.junit.jupiter.api.Assertions.*;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetCreateEntryResultSumaryTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetCreateEntryResultSumaryTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/GetHeadersTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/IsRetryableStatusCodeTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
+++ b/src/test/java/com/laserfiche/repository/api/unit/ApiClientUtils/MergeMaxSizeIntoPreferTest.java
@@ -1,3 +1,5 @@
+// Copyright (c) Laserfiche.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.unit.ApiClientUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
This is for **V1** branch.
Insert the following copyright header at the top of all `*.java` files.
```
// Copyright (c) Laserfiche.
// Licensed under the MIT License. See LICENSE in the project root for license information.
```