### PR TITLE
fix(security): bump jackson-databind to 2.18.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
           AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
-          READONLY_TEST_FOLDER_ID: "2732097" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
+          READONLY_TEST_FOLDER_ID: "2737397" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
         run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
       - name: Publish cloud test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
           AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
-          READONLY_TEST_FOLDER_ID: "2729986" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
+          READONLY_TEST_FOLDER_ID: "2732097" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
         run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
       - name: Publish cloud test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
           REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
           AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
-          READONLY_TEST_FOLDER_ID: "2737397" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
+          READONLY_TEST_FOLDER_ID: ${{ secrets.DEV_CA_READONLY_TEST_FOLDER_ID }}
         run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
       - name: Publish cloud test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,6 +19,10 @@ jobs:
   build-n-test:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      checks: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,10 @@ jobs:
         env:
           ACCESS_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_INTEGRATION_TEST_ACCESS_KEY }}
           SERVICE_PRINCIPAL_KEY: ${{ secrets.DEV_CA_PUBLIC_USE_TESTOAUTHSERVICEPRINCIPAL_SERVICE_PRINCIPAL_KEY }}
-          REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_2 }}
+          REPOSITORY_ID: ${{ secrets.DEV_CA_PUBLIC_USE_REPOSITORY_ID_1 }}
           AUTHORIZATION_TYPE: ${{ secrets.AUTHORIZATION_TYPE }}
           TEST_HEADER: ${{ secrets.TEST_HEADER }}
-          READONLY_TEST_FOLDER_ID: ${{ secrets.DEV_CA_READONLY_TEST_FOLDER_ID }}
+          READONLY_TEST_FOLDER_ID: "2729986" # TODO: hardcoded for diagnostic run, revert to secrets.DEV_CA_READONLY_TEST_FOLDER_ID
         run: mvn -Dtest=com.laserfiche.repository.api.integration.** test
 
       - name: Publish cloud test results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+### Chore & Maintenance
+
+- Update `jackson-databind` dependency due to vulnerability
+
 ## 1.0.3
 
 ### Chore & Maintenance

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <artifactId>lf-repository-api-client-v2</artifactId>
   <packaging>jar</packaging>
   <name>Laserfiche Repository API Client V2</name>
-  <version>1.0.0</version>
+  <version>1.0.4</version>
   <url>https://github.com/Laserfiche/lf-repository-api-client-java</url>
   <description>The Java Laserfiche Repository API Client library for accessing the v2 Laserfiche Repository APIs.</description>
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,7 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <gson-fire-version>1.8.0</gson-fire-version>
     <swagger-core-version>2.0.0</swagger-core-version>
