### PR TITLE
Fix test

### DIFF
--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -62,10 +62,8 @@ class EntriesApiTest extends BaseTest {
                 .setSelect("name"));
 
         assertNotNull(entry);
-        assertFalse(entry instanceof Folder
-                || entry instanceof Shortcut
-                || entry instanceof Document
-                || entry instanceof RecordSeries); // When no type information, the data is deserialized to Entry.
+		// When OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
+        assertTrue(entry instanceof Folder);
     }
 
     @Test

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -55,7 +55,7 @@ class EntriesApiTest extends BaseTest {
     }
 
     @Test
-    void getEntry_ReturnEntryWhenTypeInfoMissing() {
+    void getEntry_AlwaysReturnsEntryTypeWhenSelectIsUsed() {
         Entry entry = client.getEntry(new ParametersForGetEntry()
                 .setRepoId(repositoryId)
                 .setEntryId(1)

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -62,7 +62,7 @@ class EntriesApiTest extends BaseTest {
                 .setSelect("name"));
 
         assertNotNull(entry);
-		// When OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
+        // When OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
         assertTrue(entry instanceof Folder);
     }
 

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -62,8 +62,17 @@ class EntriesApiTest extends BaseTest {
                 .setSelect("name"));
 
         assertNotNull(entry);
-        // When OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
-        assertTrue(entry instanceof Folder);
+        boolean cloud = authorizationType == AuthorizationType.CLOUD_ACCESS_KEY;
+        if (cloud) {
+            // For cloud, when OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
+            assertTrue(entry instanceof Folder);
+        } else {
+            // For self-hosted, this feature is not yet released.
+            assertFalse(entry instanceof Folder
+                    || entry instanceof Shortcut
+                    || entry instanceof Document
+                    || entry instanceof RecordSeries); // When no type information, the data is deserialized to Entry.
+        }
     }
 
     @Test

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -67,11 +67,12 @@ class EntriesApiTest extends BaseTest {
             // For cloud, when OData $select is used, the entryType is always returned. So, data is deserialized to the correct type.
             assertTrue(entry instanceof Folder);
         } else {
-            // For self-hosted, this feature is not yet released.
+            // For self-hosted, the above feature is not yet released.
+            // So, when $select is used and it doesn't include entryType, the data is deserialized to Entry.
             assertFalse(entry instanceof Folder
                     || entry instanceof Shortcut
                     || entry instanceof Document
-                    || entry instanceof RecordSeries); // When no type information, the data is deserialized to Entry.
+                    || entry instanceof RecordSeries); //
         }
     }
 

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesApiTest.java
@@ -72,7 +72,7 @@ class EntriesApiTest extends BaseTest {
             assertFalse(entry instanceof Folder
                     || entry instanceof Shortcut
                     || entry instanceof Document
-                    || entry instanceof RecordSeries); //
+                    || entry instanceof RecordSeries);
         }
     }
 


### PR DESCRIPTION
The API is recently updated to always return entryType, when OData `$select` option is used. 
This PR fixes the related test which failed after this update.