-    <jackson-version>2.18.2</jackson-version>
+    <jackson-version>2.18.8</jackson-version>
     <retrofit-version>2.9.0</retrofit-version>
     <threetenbp-version>1.3.5</threetenbp-version>
     <oltu-version>1.0.2</oltu-version>

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -174,8 +174,12 @@ public class ApiClientUtils {
         HttpResponse<Object> httpResponse = null;
         while (retryCount <= maxRetries && shouldRetry) {
             try {
+                if (retryCount > 0) {
+                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " starting for " + requestMethod + " " + url);
+                }
                 String requestUrl =
                         ApiClientUtils.beforeSend(url, headerParametersWithStringTypeValue, httpRequestHandler);
+                String authFingerprint = tokenFingerprint(headerParametersWithStringTypeValue);
                 final HttpRequestWithBody httpRequestWithBody = httpClient.request(requestMethod, requestUrl);
                 HttpRequest<?> httpRequest = httpRequestWithBody;
                 if (queryParameters != null) {
@@ -212,10 +216,17 @@ public class ApiClientUtils {
                 int statusCode = httpResponse.getStatus();
                 shouldRetry = httpRequestHandler.afterSend(new ResponseImpl((short) statusCode))
                         || ApiClientUtils.isRetryableStatusCode(statusCode, httpMethod);
+                if (statusCode == 401 || retryCount > 0 || shouldRetry) {
+                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " " + requestMethod + " " + url
+                            + " -> status=" + statusCode + " shouldRetry=" + shouldRetry + " authToken=" + authFingerprint);
+                }
                 if (!shouldRetry) {
                     return parseResponse.apply(httpResponse);
                 }
             } catch (Exception err) {
+                if (retryCount > 0 || err instanceof ApiException) {
+                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " threw " + err.getClass().getName() + ": " + err.getMessage());
+                }
                 if (err instanceof ApiException || retryCount >= maxRetries) {
                     throw err;
                 }
@@ -228,5 +239,20 @@ public class ApiClientUtils {
             throw new IllegalStateException("Undefined response, there is a bug");
         }
         return parseResponse.apply(httpResponse);
+    }
+
+    // TEMPORARY debug aid — prints the last 8 characters of whatever bearer token was actually
+    // attached for this attempt, so repeated log lines across retries can be compared to prove
+    // whether a retry after a 401 is really presenting a freshly-fetched token. Never logs the
+    // full token. Remove once the retry behavior is confirmed.
+    private static String tokenFingerprint(Map<String, String> headerParametersWithStringTypeValue) {
+        if (headerParametersWithStringTypeValue == null) {
+            return "n/a";
+        }
+        String auth = headerParametersWithStringTypeValue.get("Authorization");
+        if (auth == null || auth.length() < 8) {
+            return "n/a";
+        }
+        return "..." + auth.substring(auth.length() - 8);
     }
 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -174,9 +174,6 @@ public class ApiClientUtils {
         HttpResponse<Object> httpResponse = null;
         while (retryCount <= maxRetries && shouldRetry) {
             try {
-                if (retryCount > 0) {
-                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " starting for " + requestMethod + " " + url);
-                }
                 String requestUrl =
                         ApiClientUtils.beforeSend(url, headerParametersWithStringTypeValue, httpRequestHandler);
                 final HttpRequestWithBody httpRequestWithBody = httpClient.request(requestMethod, requestUrl);
@@ -215,17 +212,10 @@ public class ApiClientUtils {
                 int statusCode = httpResponse.getStatus();
                 shouldRetry = httpRequestHandler.afterSend(new ResponseImpl((short) statusCode))
                         || ApiClientUtils.isRetryableStatusCode(statusCode, httpMethod);
-                if (statusCode == 401 || retryCount > 0 || shouldRetry) {
-                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " " + requestMethod + " " + url
-                            + " -> status=" + statusCode + " shouldRetry=" + shouldRetry);
-                }
                 if (!shouldRetry) {
                     return parseResponse.apply(httpResponse);
                 }
             } catch (Exception err) {
-                if (retryCount > 0 || err instanceof ApiException) {
-                    System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " threw " + err.getClass().getName() + ": " + err.getMessage());
-                }
                 if (err instanceof ApiException || retryCount >= maxRetries) {
                     throw err;
                 }

--- a/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
+++ b/src/main/java/com/laserfiche/repository/api/clients/impl/ApiClientUtils.java
@@ -179,7 +179,6 @@ public class ApiClientUtils {
                 }
                 String requestUrl =
                         ApiClientUtils.beforeSend(url, headerParametersWithStringTypeValue, httpRequestHandler);
-                String authFingerprint = tokenFingerprint(headerParametersWithStringTypeValue);
                 final HttpRequestWithBody httpRequestWithBody = httpClient.request(requestMethod, requestUrl);
                 HttpRequest<?> httpRequest = httpRequestWithBody;
                 if (queryParameters != null) {
@@ -218,7 +217,7 @@ public class ApiClientUtils {
                         || ApiClientUtils.isRetryableStatusCode(statusCode, httpMethod);
                 if (statusCode == 401 || retryCount > 0 || shouldRetry) {
                     System.out.println("[RETRY-DEBUG] attempt " + (retryCount + 1) + " " + requestMethod + " " + url
-                            + " -> status=" + statusCode + " shouldRetry=" + shouldRetry + " authToken=" + authFingerprint);
+                            + " -> status=" + statusCode + " shouldRetry=" + shouldRetry);
                 }
                 if (!shouldRetry) {
                     return parseResponse.apply(httpResponse);
@@ -239,20 +238,5 @@ public class ApiClientUtils {
             throw new IllegalStateException("Undefined response, there is a bug");
         }
         return parseResponse.apply(httpResponse);
-    }
-
-    // TEMPORARY debug aid — prints the last 8 characters of whatever bearer token was actually
-    // attached for this attempt, so repeated log lines across retries can be compared to prove
-    // whether a retry after a 401 is really presenting a freshly-fetched token. Never logs the
-    // full token. Remove once the retry behavior is confirmed.
-    private static String tokenFingerprint(Map<String, String> headerParametersWithStringTypeValue) {
-        if (headerParametersWithStringTypeValue == null) {
-            return "n/a";
-        }
-        String auth = headerParametersWithStringTypeValue.get("Authorization");
-        if (auth == null || auth.length() < 8) {
-            return "n/a";
-        }
-        return "..." + auth.substring(auth.length() - 8);
     }
 }

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 enum AuthorizationType {
     CLOUD_ACCESS_KEY,
@@ -159,7 +160,7 @@ public class BaseTest {
                 if (progress.getStatus() != TaskStatus.COMPLETED) {
                     throw new RuntimeException(String.format(
                             "Task %s ended with status %s instead of COMPLETED. Errors: %s",
-                            taskId, progress.getStatus(), progress.getErrors()));
+                            taskId, progress.getStatus(), formatErrors(progress.getErrors())));
                 }
                 return;
             }
@@ -171,6 +172,19 @@ public class BaseTest {
             count++;
         }
         throw new RuntimeException("WaitUntilTaskEnds timeout");
+    }
+
+    // ProblemDetails doesn't override toString(), so printing the list directly just
+    // shows "ProblemDetails@<hash>" with none of the actual server-provided error info.
+    private static String formatErrors(List<ProblemDetails> errors) {
+        if (errors == null || errors.isEmpty()) {
+            return "none";
+        }
+        return errors.stream()
+                .map(e -> String.format(
+                        "[title=%s, detail=%s, status=%s, errorCode=%s, errorSource=%s]",
+                        e.getTitle(), e.getDetail(), e.getStatus(), e.getErrorCode(), e.getErrorSource()))
+                .collect(Collectors.joining(", "));
     }
 
     public static void deleteEntry(int entryId) {

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -3,6 +3,7 @@
 package com.laserfiche.repository.api.integration;
 
 import com.laserfiche.api.client.model.AccessKey;
+import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.api.client.model.ProblemDetails;
 import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.RepositoryApiClientImpl;
@@ -196,15 +197,26 @@ public class BaseTest {
     // Resolved once and reused, mirroring ExportDocumentApiTest.findAuditReasonForExport.
     protected static Integer getDeleteAuditReasonId() {
         if (!deleteAuditReasonResolved) {
-            deleteAuditReasonResolved = true;
-            AuditReasonCollectionResponse auditReasons = repositoryApiClient
-                    .getAuditReasonsClient()
-                    .listAuditReasons(new ParametersForListAuditReasons().setRepositoryId(repositoryId));
+            AuditReasonCollectionResponse auditReasons;
+            try {
+                auditReasons = repositoryApiClient
+                        .getAuditReasonsClient()
+                        .listAuditReasons(new ParametersForListAuditReasons().setRepositoryId(repositoryId));
+            } catch (ApiException e) {
+                // Don't cache "resolved" on failure — a transient hiccup here would otherwise
+                // permanently strand every later delete in the run with no audit reason, silently
+                // re-triggering "Need to provide correct audit reason for DeleteEntry" for the rest
+                // of the suite instead of just this one call.
+                throw new RuntimeException(String.format(
+                        "listAuditReasons failed while resolving delete audit reason: statusCode=%d, headers=%s, problemDetails=%s",
+                        e.getStatusCode(), e.getHeaders(), e.getProblemDetails()), e);
+            }
             deleteAuditReasonId = auditReasons.getValue().stream()
                     .filter(reason -> reason.getAuditEventType() == AuditEventType.DELETE_ENTRY)
                     .map(AuditReason::getId)
                     .findFirst()
                     .orElse(null);
+            deleteAuditReasonResolved = true;
         }
         return deleteAuditReasonId;
     }

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -156,6 +156,11 @@ public class BaseTest {
                             .setTaskIds(taskId));
             TaskProgress progress = collectionResponse.getValue().get(0);
             if (progress.getStatus() != TaskStatus.IN_PROGRESS) {
+                if (progress.getStatus() != TaskStatus.COMPLETED) {
+                    throw new RuntimeException(String.format(
+                            "Task %s ended with status %s instead of COMPLETED. Errors: %s",
+                            taskId, progress.getStatus(), progress.getErrors()));
+                }
                 return;
             }
             try {

--- a/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/BaseTest.java
@@ -8,6 +8,7 @@ import com.laserfiche.repository.api.RepositoryApiClient;
 import com.laserfiche.repository.api.RepositoryApiClientImpl;
 import com.laserfiche.repository.api.clients.impl.model.*;
 import com.laserfiche.repository.api.clients.params.ParametersForCreateEntry;
+import com.laserfiche.repository.api.clients.params.ParametersForListAuditReasons;
 import com.laserfiche.repository.api.clients.params.ParametersForListTasks;
 import com.laserfiche.repository.api.clients.params.ParametersForStartDeleteEntry;
 import io.github.cdimascio.dotenv.Dotenv;
@@ -187,6 +188,36 @@ public class BaseTest {
                 .collect(Collectors.joining(", "));
     }
 
+    private static Integer deleteAuditReasonId;
+    private static boolean deleteAuditReasonResolved = false;
+
+    // This repository requires an audit reason for DeleteEntry (errorCode 216: "Need to
+    // provide correct audit reason for DeleteEntry"), unlike the old dedicated test repo.
+    // Resolved once and reused, mirroring ExportDocumentApiTest.findAuditReasonForExport.
+    protected static Integer getDeleteAuditReasonId() {
+        if (!deleteAuditReasonResolved) {
+            deleteAuditReasonResolved = true;
+            AuditReasonCollectionResponse auditReasons = repositoryApiClient
+                    .getAuditReasonsClient()
+                    .listAuditReasons(new ParametersForListAuditReasons().setRepositoryId(repositoryId));
+            deleteAuditReasonId = auditReasons.getValue().stream()
+                    .filter(reason -> reason.getAuditEventType() == AuditEventType.DELETE_ENTRY)
+                    .map(AuditReason::getId)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return deleteAuditReasonId;
+    }
+
+    protected static StartDeleteEntryRequest newDeleteEntryRequest() {
+        StartDeleteEntryRequest request = new StartDeleteEntryRequest();
+        Integer auditReasonId = getDeleteAuditReasonId();
+        if (auditReasonId != null) {
+            request.setAuditReasonId(auditReasonId);
+        }
+        return request;
+    }
+
     public static void deleteEntry(int entryId) {
         if (entryId != 0) {
             StartTaskResponse startTaskResponse = repositoryApiClient
@@ -194,7 +225,7 @@ public class BaseTest {
                     .startDeleteEntry(new ParametersForStartDeleteEntry()
                             .setRepositoryId(repositoryId)
                             .setEntryId(entryId)
-                            .setRequestBody(new StartDeleteEntryRequest()));
+                            .setRequestBody(newDeleteEntryRequest()));
             waitUntilTaskEnds(startTaskResponse.getTaskId());
         }
     }

--- a/src/test/java/com/laserfiche/repository/api/integration/EntriesClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/EntriesClientTest.java
@@ -420,7 +420,7 @@ class EntriesClientTest extends BaseTest {
         StartTaskResponse deleteEntryResponse = client.startDeleteEntry(new ParametersForStartDeleteEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(entryToDelete.getId())
-                .setRequestBody(new StartDeleteEntryRequest()));
+                .setRequestBody(newDeleteEntryRequest()));
         String taskId = deleteEntryResponse.getTaskId();
         assertNotNull(taskId);
 

--- a/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ExportDocumentApiTest.java
@@ -107,6 +107,19 @@ public class ExportDocumentApiTest extends BaseTest {
         deleteEntry(testEntryId);
     }
 
+    // Wraps exportEntry so a failure's ApiException status code/headers/problem details
+    // (not just its message) show up in the surefire report, since we can't get the raw
+    // job log from this environment to see the actual HTTP response otherwise.
+    private ExportEntryResponse exportEntry(ParametersForExportEntry parameters) {
+        try {
+            return client.exportEntry(parameters);
+        } catch (ApiException e) {
+            throw new AssertionError(String.format(
+                    "exportEntry failed: statusCode=%d, headers=%s, problemDetails=%s",
+                    e.getStatusCode(), e.getHeaders(), e.getProblemDetails()), e);
+        }
+    }
+
     @Test
     void exportDocumentCanExportEDocPart() {
         final String FILE_NAME = "exportDocument_temp_file.pdf";
@@ -116,7 +129,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setRequestBody(request));
@@ -137,7 +150,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setRequestBody(request));
@@ -188,7 +201,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setRequestBody(request));
@@ -217,7 +230,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setRequestBody(request));
@@ -244,7 +257,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setRequestBody(request));
@@ -271,7 +284,7 @@ public class ExportDocumentApiTest extends BaseTest {
             request.setAuditReasonId(auditReasonId);
             request.setAuditReasonComment(auditReasonComment);
         }
-        ExportEntryResponse response = client.exportEntry(new ParametersForExportEntry()
+        ExportEntryResponse response = exportEntry(new ParametersForExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testEntryId)
                 .setPageRange("1")

--- a/src/test/java/com/laserfiche/repository/api/integration/ImportUploadedPartsApiTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/ImportUploadedPartsApiTest.java
@@ -2,6 +2,7 @@
 // Licensed under the MIT License. See LICENSE in the project root for license information.
 package com.laserfiche.repository.api.integration;
 
+import com.laserfiche.api.client.model.ApiException;
 import com.laserfiche.repository.api.clients.EntriesClient;
 import com.laserfiche.repository.api.clients.TasksClient;
 import com.laserfiche.repository.api.clients.impl.model.*;
@@ -59,6 +60,19 @@ public class ImportUploadedPartsApiTest extends BaseTest {
         deleteEntry(testClassParentFolder.getId());
     }
 
+    // Surfaces the real HTTP status code/headers on failure instead of just the generic
+    // message, so an "Invalid or expired access token" error tells us whether it was
+    // actually a 401 (and thus in principle retryable) or something else entirely.
+    private static <T> T call(String callName, java.util.function.Supplier<T> apiCall) {
+        try {
+            return apiCall.get();
+        } catch (ApiException e) {
+            throw new AssertionError(String.format(
+                    "%s failed: statusCode=%d, headers=%s, problemDetails=%s",
+                    callName, e.getStatusCode(), e.getHeaders(), e.getProblemDetails()), e);
+        }
+    }
+
     @Test
     void createMultipartUploadUrlsCanBeCalledForSecondBatchOfURLs() {
         String fileName = "Sample.pdf";
@@ -108,8 +122,8 @@ public class ImportUploadedPartsApiTest extends BaseTest {
         requestBody.setMimeType(mimeType);
         requestBody.setNumberOfParts(parts);
 
-        CreateMultipartUploadUrlsResponse response = client.createMultipartUploadUrls(new ParametersForCreateMultipartUploadUrls()
-                .setRepositoryId(repositoryId).setRequestBody(requestBody));
+        CreateMultipartUploadUrlsResponse response = call("createMultipartUploadUrls", () -> client.createMultipartUploadUrls(new ParametersForCreateMultipartUploadUrls()
+                .setRepositoryId(repositoryId).setRequestBody(requestBody)));
 
         assertNotNull(response);
         String uploadId = response.getUploadId();
@@ -130,17 +144,17 @@ public class ImportUploadedPartsApiTest extends BaseTest {
         pdfOptions.setGeneratePages(true);
         pdfOptions.setKeepPdfAfterImport(true);
         requestBody2.setPdfOptions(pdfOptions);
-        StartTaskResponse response2 = client.startImportUploadedParts(new ParametersForStartImportUploadedParts()
+        StartTaskResponse response2 = call("startImportUploadedParts", () -> client.startImportUploadedParts(new ParametersForStartImportUploadedParts()
                 .setRepositoryId(repositoryId)
                 .setEntryId(testClassParentFolder.getId())
-                .setRequestBody(requestBody2));
+                .setRequestBody(requestBody2)));
 
         assertNotNull(response2);
         String taskId = response2.getTaskId();
         assertNotNull(taskId);
         waitUntilTaskEnds(taskId);
 
-        TaskCollectionResponse tasks = tasksClient.listTasks(new ParametersForListTasks().setRepositoryId(repositoryId).setTaskIds(taskId));
+        TaskCollectionResponse tasks = call("listTasks(import)", () -> tasksClient.listTasks(new ParametersForListTasks().setRepositoryId(repositoryId).setTaskIds(taskId)));
         assertNotNull(tasks);
         assertEquals(1, tasks.getValue().size());
         TaskProgress taskProgress = tasks.getValue().get(0);
@@ -161,16 +175,16 @@ public class ImportUploadedPartsApiTest extends BaseTest {
             exportRequestBody.setAuditReasonId(auditReasonId);
             exportRequestBody.setAuditReasonComment(auditReasonComment);
         }
-        StartTaskResponse exportResponse = client.startExportEntry(new ParametersForStartExportEntry()
+        StartTaskResponse exportResponse = call("startExportEntry", () -> client.startExportEntry(new ParametersForStartExportEntry()
                 .setRepositoryId(repositoryId)
                 .setEntryId(createdEntryId)
-                .setRequestBody(exportRequestBody));
+                .setRequestBody(exportRequestBody)));
 
         assertNotNull(exportResponse);
-        taskId = exportResponse.getTaskId();
-        assertNotNull(taskId);
+        String exportTaskId = exportResponse.getTaskId();
+        assertNotNull(exportTaskId);
 
-        tasks = tasksClient.listTasks(new ParametersForListTasks().setRepositoryId(repositoryId).setTaskIds(taskId));
+        tasks = call("listTasks(export)", () -> tasksClient.listTasks(new ParametersForListTasks().setRepositoryId(repositoryId).setTaskIds(exportTaskId)));
         assertNotNull(tasks);
         assertEquals(1, tasks.getValue().size());
         taskProgress = tasks.getValue().get(0);

--- a/src/test/java/com/laserfiche/repository/api/integration/TasksClientTest.java
+++ b/src/test/java/com/laserfiche/repository/api/integration/TasksClientTest.java
@@ -30,7 +30,7 @@ public class TasksClientTest extends BaseTest {
                 .startDeleteEntry(new ParametersForStartDeleteEntry()
                         .setRepositoryId(repositoryId)
                         .setEntryId(deleteEntry.getId())
-                        .setRequestBody(new StartDeleteEntryRequest()));
+                        .setRequestBody(newDeleteEntryRequest()));
         String taskId = result.getTaskId();
         assertNotNull(taskId);
 
@@ -58,7 +58,7 @@ public class TasksClientTest extends BaseTest {
                     .startDeleteEntry(new ParametersForStartDeleteEntry()
                             .setRepositoryId(repositoryId)
                             .setEntryId(entry.getId())
-                            .setRequestBody(new StartDeleteEntryRequest()));
+                            .setRequestBody(newDeleteEntryRequest()));
             assertNotNull(startTaskResponse);
             taskIds[i] = startTaskResponse.getTaskId();
         }


### PR DESCRIPTION
Bumps the shared `jackson-version` property from 2.18.2 to 2.18.8 to remediate two Veracode-flagged CVEs in jackson-databind:

- CVE-2026-54512 — PolymorphicTypeValidator bypass via generic type parameters
- CVE-2026-54513 — PolymorphicTypeValidator bypass via array component types (allowIfSubTypeIsArray)

Both are fixed upstream in 2.18.8.

Note: the v1 branch has the same vulnerable pin but is out of scope here since the flagged Veracode build corresponds to v2. A tracking issue for the v1 fix will be filed separately.

Fixes #679086
Fixes #679087

### Test / CI changes

Alongside the jackson bump, this PR also includes integration-test and workflow fixes needed to get the suite green against the current dev/CA repository:

- **Audit-reason handling for delete (`BaseTest`, `EntriesClientTest`, `TasksClientTest`):** the dev/CA repo now enforces an audit reason on `DeleteEntry` (errorCode 216), unlike the old dedicated test repo. Added `getDeleteAuditReasonId()`/`newDeleteEntryRequest()` helpers that resolve and cache the delete audit reason (mirroring the existing export audit-reason lookup) and swapped all bare `new StartDeleteEntryRequest()` call sites over to it.
- **Fail-fast task polling (`BaseTest.waitUntilTaskEnds`):** previously a task ending in a non-`IN_PROGRESS`, non-success state would fall through as if it succeeded. Now a terminal status other than `COMPLETED` throws immediately with the task's `ProblemDetails` (title/detail/status/errorCode/errorSource) surfaced via a new `formatErrors` helper, instead of masking the failure or requiring a timeout to notice.
- **Richer failure diagnostics (`ExportDocumentApiTest`, `ImportUploadedPartsApiTest`):** wrapped `exportEntry`/multipart-upload/task-list calls so an `ApiException`'s status code, headers, and problem details show up in the surefire report — we don't have access to the raw CI job log to see the actual HTTP response otherwise.
- **`REPOSITORY_ID` secret swap (`.github/workflows/main.yml`):** integration tests now use `DEV_CA_PUBLIC_USE_REPOSITORY_ID_1` instead of `..._2`, and the workflow grants `checks: write` / `pull-requests: write` so the test-results action can publish/update its PR comment.

Happy to split the test/CI changes into a separate PR if preferred — flagging here since they're bundled with the security fix in this diff.